### PR TITLE
fix(pikpak&pikpak_share): fix captcha_sign error

### DIFF
--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -14,7 +14,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -49,7 +48,6 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 				d.Common.CaptchaToken = token
 				op.MustSaveDriverStorage(d)
 			},
-			LowLatencyAddr: "",
 		}
 	}
 
@@ -138,14 +136,6 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 	d.Addition.RefreshToken = d.RefreshToken
 	op.MustSaveDriverStorage(d)
 
-	if d.UseLowLatencyAddress && d.Addition.CustomLowLatencyAddress != "" {
-		d.Common.LowLatencyAddr = d.Addition.CustomLowLatencyAddress
-	} else if d.UseLowLatencyAddress {
-		d.Common.LowLatencyAddr = findLowestLatencyAddress(DlAddr)
-		d.Addition.CustomLowLatencyAddress = d.Common.LowLatencyAddr
-		op.MustSaveDriverStorage(d)
-	}
-
 	return nil
 }
 
@@ -186,12 +176,6 @@ func (d *PikPak) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	if !d.DisableMediaLink && len(resp.Medias) > 0 && resp.Medias[0].Link.Url != "" {
 		log.Debugln("use media link")
 		url = resp.Medias[0].Link.Url
-	}
-
-	if d.UseLowLatencyAddress && d.Common.LowLatencyAddr != "" {
-		// 替换为加速链接
-		re := regexp.MustCompile(`https://[^/]+/download/`)
-		url = re.ReplaceAllString(url, "https://"+d.Common.LowLatencyAddr+"/download/")
 	}
 
 	return &model.Link{

--- a/drivers/pikpak/meta.go
+++ b/drivers/pikpak/meta.go
@@ -7,16 +7,14 @@ import (
 
 type Addition struct {
 	driver.RootID
-	Username                string `json:"username" required:"true"`
-	Password                string `json:"password" required:"true"`
-	Platform                string `json:"platform" required:"true" type:"select" options:"android,web,pc"`
-	RefreshToken            string `json:"refresh_token" required:"true" default:""`
-	RefreshTokenMethod      string `json:"refresh_token_method" required:"true" type:"select" options:"oauth2,http"`
-	CaptchaToken            string `json:"captcha_token" default:""`
-	DeviceID                string `json:"device_id"  required:"false" default:""`
-	DisableMediaLink        bool   `json:"disable_media_link" default:"true"`
-	UseLowLatencyAddress    bool   `json:"use_low_latency_address" default:"false"`
-	CustomLowLatencyAddress string `json:"custom_low_latency_address" default:""`
+	Username           string `json:"username" required:"true"`
+	Password           string `json:"password" required:"true"`
+	Platform           string `json:"platform" required:"true" default:"web" type:"select" options:"android,web,pc"`
+	RefreshToken       string `json:"refresh_token" required:"true" default:""`
+	RefreshTokenMethod string `json:"refresh_token_method" required:"true" type:"select" options:"oauth2,http"`
+	CaptchaToken       string `json:"captcha_token" default:""`
+	DeviceID           string `json:"device_id"  required:"false" default:""`
+	DisableMediaLink   bool   `json:"disable_media_link" default:"true"`
 }
 
 var config = driver.Config{

--- a/drivers/pikpak/util.go
+++ b/drivers/pikpak/util.go
@@ -30,32 +30,34 @@ import (
 // do others that not defined in Driver interface
 
 var AndroidAlgorithms = []string{
-	"aDhgaSE3MsjROCmpmsWqP1sJdFJ",
-	"+oaVkqdd8MJuKT+uMr2AYKcd9tdWge3XPEPR2hcePUknd",
-	"u/sd2GgT2fTytRcKzGicHodhvIltMntA3xKw2SRv7S48OdnaQIS5mn",
-	"2WZiae2QuqTOxBKaaqCNHCW3olu2UImelkDzBn",
-	"/vJ3upic39lgmrkX855Qx",
-	"yNc9ruCVMV7pGV7XvFeuLMOcy1",
-	"4FPq8mT3JQ1jzcVxMVfwFftLQm33M7i",
-	"xozoy5e3Ea",
+	"7xOq4Z8s",
+	"QE9/9+IQco",
+	"WdX5J9CPLZp",
+	"NmQ5qFAXqH3w984cYhMeC5TJR8j",
+	"cc44M+l7GDhav",
+	"KxGjo/wHB+Yx8Lf7kMP+/m9I+",
+	"wla81BUVSmDkctHDpUT",
+	"c6wMr1sm1WxiR3i8LDAm3W",
+	"hRLrEQCFNYi0PFPV",
+	"o1J41zIraDtJPNuhBu7Ifb/q3",
+	"U",
+	"RrbZvV0CTu3gaZJ56PVKki4IeP",
+	"NNuRbLckJqUp1Do0YlrKCUP",
+	"UUwnBbipMTvInA0U0E9",
+	"VzGc",
 }
 
 var WebAlgorithms = []string{
-	"C9qPpZLN8ucRTaTiUMWYS9cQvWOE",
-	"+r6CQVxjzJV6LCV",
-	"F",
-	"pFJRC",
-	"9WXYIDGrwTCz2OiVlgZa90qpECPD6olt",
-	"/750aCr4lm/Sly/c",
-	"RB+DT/gZCrbV",
-	"",
-	"CyLsf7hdkIRxRm215hl",
-	"7xHvLi2tOYP0Y92b",
-	"ZGTXXxu8E/MIWaEDB+Sm/",
-	"1UI3",
-	"E7fP5Pfijd+7K+t6Tg/NhuLq0eEUVChpJSkrKxpO",
-	"ihtqpG6FMt65+Xk+tWUH2",
-	"NhXXU9rg4XXdzo7u5o",
+	"fyZ4+p77W1U4zcWBUwefAIFhFxvADWtT1wzolCxhg9q7etmGUjXr",
+	"uSUX02HYJ1IkyLdhINEFcCf7l2",
+	"iWt97bqD/qvjIaPXB2Ja5rsBWtQtBZZmaHH2rMR41",
+	"3binT1s/5a1pu3fGsN",
+	"8YCCU+AIr7pg+yd7CkQEY16lDMwi8Rh4WNp5",
+	"DYS3StqnAEKdGddRP8CJrxUSFh",
+	"crquW+4",
+	"ryKqvW9B9hly+JAymXCIfag5Z",
+	"Hr08T/NDTX1oSJfHk90c",
+	"i",
 }
 
 var PCAlgorithms = []string{
@@ -80,58 +82,20 @@ const (
 const (
 	AndroidClientID      = "YNxT9w7GMdWvEOKa"
 	AndroidClientSecret  = "dbw2OtmVEeuUvIptb1Coyg"
-	AndroidClientVersion = "1.48.3"
+	AndroidClientVersion = "1.49.3"
 	AndroidPackageName   = "com.pikcloud.pikpak"
 	AndroidSdkVersion    = "2.0.4.204101"
 	WebClientID          = "YUMx5nI8ZU8Ap8pm"
 	WebClientSecret      = "dbw2OtmVEeuUvIptb1Coyg"
-	WebClientVersion     = "2.0.0"
-	WebPackageName       = "mypikpak.net"
+	WebClientVersion     = "undefined"
+	WebPackageName       = "drive.mypikpak.com"
 	WebSdkVersion        = "8.0.3"
 	PCClientID           = "YvtoWO6GNHiuCl7x"
 	PCClientSecret       = "1NIH5R1IEe2pAxZE3hv3uA"
 	PCClientVersion      = "undefined" // 2.5.6.4831
-	PCPackageName        = "mypikpak.net"
+	PCPackageName        = "mypikpak.com"
 	PCSdkVersion         = "8.0.3"
 )
-
-var DlAddr = []string{
-	"dl-a10b-0621.mypikpak.net",
-	"dl-a10b-0622.mypikpak.net",
-	"dl-a10b-0623.mypikpak.net",
-	"dl-a10b-0624.mypikpak.net",
-	"dl-a10b-0625.mypikpak.net",
-	"dl-a10b-0858.mypikpak.net",
-	"dl-a10b-0859.mypikpak.net",
-	"dl-a10b-0860.mypikpak.net",
-	"dl-a10b-0861.mypikpak.net",
-	"dl-a10b-0862.mypikpak.net",
-	"dl-a10b-0863.mypikpak.net",
-	"dl-a10b-0864.mypikpak.net",
-	"dl-a10b-0865.mypikpak.net",
-	"dl-a10b-0866.mypikpak.net",
-	"dl-a10b-0867.mypikpak.net",
-	"dl-a10b-0868.mypikpak.net",
-	"dl-a10b-0869.mypikpak.net",
-	"dl-a10b-0870.mypikpak.net",
-	"dl-a10b-0871.mypikpak.net",
-	"dl-a10b-0872.mypikpak.net",
-	"dl-a10b-0873.mypikpak.net",
-	"dl-a10b-0874.mypikpak.net",
-	"dl-a10b-0875.mypikpak.net",
-	"dl-a10b-0876.mypikpak.net",
-	"dl-a10b-0877.mypikpak.net",
-	"dl-a10b-0878.mypikpak.net",
-	"dl-a10b-0879.mypikpak.net",
-	"dl-a10b-0880.mypikpak.net",
-	"dl-a10b-0881.mypikpak.net",
-	"dl-a10b-0882.mypikpak.net",
-	"dl-a10b-0883.mypikpak.net",
-	"dl-a10b-0884.mypikpak.net",
-	"dl-a10b-0885.mypikpak.net",
-	"dl-a10b-0886.mypikpak.net",
-	"dl-a10b-0887.mypikpak.net",
-}
 
 func (d *PikPak) login() error {
 	// 检查用户名和密码是否为空
@@ -338,7 +302,6 @@ type Common struct {
 	UserAgent     string
 	// 验证码token刷新成功回调
 	RefreshCTokenCk func(token string)
-	LowLatencyAddr  string
 }
 
 func generateDeviceSign(deviceID, packageName string) string {
@@ -728,47 +691,4 @@ func OssOption(params *S3Params) []oss.Option {
 		oss.UserAgentHeader(OSSUserAgent),
 	}
 	return options
-}
-
-type AddressLatency struct {
-	Address string
-	Latency time.Duration
-}
-
-func checkLatency(address string, wg *sync.WaitGroup, ch chan<- AddressLatency) {
-	defer wg.Done()
-	start := time.Now()
-	resp, err := http.Get("https://" + address + "/generate_204")
-	if err != nil {
-		ch <- AddressLatency{Address: address, Latency: time.Hour} // Set high latency on error
-		return
-	}
-	defer resp.Body.Close()
-	latency := time.Since(start)
-	ch <- AddressLatency{Address: address, Latency: latency}
-}
-
-func findLowestLatencyAddress(addresses []string) string {
-	var wg sync.WaitGroup
-	ch := make(chan AddressLatency, len(addresses))
-
-	for _, address := range addresses {
-		wg.Add(1)
-		go checkLatency(address, &wg, ch)
-	}
-
-	wg.Wait()
-	close(ch)
-
-	var lowestLatencyAddress string
-	lowestLatency := time.Hour
-
-	for result := range ch {
-		if result.Latency < lowestLatency {
-			lowestLatency = result.Latency
-			lowestLatencyAddress = result.Address
-		}
-	}
-
-	return lowestLatencyAddress
 }

--- a/drivers/pikpak_share/driver.go
+++ b/drivers/pikpak_share/driver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/alist-org/alist/v3/internal/op"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -37,7 +36,6 @@ func (d *PikPakShare) Init(ctx context.Context) error {
 				d.Common.CaptchaToken = token
 				op.MustSaveDriverStorage(d)
 			},
-			LowLatencyAddr: "",
 		}
 	}
 
@@ -69,14 +67,6 @@ func (d *PikPakShare) Init(ctx context.Context) error {
 		d.PackageName = PCPackageName
 		d.Algorithms = PCAlgorithms
 		d.UserAgent = "MainWindow Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) PikPak/2.5.6.4831 Chrome/100.0.4896.160 Electron/18.3.15 Safari/537.36"
-	}
-
-	if d.UseLowLatencyAddress && d.Addition.CustomLowLatencyAddress != "" {
-		d.Common.LowLatencyAddr = d.Addition.CustomLowLatencyAddress
-	} else if d.UseLowLatencyAddress {
-		d.Common.LowLatencyAddr = findLowestLatencyAddress(DlAddr)
-		d.Addition.CustomLowLatencyAddress = d.Common.LowLatencyAddr
-		op.MustSaveDriverStorage(d)
 	}
 
 	// 获取CaptchaToken
@@ -129,12 +119,6 @@ func (d *PikPakShare) Link(ctx context.Context, file model.Obj, args model.LinkA
 			downloadUrl = resp.FileInfo.Medias[0].Link.Url
 		}
 
-	}
-
-	if d.UseLowLatencyAddress && d.Common.LowLatencyAddr != "" {
-		// 替换为加速链接
-		re := regexp.MustCompile(`https://[^/]+/download/`)
-		downloadUrl = re.ReplaceAllString(downloadUrl, "https://"+d.Common.LowLatencyAddr+"/download/")
 	}
 
 	return &model.Link{

--- a/drivers/pikpak_share/meta.go
+++ b/drivers/pikpak_share/meta.go
@@ -7,13 +7,11 @@ import (
 
 type Addition struct {
 	driver.RootID
-	ShareId                 string `json:"share_id" required:"true"`
-	SharePwd                string `json:"share_pwd"`
-	Platform                string `json:"platform" required:"true" type:"select" options:"android,web,pc"`
-	DeviceID                string `json:"device_id"  required:"false" default:""`
-	UseTransCodingAddress   bool   `json:"use_transcoding_address" required:"true" default:"false"`
-	UseLowLatencyAddress    bool   `json:"use_low_latency_address" default:"false"`
-	CustomLowLatencyAddress string `json:"custom_low_latency_address" default:""`
+	ShareId               string `json:"share_id" required:"true"`
+	SharePwd              string `json:"share_pwd"`
+	Platform              string `json:"platform" default:"web" required:"true" type:"select" options:"android,web,pc"`
+	DeviceID              string `json:"device_id"  required:"false" default:""`
+	UseTransCodingAddress bool   `json:"use_transcoding_address" required:"true" default:"false"`
 }
 
 var config = driver.Config{

--- a/drivers/pikpak_share/util.go
+++ b/drivers/pikpak_share/util.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -18,32 +17,34 @@ import (
 )
 
 var AndroidAlgorithms = []string{
-	"aDhgaSE3MsjROCmpmsWqP1sJdFJ",
-	"+oaVkqdd8MJuKT+uMr2AYKcd9tdWge3XPEPR2hcePUknd",
-	"u/sd2GgT2fTytRcKzGicHodhvIltMntA3xKw2SRv7S48OdnaQIS5mn",
-	"2WZiae2QuqTOxBKaaqCNHCW3olu2UImelkDzBn",
-	"/vJ3upic39lgmrkX855Qx",
-	"yNc9ruCVMV7pGV7XvFeuLMOcy1",
-	"4FPq8mT3JQ1jzcVxMVfwFftLQm33M7i",
-	"xozoy5e3Ea",
+	"7xOq4Z8s",
+	"QE9/9+IQco",
+	"WdX5J9CPLZp",
+	"NmQ5qFAXqH3w984cYhMeC5TJR8j",
+	"cc44M+l7GDhav",
+	"KxGjo/wHB+Yx8Lf7kMP+/m9I+",
+	"wla81BUVSmDkctHDpUT",
+	"c6wMr1sm1WxiR3i8LDAm3W",
+	"hRLrEQCFNYi0PFPV",
+	"o1J41zIraDtJPNuhBu7Ifb/q3",
+	"U",
+	"RrbZvV0CTu3gaZJ56PVKki4IeP",
+	"NNuRbLckJqUp1Do0YlrKCUP",
+	"UUwnBbipMTvInA0U0E9",
+	"VzGc",
 }
 
 var WebAlgorithms = []string{
-	"C9qPpZLN8ucRTaTiUMWYS9cQvWOE",
-	"+r6CQVxjzJV6LCV",
-	"F",
-	"pFJRC",
-	"9WXYIDGrwTCz2OiVlgZa90qpECPD6olt",
-	"/750aCr4lm/Sly/c",
-	"RB+DT/gZCrbV",
-	"",
-	"CyLsf7hdkIRxRm215hl",
-	"7xHvLi2tOYP0Y92b",
-	"ZGTXXxu8E/MIWaEDB+Sm/",
-	"1UI3",
-	"E7fP5Pfijd+7K+t6Tg/NhuLq0eEUVChpJSkrKxpO",
-	"ihtqpG6FMt65+Xk+tWUH2",
-	"NhXXU9rg4XXdzo7u5o",
+	"fyZ4+p77W1U4zcWBUwefAIFhFxvADWtT1wzolCxhg9q7etmGUjXr",
+	"uSUX02HYJ1IkyLdhINEFcCf7l2",
+	"iWt97bqD/qvjIaPXB2Ja5rsBWtQtBZZmaHH2rMR41",
+	"3binT1s/5a1pu3fGsN",
+	"8YCCU+AIr7pg+yd7CkQEY16lDMwi8Rh4WNp5",
+	"DYS3StqnAEKdGddRP8CJrxUSFh",
+	"crquW+4",
+	"ryKqvW9B9hly+JAymXCIfag5Z",
+	"Hr08T/NDTX1oSJfHk90c",
+	"i",
 }
 
 var PCAlgorithms = []string{
@@ -62,58 +63,20 @@ var PCAlgorithms = []string{
 const (
 	AndroidClientID      = "YNxT9w7GMdWvEOKa"
 	AndroidClientSecret  = "dbw2OtmVEeuUvIptb1Coyg"
-	AndroidClientVersion = "1.48.3"
+	AndroidClientVersion = "1.49.3"
 	AndroidPackageName   = "com.pikcloud.pikpak"
 	AndroidSdkVersion    = "2.0.4.204101"
 	WebClientID          = "YUMx5nI8ZU8Ap8pm"
 	WebClientSecret      = "dbw2OtmVEeuUvIptb1Coyg"
-	WebClientVersion     = "2.0.0"
-	WebPackageName       = "mypikpak.net"
+	WebClientVersion     = "undefined"
+	WebPackageName       = "drive.mypikpak.com"
 	WebSdkVersion        = "8.0.3"
 	PCClientID           = "YvtoWO6GNHiuCl7x"
 	PCClientSecret       = "1NIH5R1IEe2pAxZE3hv3uA"
 	PCClientVersion      = "undefined" // 2.5.6.4831
-	PCPackageName        = "mypikpak.net"
+	PCPackageName        = "mypikpak.com"
 	PCSdkVersion         = "8.0.3"
 )
-
-var DlAddr = []string{
-	"dl-a10b-0621.mypikpak.net",
-	"dl-a10b-0622.mypikpak.net",
-	"dl-a10b-0623.mypikpak.net",
-	"dl-a10b-0624.mypikpak.net",
-	"dl-a10b-0625.mypikpak.net",
-	"dl-a10b-0858.mypikpak.net",
-	"dl-a10b-0859.mypikpak.net",
-	"dl-a10b-0860.mypikpak.net",
-	"dl-a10b-0861.mypikpak.net",
-	"dl-a10b-0862.mypikpak.net",
-	"dl-a10b-0863.mypikpak.net",
-	"dl-a10b-0864.mypikpak.net",
-	"dl-a10b-0865.mypikpak.net",
-	"dl-a10b-0866.mypikpak.net",
-	"dl-a10b-0867.mypikpak.net",
-	"dl-a10b-0868.mypikpak.net",
-	"dl-a10b-0869.mypikpak.net",
-	"dl-a10b-0870.mypikpak.net",
-	"dl-a10b-0871.mypikpak.net",
-	"dl-a10b-0872.mypikpak.net",
-	"dl-a10b-0873.mypikpak.net",
-	"dl-a10b-0874.mypikpak.net",
-	"dl-a10b-0875.mypikpak.net",
-	"dl-a10b-0876.mypikpak.net",
-	"dl-a10b-0877.mypikpak.net",
-	"dl-a10b-0878.mypikpak.net",
-	"dl-a10b-0879.mypikpak.net",
-	"dl-a10b-0880.mypikpak.net",
-	"dl-a10b-0881.mypikpak.net",
-	"dl-a10b-0882.mypikpak.net",
-	"dl-a10b-0883.mypikpak.net",
-	"dl-a10b-0884.mypikpak.net",
-	"dl-a10b-0885.mypikpak.net",
-	"dl-a10b-0886.mypikpak.net",
-	"dl-a10b-0887.mypikpak.net",
-}
 
 func (d *PikPakShare) request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
 	req := base.RestyClient.R()
@@ -227,7 +190,6 @@ type Common struct {
 	UserAgent     string
 	// 验证码token刷新成功回调
 	RefreshCTokenCk func(token string)
-	LowLatencyAddr  string
 }
 
 func (c *Common) SetUserAgent(userAgent string) {
@@ -366,47 +328,4 @@ func (d *PikPakShare) refreshCaptchaToken(action string, metas map[string]string
 	}
 	d.Common.SetCaptchaToken(resp.CaptchaToken)
 	return nil
-}
-
-type AddressLatency struct {
-	Address string
-	Latency time.Duration
-}
-
-func checkLatency(address string, wg *sync.WaitGroup, ch chan<- AddressLatency) {
-	defer wg.Done()
-	start := time.Now()
-	resp, err := http.Get("https://" + address + "/generate_204")
-	if err != nil {
-		ch <- AddressLatency{Address: address, Latency: time.Hour} // Set high latency on error
-		return
-	}
-	defer resp.Body.Close()
-	latency := time.Since(start)
-	ch <- AddressLatency{Address: address, Latency: latency}
-}
-
-func findLowestLatencyAddress(addresses []string) string {
-	var wg sync.WaitGroup
-	ch := make(chan AddressLatency, len(addresses))
-
-	for _, address := range addresses {
-		wg.Add(1)
-		go checkLatency(address, &wg, ch)
-	}
-
-	wg.Wait()
-	close(ch)
-
-	var lowestLatencyAddress string
-	lowestLatency := time.Hour
-
-	for result := range ch {
-		if result.Latency < lowestLatency {
-			lowestLatency = result.Latency
-			lowestLatencyAddress = result.Address
-		}
-	}
-
-	return lowestLatencyAddress
 }


### PR DESCRIPTION
### 改动

- 修复 #7350 导致的 `captcha_sign`  计算错误的问题
- 因为 `PikPak` 官方改动，移除了 指定下载域名功能：#7481
- 现在`PikPak`驱动 和 `PikPakShare` 驱动 初始化时 `Platform` 默认为 `Web`端：#7482
- 跟随官方版本，更新部分签名参数