### PR TITLE
fix(terabox): panic due to slice out of range

### DIFF
--- a/drivers/terabox/util.go
+++ b/drivers/terabox/util.go
@@ -86,11 +86,15 @@ func (d *Terabox) request(rurl string, method string, callback base.ReqCallback,
 			return d.request(rurl, method, callback, resp, true)
 		}
 	} else if errno == -6 {
-		log.Debugln(res.Header())
-		d.url_domain_prefix = res.Header()["Url-Domain-Prefix"][0]
-		d.base_url = "https://" + d.url_domain_prefix + ".terabox.com"
-		log.Debugln("Redirect base_url to", d.base_url)
-		return d.request(rurl, method, callback, resp, noRetry...)
+		header := res.Header()
+		log.Debugln(header)
+		urlDomainPrefix := header.Get("Url-Domain-Prefix")
+		if len(urlDomainPrefix) > 0 {
+			d.url_domain_prefix = urlDomainPrefix
+			d.base_url = "https://" + d.url_domain_prefix + ".terabox.com"
+			log.Debugln("Redirect base_url to", d.base_url)
+			return d.request(rurl, method, callback, resp, noRetry...)
+		}
 	}
 	return res.Body(), nil
 }


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7487 中第`1`个问题：如果`Terobox`的`Cookie`失效或填写错误，会在`driver Init`阶段`panic`

### 问题原因
https://github.com/AlistGo/alist/blob/0a46979c519885465e586da009b70422382c84ac/drivers/terabox/util.go#L90C3-L90C61
1. 在`Terobox Init`进行登录时，如果当前`ip`与注册时的区域不符时，接口会返回`errno=6`然后进入这段逻辑，并根据`header`中返回的`url prefix`设置正确的`url`
2. 但是，在更换`prefix`后重新请求时，如果`Cookie`不合法，也会返回`errno=6`，导致再次进入到这段逻辑中，由于这时`header`中没有`Url-Domain-Prefix`了，导致访问`nil`的切片造成`panic`

### 修复方案
增加非空判断，如果`Cookie`不合法则会抛出错误