### PR TITLE
feat(search): allow database fulltext index using custom parser

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -18,6 +18,7 @@ type Database struct {
 	TablePrefix string `json:"table_prefix" env:"TABLE_PREFIX"`
 	SSLMode     string `json:"ssl_mode" env:"SSL_MODE"`
 	DSN         string `json:"dsn" env:"DSN"`
+	Parser      string `json:"parser" env:"PARSER"`
 }
 
 type Meilisearch struct {

--- a/internal/search/db/init.go
+++ b/internal/search/db/init.go
@@ -19,19 +19,26 @@ var config = searcher.Config{
 func init() {
 	searcher.RegisterSearcher(config, func() (searcher.Searcher, error) {
 		db := db.GetDb()
+		var parser string
 		switch conf.Conf.Database.Type {
 		case "mysql":
+			if conf.Conf.Database.Parser != "" {
+				parser = fmt.Sprintf(" WITH PARSER %s", conf.Conf.Database.Parser)
+			}
 			tableName := fmt.Sprintf("%ssearch_nodes", conf.Conf.Database.TablePrefix)
-			tx := db.Exec(fmt.Sprintf("CREATE FULLTEXT INDEX idx_%s_name_fulltext ON %s(name);", tableName, tableName))
+			tx := db.Exec(fmt.Sprintf("CREATE FULLTEXT INDEX idx_%s_name_fulltext%s ON %s(name);", tableName, parser, tableName))
 			if err := tx.Error; err != nil && !strings.Contains(err.Error(), "Error 1061 (42000)") { // duplicate error
 				log.Errorf("failed to create full text index: %v", err)
 				return nil, err
 			}
 		case "postgres":
+			if conf.Conf.Database.Parser != "" {
+				parser = fmt.Sprintf(" gin_%s", conf.Conf.Database.Parser)
+			}
 			db.Exec("CREATE EXTENSION pg_trgm;")
 			db.Exec("CREATE EXTENSION btree_gin;")
 			tableName := fmt.Sprintf("%ssearch_nodes", conf.Conf.Database.TablePrefix)
-			tx := db.Exec(fmt.Sprintf("CREATE INDEX idx_%s_name ON %s USING GIN (name);", tableName, tableName))
+			tx := db.Exec(fmt.Sprintf("CREATE INDEX idx_%s_name ON %s USING GIN (name%s);", tableName, tableName, parser))
 			if err := tx.Error; err != nil && !strings.Contains(err.Error(), "SQLSTATE 42P07") {
 				log.Errorf("failed to create index using GIN: %v", err)
 				return nil, err


### PR DESCRIPTION
The Ngram Parser can be used directly in MySQL 8.0 and above. In addition, both MySQL and Postgres can utilize various plugins to enhance tokenization for different languages.

This PR adds field `` Parser string `json:"parser" env:"PARSER"` `` in `conf.Conf.Database` to allow admin custom parser for database fulltext index. Although only system admin can set this setting via the config file or environment variables, I want to make it clear that this field is not SQL safe and could be used to implement SQL injection.

The changes in this PR have tested in:

|Tested|Database|Parser|Docker Image|
|:---:|---|:---:|---|
|:white_square_button:|Mysql|`ngram`||
|:white_square_button:|Postgres|||