### PR TITLE
fix(cloudreve): support upload to remote and OneDrive storage (#6882)

### DIFF
--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
@@ -134,6 +135,8 @@ func (d *Cloudreve) Put(ctx context.Context, dstDir model.Obj, stream model.File
 	if io.ReadCloser(stream) == http.NoBody {
 		return d.create(ctx, dstDir, stream)
 	}
+
+	// 获取存储策略
 	var r DirectoryResp
 	err := d.request(http.MethodGet, "/directory"+dstDir.GetPath(), nil, &r)
 	if err != nil {
@@ -146,6 +149,8 @@ func (d *Cloudreve) Put(ctx context.Context, dstDir model.Obj, stream model.File
 		"policy_id":     r.Policy.Id,
 		"last_modified": stream.ModTime().Unix(),
 	}
+
+	// 获取上传会话信息
 	var u UploadInfo
 	err = d.request(http.MethodPut, "/file/upload", func(req *resty.Request) {
 		req.SetBody(uploadBody)
@@ -153,36 +158,50 @@ func (d *Cloudreve) Put(ctx context.Context, dstDir model.Obj, stream model.File
 	if err != nil {
 		return err
 	}
-	var chunkSize = u.ChunkSize
-	var buf []byte
-	var chunk int
-	for {
-		var n int
-		buf = make([]byte, chunkSize)
-		n, err = io.ReadAtLeast(stream, buf, chunkSize)
-		if err != nil && err != io.ErrUnexpectedEOF {
-			if err == io.EOF {
-				return nil
+
+	// 根据存储方式选择分片上传的方法
+	switch r.Policy.Type {
+	case "onedrive":
+		err = d.upOneDrive(ctx, stream, u, up)
+	case "remote": // 从机存储
+		err = d.upRemote(ctx, stream, u, up)
+	case "local": // 本机存储
+		var chunkSize = u.ChunkSize
+		var buf []byte
+		var chunk int
+		for {
+			var n int
+			buf = make([]byte, chunkSize)
+			n, err = io.ReadAtLeast(stream, buf, chunkSize)
+			if err != nil && err != io.ErrUnexpectedEOF {
+				if err == io.EOF {
+					return nil
+				}
+				return err
 			}
-			return err
+			if n == 0 {
+				break
+			}
+			buf = buf[:n]
+			err = d.request(http.MethodPost, "/file/upload/"+u.SessionID+"/"+strconv.Itoa(chunk), func(req *resty.Request) {
+				req.SetHeader("Content-Type", "application/octet-stream")
+				req.SetHeader("Content-Length", strconv.Itoa(n))
+				req.SetBody(buf)
+			}, nil)
+			if err != nil {
+				break
+			}
+			chunk++
 		}
-
-		if n == 0 {
-			break
-		}
-		buf = buf[:n]
-		err = d.request(http.MethodPost, "/file/upload/"+u.SessionID+"/"+strconv.Itoa(chunk), func(req *resty.Request) {
-			req.SetHeader("Content-Type", "application/octet-stream")
-			req.SetHeader("Content-Length", strconv.Itoa(n))
-			req.SetBody(buf)
-		}, nil)
-		if err != nil {
-			break
-		}
-		chunk++
-
+	default:
+		err = errs.NotImplement
 	}
-	return err
+	if err != nil {
+		// 删除失败的会话
+		err = d.request(http.MethodDelete, "/file/upload/"+u.SessionID, nil, nil)
+		return err
+	}
+	return nil
 }
 
 func (d *Cloudreve) create(ctx context.Context, dir model.Obj, file model.Obj) error {

--- a/drivers/cloudreve/types.go
+++ b/drivers/cloudreve/types.go
@@ -21,9 +21,11 @@ type Policy struct {
 }
 
 type UploadInfo struct {
-	SessionID string `json:"sessionID"`
-	ChunkSize int    `json:"chunkSize"`
-	Expires   int    `json:"expires"`
+	SessionID  string   `json:"sessionID"`
+	ChunkSize  int      `json:"chunkSize"`
+	Expires    int      `json:"expires"`
+	UploadURLs []string `json:"uploadURLs"`
+	Credential string   `json:"credential,omitempty"`
 }
 
 type DirectoryResp struct {


### PR DESCRIPTION
修复了对 Cloudreve 从机存储（remote） 和 OneDrive 上传功能的支持