### PR TITLE
fix(115): support float QPS

### DIFF
--- a/drivers/115/meta.go
+++ b/drivers/115/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	QRCodeToken  string  `json:"qrcode_token" type:"text" help:"one of QR code token and cookie required"`
 	QRCodeSource string  `json:"qrcode_source" type:"select" options:"web,android,ios,tv,alipaymini,wechatmini,qandroid" default:"linux" help:"select the QR code device, default linux"`
 	PageSize     int64   `json:"page_size" type:"number" default:"1000" help:"list api per page size of 115 driver"`
-	LimitRate    float64 `json:"limit_rate" type:"number" default:"2" help:"limit all api request rate ([limit]r/1s)"`
+	LimitRate    float64 `json:"limit_rate" type:"float" default:"2" help:"limit all api request rate ([limit]r/1s)"`
 	driver.RootID
 }
 

--- a/drivers/115_share/meta.go
+++ b/drivers/115_share/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	QRCodeToken  string  `json:"qrcode_token" type:"text" help:"one of QR code token and cookie required"`
 	QRCodeSource string  `json:"qrcode_source" type:"select" options:"web,android,ios,tv,alipaymini,wechatmini,qandroid" default:"linux" help:"select the QR code device, default linux"`
 	PageSize     int64   `json:"page_size" type:"number" default:"1000" help:"list api per page size of 115 driver"`
-	LimitRate    float64 `json:"limit_rate" type:"number" default:"2" help:"limit all api request rate (1r/[limit_rate]s)"`
+	LimitRate    float64 `json:"limit_rate" type:"float" default:"2" help:"limit all api request rate (1r/[limit_rate]s)"`
 	ShareCode    string  `json:"share_code" type:"text" required:"true" help:"share code of 115 share link"`
 	ReceiveCode  string  `json:"receive_code" type:"text" required:"true" help:"receive code of 115 share link"`
 	driver.RootID


### PR DESCRIPTION
Change the type of `LimitRate` in 115 Cloud and 115 Share from `number` to `float`