### PR TITLE
fix(terabox): big file upload issue

### DIFF
--- a/drivers/terabox/driver.go
+++ b/drivers/terabox/driver.go
@@ -10,8 +10,6 @@ import (
 	"math"
 	stdpath "path"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/pkg/utils"
@@ -24,9 +22,9 @@ import (
 type Terabox struct {
 	model.Storage
 	Addition
-	JsToken         string
+	JsToken           string
 	url_domain_prefix string
-	base_url        string
+	base_url          string
 }
 
 func (d *Terabox) Config() driver.Config {
@@ -145,52 +143,24 @@ func (d *Terabox) Put(ctx context.Context, dstDir model.Obj, stream model.FileSt
 	}
 	log.Debugln(locateupload_resp)
 
-	tempFile, err := stream.CacheFullInTempFile()
-	if err != nil {
-		return err
-	}
-	var Default int64 = 4 * 1024 * 1024
-	defaultByteData := make([]byte, Default)
-	count := int(math.Ceil(float64(stream.GetSize()) / float64(Default)))
-	// cal md5
-	h1 := md5.New()
-	h2 := md5.New()
-	block_list := make([]string, 0)
-	left := stream.GetSize()
-	for i := 0; i < count; i++ {
-		byteSize := Default
-		var byteData []byte
-		if left < Default {
-			byteSize = left
-			byteData = make([]byte, byteSize)
-		} else {
-			byteData = defaultByteData
-		}
-		left -= byteSize
-		_, err = io.ReadFull(tempFile, byteData)
-		if err != nil {
-			return err
-		}
-		h1.Write(byteData)
-		h2.Write(byteData)
-		block_list = append(block_list, fmt.Sprintf("\"%s\"", hex.EncodeToString(h2.Sum(nil))))
-		h2.Reset()
-	}
-
-	_, err = tempFile.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
-
+	// precreate file
 	rawPath := stdpath.Join(dstDir.GetPath(), stream.GetName())
 	path := encodeURIComponent(rawPath)
-	block_list_str := fmt.Sprintf("[%s]", strings.Join(block_list, ","))
+
+	var precreateBlockListStr string
+	if stream.GetSize() > initialChunkSize {
+		precreateBlockListStr = `["5910a591dd8fc18c32a8f3df4fdc1761","a5fc157d78e6ad1c7e114b056c92821e"]`
+	} else {
+		precreateBlockListStr = `["5910a591dd8fc18c32a8f3df4fdc1761"]`
+	}
+
 	data := map[string]string{
-		"path":        rawPath,
-		"autoinit":    "1",
-		"target_path": dstDir.GetPath(),
-		"block_list":  block_list_str,
-		"local_mtime": strconv.FormatInt(time.Now().Unix(), 10),
+		"path":                  rawPath,
+		"autoinit":              "1",
+		"target_path":           dstDir.GetPath(),
+		"block_list":            precreateBlockListStr,
+		"local_mtime":           strconv.FormatInt(stream.ModTime().Unix(), 10),
+		"file_limit_switch_v34": "true",
 	}
 	var precreateResp PrecreateResp
 	log.Debugln(data)
@@ -206,6 +176,13 @@ func (d *Terabox) Put(ctx context.Context, dstDir model.Obj, stream model.FileSt
 	if precreateResp.ReturnType == 2 {
 		return nil
 	}
+
+	// upload chunks
+	tempFile, err := stream.CacheFullInTempFile()
+	if err != nil {
+		return err
+	}
+
 	params := map[string]string{
 		"method":     "upload",
 		"path":       path,
@@ -215,24 +192,37 @@ func (d *Terabox) Put(ctx context.Context, dstDir model.Obj, stream model.FileSt
 		"channel":    "dubox",
 		"clienttype": "0",
 	}
-	left = stream.GetSize()
-	for i, partseq := range precreateResp.BlockList {
+
+	streamSize := stream.GetSize()
+	chunkSize := calculateChunkSize(streamSize)
+	chunkByteData := make([]byte, chunkSize)
+	count := int(math.Ceil(float64(streamSize) / float64(chunkSize)))
+	left := streamSize
+	uploadBlockList := make([]string, 0, count)
+	h := md5.New()
+	for partseq := 0; partseq < count; partseq++ {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
 		}
-		byteSize := Default
+		byteSize := chunkSize
 		var byteData []byte
-		if left < Default {
+		if left >= chunkSize {
+			byteData = chunkByteData
+		} else {
 			byteSize = left
 			byteData = make([]byte, byteSize)
-		} else {
-			byteData = defaultByteData
 		}
 		left -= byteSize
 		_, err = io.ReadFull(tempFile, byteData)
 		if err != nil {
 			return err
 		}
+
+		// calculate md5
+		h.Write(byteData)
+		uploadBlockList = append(uploadBlockList, hex.EncodeToString(h.Sum(nil)))
+		h.Reset()
+
 		u := "https://" + locateupload_resp.Host + "/rest/2.0/pcs/superfile2"
 		params["partseq"] = strconv.Itoa(partseq)
 		res, err := base.RestyClient.R().
@@ -245,25 +235,39 @@ func (d *Terabox) Put(ctx context.Context, dstDir model.Obj, stream model.FileSt
 			return err
 		}
 		log.Debugln(res.String())
-		if len(precreateResp.BlockList) > 0 {
-			up(float64(i) * 100 / float64(len(precreateResp.BlockList)))
+		if count > 0 {
+			up(float64(partseq) * 100 / float64(count))
 		}
 	}
+
+	// create file
 	params = map[string]string{
 		"isdir": "0",
 		"rtype": "1",
+	}
+
+	uploadBlockListStr, err := utils.Json.MarshalToString(uploadBlockList)
+	if err != nil {
+		return err
 	}
 	data = map[string]string{
 		"path":        rawPath,
 		"size":        strconv.FormatInt(stream.GetSize(), 10),
 		"uploadid":    precreateResp.Uploadid,
 		"target_path": dstDir.GetPath(),
-		"block_list":  block_list_str,
-		"local_mtime": strconv.FormatInt(time.Now().Unix(), 10),
+		"block_list":  uploadBlockListStr,
+		"local_mtime": strconv.FormatInt(stream.ModTime().Unix(), 10),
 	}
-	res, err = d.post_form("/api/create", params, data, nil)
+	var createResp CreateResp
+	res, err = d.post_form("/api/create", params, data, &createResp)
 	log.Debugln(string(res))
-	return err
+	if err != nil {
+		return err
+	}
+	if createResp.Errno != 0 {
+		return fmt.Errorf("[terabox] failed to create file, errno: %d", createResp.Errno)
+	}
+	return nil
 }
 
 var _ driver.Driver = (*Terabox)(nil)

--- a/drivers/terabox/types.go
+++ b/drivers/terabox/types.go
@@ -99,3 +99,7 @@ type CheckLoginResp struct {
 type LocateUploadResp struct {
 	Host string `json:"host"`
 }
+
+type CreateResp struct {
+	Errno int `json:"errno"`
+}

--- a/drivers/terabox/util.go
+++ b/drivers/terabox/util.go
@@ -17,6 +17,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	initialChunkSize     int64 = 4 << 20 // 4MB
+	initialSizeThreshold int64 = 4 << 30 // 4GB
+)
+
 func getStrBetween(raw, start, end string) string {
 	regexPattern := fmt.Sprintf(`%s(.*?)%s`, regexp.QuoteMeta(start), regexp.QuoteMeta(end))
 	regex := regexp.MustCompile(regexPattern)
@@ -257,4 +262,20 @@ func encodeURIComponent(str string) string {
 	r := url.QueryEscape(str)
 	r = strings.ReplaceAll(r, "+", "%20")
 	return r
+}
+
+func calculateChunkSize(streamSize int64) int64 {
+	chunkSize := initialChunkSize
+	sizeThreshold := initialSizeThreshold
+
+	if streamSize < chunkSize {
+		return streamSize
+	}
+
+	for streamSize > sizeThreshold {
+		chunkSize <<= 1
+		sizeThreshold <<= 1
+	}
+
+	return chunkSize
 }


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7490

### 问题原因
1. `/api/create`接口报错，返回了`errno`和`errmsg`，但`alist`没有对`errno`做判断，导致页面上误显示为上传成功；
2. 根据返回的`errno: 10`和`errmsg: "create super file failed."`，无法定位到问题，所以需查看官方接口参数；
3. 根据对`Terabox`抓包分析，在上传超过`8GB`的文件时，`chunk`大小为`16MB`，而`alist`的逻辑用的是`4MB`，可能因为`chunk`太多导致在最终的`/api/create`接口中上传失败；
4. `Terabox`还更新了`/api/precreate`接口的入参字段。

### 修复方案 
1. 对`Terabox`做了多次抓包分析，发现`chunk`的大小会按如下规则动态调整：

| 文件大小  | chunk |
| :-------------: | :-------------: |
| (0GB, 4GB]  | 4MB  |
| (4GB, 8GB]  | 8MB  |
| (8GB, 16GB]  | 16MB  |
| (16GB, 32GB]  | 32MB  |
| (32GB, 64GB]  | 64MB  |
| (64GB, 128GB]  | 128MB  |
2. 在`/api/precreate`接口中，请求体有如下变化：
<img width="806" alt="Snipaste_2024-11-13_22-28-53" src="https://github.com/user-attachments/assets/ff5899fb-ae65-4a24-ba1b-9026e2316e56">

其中`block_list`是固定值，用多个账号测试发现都是这个值，不再需要在这个阶段计算`chunks`的`md5`了。
3. 额外修正了`local_mtime`字段的值，改成本地文件的`mtime`，不应该传当前时间戳。
### 自测结果
1. 9GB大文件上传成功；
<img width="997" alt="Snipaste_2024-11-13_18-03-33" src="https://github.com/user-attachments/assets/cf68ddd9-ef7f-4dc5-8cd3-7f4dbc785b15">

<img width="1278" alt="Snipaste_2024-11-13_18-07-05" src="https://github.com/user-attachments/assets/e3e11e73-2b09-4e13-9103-aa050731f539">

2. 以下文件均上传成功。
![Snipaste_2024-11-13_23-22-42](https://github.com/user-attachments/assets/1557eeed-d955-4749-847f-c32b471998d8)

<img width="1027" alt="Snipaste_2024-11-13_23-25-22" src="https://github.com/user-attachments/assets/186182c4-c67b-435c-9c38-511a39fd4551">

