### PR TITLE
fix(ftp-server): large transfer leads to client timeout

### DIFF
--- a/server/ftp/fsup.go
+++ b/server/ftp/fsup.go
@@ -87,5 +87,6 @@ func (f *FileUploadProxy) Close() error {
 		WebPutAsTask: false,
 	}
 	s.SetTmpFile(f.buffer)
-	return fs.PutDirectly(f.ctx, dir, s, true)
+	_, err = fs.PutAsTask(f.ctx, dir, s)
+	return err
 }

--- a/server/ftp/fsup.go
+++ b/server/ftp/fsup.go
@@ -87,6 +87,7 @@ func (f *FileUploadProxy) Close() error {
 		WebPutAsTask: false,
 	}
 	s.SetTmpFile(f.buffer)
+	s.Closers.Add(f.buffer)
 	_, err = fs.PutAsTask(f.ctx, dir, s)
 	return err
 }


### PR DESCRIPTION
刚刚pr合并的时候我还在测，结果真的就发现了两个bug，哭了。

问题1：上传大文件结束时，服务端会阻塞式地将本地的临时文件上传到网盘，期间FTP客户端会显示100%不动。这本来是预期的行为，但某些FTP客户端在这种情况下会认为上传超时失败，所以只能改成不阻塞的“以任务形式上传”

问题2：临时文件不会自动删除，而且挂载另一个AListV3时没法上传，发现是因为临时文件在`SetTmpFile`以后还得手动加入`Closers`里面，否则文件不能自动关闭。