### PR TITLE
fix(storage): delete storage fails if a panic occurred during initialization

### DIFF
--- a/drivers/chaoxing/driver.go
+++ b/drivers/chaoxing/driver.go
@@ -67,7 +67,9 @@ func (d *ChaoXing) Init(ctx context.Context) error {
 }
 
 func (d *ChaoXing) Drop(ctx context.Context) error {
-	d.cron.Stop()
+	if d.cron != nil {
+		d.cron.Stop()
+	}
 	return nil
 }
 

--- a/drivers/vtencent/drive.go
+++ b/drivers/vtencent/drive.go
@@ -55,7 +55,9 @@ func (d *Vtencent) Init(ctx context.Context) error {
 }
 
 func (d *Vtencent) Drop(ctx context.Context) error {
-	d.cron.Stop()
+	if d.cron != nil {
+		d.cron.Stop()
+	}
 	return nil
 }
 

--- a/internal/op/storage.go
+++ b/internal/op/storage.go
@@ -101,7 +101,7 @@ func initStorage(ctx context.Context, storage model.Storage, storageDriver drive
 			log.Errorf("panic init storage: %s", errInfo)
 			driverStorage.SetStatus(errInfo)
 			MustSaveDriverStorage(storageDriver)
-			storagesMap.Delete(driverStorage.MountPath)
+			storagesMap.Store(driverStorage.MountPath, storageDriver)
 		}
 	}()
 	// Unmarshal Addition


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7487 中的第`2`个问题：如果在`alist`启动时，某个`storage`的初始化过程中发生`panic`，之后删除这个`storage`时会报错：`failed get storage driver: no mount path for an storage is: XXXX`.

### 问题原因
1. 在删除`storage`时，会去`storagesMap`中查询，如果查不到则会报错；
2. 在`initStorage`流程中，如果`storageDriver.Init()`发生了`panic`，在`recover()`中没有向`storagesMap`写入这个`storage`，所以后续的删除操作会报错。

### 修复方案
1. 发生了`panic`时，在`recover()`中向`storagesMap`写入这个`storage`；
2. 对所有类型`driver`的`Drop`方法完善`nil`检查。

### 自测

https://github.com/user-attachments/assets/b5e3c64b-b3fb-4343-9ba6-77ab05afbec8

<img width="1282" alt="Snipaste_2024-11-14_16-05-07" src="https://github.com/user-attachments/assets/70d82527-66ef-4ee7-8157-8d36562276e4">
