### PR TITLE
fix(permission): enhance the strictness of permissions

### DIFF
--- a/internal/bootstrap/data/user.go
+++ b/internal/bootstrap/data/user.go
@@ -26,12 +26,13 @@ func initUser() {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			salt := random.String(16)
 			admin = &model.User{
-				Username: "admin",
-				Salt:     salt,
-				PwdHash:  model.TwoHashPwd(adminPassword, salt),
-				Role:     model.ADMIN,
-				BasePath: "/",
-				Authn:    "[]",
+				Username:   "admin",
+				Salt:       salt,
+				PwdHash:    model.TwoHashPwd(adminPassword, salt),
+				Role:       model.ADMIN,
+				BasePath:   "/",
+				Authn:      "[]",
+				Permission: 0xFF, // 0(can see hidden) - 7(can remove)
 			}
 			if err := op.CreateUser(admin); err != nil {
 				panic(err)

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -32,16 +32,18 @@ type User struct {
 	Role     int    `json:"role"`                                      // user's role
 	Disabled bool   `json:"disabled"`
 	// Determine permissions by bit
-	//   0: can see hidden files
-	//   1: can access without password
-	//   2: can add offline download tasks
-	//   3: can mkdir and upload
-	//   4: can rename
-	//   5: can move
-	//   6: can copy
-	//   7: can remove
-	//   8: webdav read
-	//   9: webdav write
+	//   0:  can see hidden files
+	//   1:  can access without password
+	//   2:  can add offline download tasks
+	//   3:  can mkdir and upload
+	//   4:  can rename
+	//   5:  can move
+	//   6:  can copy
+	//   7:  can remove
+	//   8:  webdav read
+	//   9:  webdav write
+	//   10: ftp/sftp login and read
+	//   11: ftp/sftp write
 	Permission int32  `json:"permission"`
 	OtpSecret  string `json:"-"`
 	SsoID      string `json:"sso_id"` // unique by sso platform
@@ -78,43 +80,43 @@ func (u *User) SetPassword(pwd string) *User {
 }
 
 func (u *User) CanSeeHides() bool {
-	return u.IsAdmin() || u.Permission&1 == 1
+	return u.Permission&1 == 1
 }
 
 func (u *User) CanAccessWithoutPassword() bool {
-	return u.IsAdmin() || (u.Permission>>1)&1 == 1
+	return (u.Permission>>1)&1 == 1
 }
 
 func (u *User) CanAddOfflineDownloadTasks() bool {
-	return u.IsAdmin() || (u.Permission>>2)&1 == 1
+	return (u.Permission>>2)&1 == 1
 }
 
 func (u *User) CanWrite() bool {
-	return u.IsAdmin() || (u.Permission>>3)&1 == 1
+	return (u.Permission>>3)&1 == 1
 }
 
 func (u *User) CanRename() bool {
-	return u.IsAdmin() || (u.Permission>>4)&1 == 1
+	return (u.Permission>>4)&1 == 1
 }
 
 func (u *User) CanMove() bool {
-	return u.IsAdmin() || (u.Permission>>5)&1 == 1
+	return (u.Permission>>5)&1 == 1
 }
 
 func (u *User) CanCopy() bool {
-	return u.IsAdmin() || (u.Permission>>6)&1 == 1
+	return (u.Permission>>6)&1 == 1
 }
 
 func (u *User) CanRemove() bool {
-	return u.IsAdmin() || (u.Permission>>7)&1 == 1
+	return (u.Permission>>7)&1 == 1
 }
 
 func (u *User) CanWebdavRead() bool {
-	return u.IsAdmin() || (u.Permission>>8)&1 == 1
+	return (u.Permission>>8)&1 == 1
 }
 
 func (u *User) CanWebdavManage() bool {
-	return u.IsAdmin() || (u.Permission>>9)&1 == 1
+	return (u.Permission>>9)&1 == 1
 }
 
 func (u *User) CanFTPAccess() bool {

--- a/server/webdav/file.go
+++ b/server/webdav/file.go
@@ -33,6 +33,13 @@ func moveFiles(ctx context.Context, src, dst string, overwrite bool) (status int
 	dstDir := path.Dir(dst)
 	srcName := path.Base(src)
 	dstName := path.Base(dst)
+	user := ctx.Value("user").(*model.User)
+	if srcDir != dstDir && !user.CanMove() {
+		return http.StatusForbidden, nil
+	}
+	if srcName != dstName && !user.CanRename() {
+		return http.StatusForbidden, nil
+	}
 	if srcDir == dstDir {
 		err = fs.Rename(ctx, src, dstName)
 	} else {


### PR DESCRIPTION
Add constraints of the permission system on the admin user
Add basic permissions requirement for the WebDAV endpoint

The benefits of these modifications:
- Ensuring that the admin user is also within the scope of permission management helps to prevent accidental operations.
- Requiring two permissions for WebDAV write requests helps to achieve more refined permission management.

Frontend part AlistGo/alist-web#216

Closes #7680