### PR TITLE
🐛 local driver: Preserve file owner when copying

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -280,7 +280,7 @@ func (d *Local) Copy(_ context.Context, srcObj, dstDir model.Obj) error {
 	return cp.Copy(srcPath, dstPath, cp.Options{
 		Sync:          true, // Sync file to disk after copy, may have performance penalty in filesystem such as ZFS
 		PreserveTimes: true,
-		NumOfWorkers:  0, // Serialized copy without using goroutine
+		PreserveOwner: true,
 	})
 }
 


### PR DESCRIPTION
Fix issue when user specified for running alist is different from the owner of file(s) being copied/moved in local filesystem, causing the file(s) owner changed unexpectedly.
Optimal copy options (such as the size of copy buffer) may need further consideration , but until now it should be functional basically.

PS. We may consider using os.CopyFS (since 1.23) provided by standard library when it comes stable in the future.