### PR TITLE
ci(docker): support riscv64 and ppc64le

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -84,7 +84,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
 
       - name: Build and push with ffmpeg
         id: docker_build_ffmpeg
@@ -96,7 +96,7 @@ jobs:
           tags: ${{ steps.meta-ffmpeg.outputs.tags }}
           labels: ${{ steps.meta-ffmpeg.outputs.labels }}
           build-args: INSTALL_FFMPEG=true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
 
   build_docker_with_aria2:
     needs: build_docker

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/musl-libs
-          key: docker-musl-libs
+          key: docker-musl-libs-v2
 
       - name: Download Musl Library
         if: steps.cache-musl.outputs.cache-hit != 'true'

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/musl-libs
-          key: docker-musl-libs
+          key: docker-musl-libs-v2
 
       - name: Download Musl Library
         if: steps.cache-musl.outputs.cache-hit != 'true'

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -58,7 +58,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
 
       - name: Docker meta with ffmpeg
         id: meta-ffmpeg
@@ -79,7 +79,7 @@ jobs:
           tags: ${{ steps.meta-ffmpeg.outputs.tags }}
           labels: ${{ steps.meta-ffmpeg.outputs.labels }}
           build-args: INSTALL_FFMPEG=true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
 
   release_docker_with_aria2:
     needs: release_docker

--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,7 @@ BuildDocker() {
 PrepareBuildDockerMusl() {
   mkdir -p build/musl-libs
   BASE="https://musl.cc/"
-  FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross i486-linux-musl-cross s390x-linux-musl-cross armv6-linux-musleabihf-cross armv7l-linux-musleabihf-cross)
+  FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross i486-linux-musl-cross s390x-linux-musl-cross armv6-linux-musleabihf-cross armv7l-linux-musleabihf-cross riscv64-linux-musl-cross powerpc64le-linux-musl-cross)
   for i in "${FILES[@]}"; do
     url="${BASE}${i}.tgz"
     lib_tgz="build/${i}.tgz"
@@ -112,8 +112,8 @@ BuildDockerMultiplatform() {
   docker_lflags="--extldflags '-static -fpic' $ldflags"
   export CGO_ENABLED=1
 
-  OS_ARCHES=(linux-amd64 linux-arm64 linux-386 linux-s390x)
-  CGO_ARGS=(x86_64-linux-musl-gcc aarch64-linux-musl-gcc i486-linux-musl-gcc s390x-linux-musl-gcc)
+  OS_ARCHES=(linux-amd64 linux-arm64 linux-386 linux-s390x linux-riscv64 linux-ppc64le)
+  CGO_ARGS=(x86_64-linux-musl-gcc aarch64-linux-musl-gcc i486-linux-musl-gcc s390x-linux-musl-gcc riscv64-linux-musl-gcc powerpc64le-linux-musl-gcc)
   for i in "${!OS_ARCHES[@]}"; do
     os_arch=${OS_ARCHES[$i]}
     cgo_cc=${CGO_ARGS[$i]}


### PR DESCRIPTION
`linux/riscv64`, `linux/ppc64le` support is added to docker release.

Can't test the build result for I have no such kind of device.

Test Action: https://github.com/Mmx233/alist/actions/runs/11551964189/job/32150087995

Test Image: `mmx233/alist:v3.38.0-beta1`, `mmx233/alist:v3.38.0-beta1-ffmpeg`