### PR TITLE
feat(sso): add custom extra scope support

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -164,6 +164,7 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.SSOApplicationName, Value: "", Type: conf.TypeString, Group: model.SSO, Flag: model.PRIVATE},
 		{Key: conf.SSOEndpointName, Value: "", Type: conf.TypeString, Group: model.SSO, Flag: model.PRIVATE},
 		{Key: conf.SSOJwtPublicKey, Value: "", Type: conf.TypeString, Group: model.SSO, Flag: model.PRIVATE},
+		{Key: conf.SSOExtraScopes, Value: "", Type: conf.TypeString, Group: model.SSO, Flag: model.PRIVATE},
 		{Key: conf.SSOAutoRegister, Value: "false", Type: conf.TypeBool, Group: model.SSO, Flag: model.PRIVATE},
 		{Key: conf.SSODefaultDir, Value: "/", Type: conf.TypeString, Group: model.SSO, Flag: model.PRIVATE},
 		{Key: conf.SSODefaultPermission, Value: "0", Type: conf.TypeNumber, Group: model.SSO, Flag: model.PRIVATE},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -72,6 +72,7 @@ const (
 	SSOApplicationName   = "sso_application_name"
 	SSOEndpointName      = "sso_endpoint_name"
 	SSOJwtPublicKey      = "sso_jwt_public_key"
+	SSOExtraScopes       = "sso_extra_scopes"
 	SSOAutoRegister      = "sso_auto_register"
 	SSODefaultDir        = "sso_default_dir"
 	SSODefaultPermission = "sso_default_permission"

--- a/server/handles/ssologin.go
+++ b/server/handles/ssologin.go
@@ -4,12 +4,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/Xhofe/go-cache"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/Xhofe/go-cache"
 
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/db"
@@ -123,6 +124,10 @@ func GetOIDCClient(c *gin.Context, useCompatibility bool, redirectUri, method st
 	}
 	clientId := setting.GetStr(conf.SSOClientId)
 	clientSecret := setting.GetStr(conf.SSOClientSecret)
+	extraScopes := []string{}
+	if setting.GetStr(conf.SSOExtraScopes) != "" {
+		extraScopes = strings.Split(setting.GetStr(conf.SSOExtraScopes), " ")
+	}
 	return &oauth2.Config{
 		ClientID:     clientId,
 		ClientSecret: clientSecret,
@@ -132,7 +137,7 @@ func GetOIDCClient(c *gin.Context, useCompatibility bool, redirectUri, method st
 		Endpoint: provider.Endpoint(),
 
 		// "openid" is a required scope for OpenID Connect flows.
-		Scopes: []string{oidc.ScopeOpenID, "profile"},
+		Scopes: append([]string{oidc.ScopeOpenID, "profile"}, extraScopes...),
 	}, nil
 }
 


### PR DESCRIPTION
This PR allows user set custom extra scope for SSO login.

## Purpose
The purpose of this change is to give users more flexibility of username key (`sso_oidc_username_key`) based on ID token from OIDC server, for example, using `email` or `username`. Some OIDC implementations adds extra claims to ID token based what scope are passed to the server, so allowing users customize the scope is a must.

## Implementation
This PR adds a new settings option, `SSOExtraScopes` (`sso_extra_scopes`). If the settings option is not empty, it will be appended to the default scopes (`[openid profile]`).

## Front-end / i18n considerations

A new settings key, `sso_extra_scopes` would be added to front-end / i18n file. I have opened a related PR on front-end project: https://github.com/AlistGo/alist-web/pull/203.

There are also small typo and styles fixes should be made, like `Sso` should be `SSO`, `Ldap` should be `LDAP`. Such changes are already conatined in the related PR. Please also kindly change translation on Crowdin for better looking.