### PR TITLE
feat(s3): support custom host presign

### DIFF
--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -99,8 +99,12 @@ func (d *S3) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*mo
 	var link model.Link
 	var err error
 	if d.CustomHost != "" {
-		err = req.Build()
-		link.URL = req.HTTPRequest.URL.String()
+		if d.EnableCustomHostPresign {
+			link.URL, err = req.Presign(time.Hour * time.Duration(d.SignURLExpire))
+		} else {
+			err = req.Build()
+			link.URL = req.HTTPRequest.URL.String()
+		}
 		if d.RemoveBucket {
 			link.URL = strings.Replace(link.URL, "/"+d.Bucket, "", 1)
 		}

--- a/drivers/s3/meta.go
+++ b/drivers/s3/meta.go
@@ -14,6 +14,7 @@ type Addition struct {
 	SecretAccessKey          string `json:"secret_access_key" required:"true"`
 	SessionToken             string `json:"session_token"`
 	CustomHost               string `json:"custom_host"`
+	EnableCustomHostPresign  bool   `json:"enable_custom_host_presign"`
 	SignURLExpire            int    `json:"sign_url_expire" type:"number" default:"4"`
 	Placeholder              string `json:"placeholder"`
 	ForcePathStyle           bool   `json:"force_path_style"`


### PR DESCRIPTION
Add a boolean addition `EnableCustomHostPresign` to determine whether to attach the sign when using the custom host.

- Previous behavior (taking Aliyun OSS as an example):
  - Download link without custom host (using internal endpoint):
    ```
    https://<bucket-name>.oss-cn-beijing-internal.aliyuncs.com/<filename>?X-Amz-Algorithm=***&X-Amz-Credential=***...
    ```
  - Download link within custom host (using external endpoint, the following link is **invalid**):
    ```
    https://<bucket-name>.oss-cn-beijing.aliyuncs.com/<filename>
    ```
- Current behavior when `EnableCustomHostPresign` is `false`: Same as previous
- Current behavior when `EnableCustomHostPresign` is `true`:
  - Download link within custom host (using external endpoint, the following link is **valid**):
    ```
    https://<bucket-name>.oss-cn-beijing.aliyuncs.com/<filename>?X-Amz-Algorithm=***&X-Amz-Credential=***...
    ```

Closes #7696