### PR TITLE
fix(net): close of closed channel

### DIFF
--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -169,9 +169,7 @@ func (d *downloader) sendChunkTask() *chunk {
 
 // when the final reader Close, we interrupt
 func (d *downloader) interrupt() error {
-	if d.chunkChannel == nil {
-		return nil
-	}
+
 	d.cancel()
 	if d.written != d.params.Range.Length {
 		log.Debugf("Downloader interrupt before finish")
@@ -181,7 +179,6 @@ func (d *downloader) interrupt() error {
 	}
 	defer func() {
 		close(d.chunkChannel)
-		d.chunkChannel = nil
 		for _, buf := range d.bufs {
 			buf.Close()
 		}

--- a/internal/net/serve.go
+++ b/internal/net/serve.go
@@ -174,7 +174,7 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request, name string, modTime time
 			pw.Close()
 		}()
 	}
-	defer sendContent.Close()
+	//defer sendContent.Close()
 
 	w.Header().Set("Accept-Ranges", "bytes")
 	if w.Header().Get("Content-Encoding") == "" {


### PR DESCRIPTION
群里有人说新版本内存释放回收慢，看了下有这个改动。
[close of closed channel问题](https://github.com/AlistGo/alist/pull/7529)
关闭两次信道造成panic
[close1](https://github.com/AlistGo/alist/blob/main/server/common/proxy.go#L57)
[close 2](https://github.com/AlistGo/alist/blob/main/internal/net/serve.go#L177)

