### PR TITLE
refactor(aliyunopen,config): Modify default properties

### DIFF
--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Addition struct {
-	DriveType string `json:"drive_type" type:"select" options:"default,resource,backup" default:"default"`
+	DriveType string `json:"drive_type" type:"select" options:"default,resource,backup" default:"resource"`
 	driver.RootID
 	RefreshToken       string `json:"refresh_token" required:"true"`
 	OrderBy            string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -131,22 +131,22 @@ func DefaultConfig() *Config {
 		TlsInsecureSkipVerify: true,
 		Tasks: TasksConfig{
 			Download: TaskConfig{
-				Workers:        5,
-				MaxRetry:       1,
-				TaskPersistant: true,
+				Workers:  5,
+				MaxRetry: 1,
+				// TaskPersistant: true,
 			},
 			Transfer: TaskConfig{
-				Workers:        5,
-				MaxRetry:       2,
-				TaskPersistant: true,
+				Workers:  5,
+				MaxRetry: 2,
+				// TaskPersistant: true,
 			},
 			Upload: TaskConfig{
 				Workers: 5,
 			},
 			Copy: TaskConfig{
-				Workers:        5,
-				MaxRetry:       2,
-				TaskPersistant: true,
+				Workers:  5,
+				MaxRetry: 2,
+				// TaskPersistant: true,
 			},
 		},
 		Cors: Cors{


### PR DESCRIPTION
根据最近几个月的反馈：
1. 修改阿里云盘默认类型为 `资源库`
   - 很多人默认文件都在资源库，但是不是达人，然后导致添加后看不到文件 时常看到这个问题，修改默认云盘类型为资源库，不需要手动修改了
3. 以及配置文件持久化默认不启用
   - 可能网络原因上传 复制等操作导致失败，不知道已经有持久化，然后占用很大本地空间，不知道什么原因，改成默认不启用，需要的自行按需启用
