### PR TITLE
feat(local): thumbnail token bucket smooth migration

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -76,7 +76,7 @@ func (d *Local) Init(ctx context.Context) error {
 	if d.thumbConcurrency == 0 {
 		d.thumbTokenBucket = NewNopTokenBucket()
 	} else {
-		d.thumbTokenBucket = NewStaticTokenBucket(d.thumbConcurrency)
+		d.thumbTokenBucket = NewStaticTokenBucketWithMigration(d.thumbTokenBucket, d.thumbConcurrency)
 	}
 	return nil
 }


### PR DESCRIPTION
Token bucket of thumbnail concurrent now can migrate smoothly. The concurrent during migration will not bigger than max(new, old) now.

Test Image: `mmx233/alist:v3.38.0-alpha2`, `mmx233/alist:v3.38.0-alpha2-ffmpeg`