### PR TITLE
fix(139): handle upload file conflicts

### DIFF
--- a/drivers/139/types.go
+++ b/drivers/139/types.go
@@ -261,6 +261,7 @@ type PersonalUploadResp struct {
 	BaseResp
 	Data struct {
 		FileId      string             `json:"fileId"`
+		FileName    string             `json:"fileName"`
 		PartInfos   []PersonalPartInfo `json:"partInfos"`
 		Exist       bool               `json:"exist"`
 		RapidUpload bool               `json:"rapidUpload"`


### PR DESCRIPTION
问题描述：

- 139上传同名文件（更新）时不会覆盖现有文件，而是自动重命名添加日期。
- 这种行为不同于 Alist 中其他存储，导致自动备份工具（如Cloud Sync）频繁提示上传失败。
- 实际查看网盘后，发现存在大量带有日期标记的重复文件。

解决方案：

- 手动实现处理冲突的相关逻辑。
- 对于新个人云，创建上传信息后即可通过判断文件名得知是否冲突，随后将旧文件重命名然后删除即可。
- 对于家庭云，由于创建上传信息后无法获取自动重命名后的文件名，需要在上传前重命名并删除旧文件。
