### PR TITLE
fix(webauthn): handle error when removing webauthn credential

### DIFF
--- a/server/handles/webauthn.go
+++ b/server/handles/webauthn.go
@@ -207,6 +207,10 @@ func DeleteAuthnLogin(c *gin.Context) {
 		return
 	}
 	err = db.RemoveAuthn(user, req.ID)
+	if err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
 	err = op.DelUserCache(user.Username)
 	if err != nil {
 		common.ErrorResp(c, err, 400)


### PR DESCRIPTION
It shouldn't typically respond with success status when deleting WebAuthn credential fails.