### PR TITLE
feat(github): add github api driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/dropbox"
 	_ "github.com/alist-org/alist/v3/drivers/febbox"
 	_ "github.com/alist-org/alist/v3/drivers/ftp"
+	_ "github.com/alist-org/alist/v3/drivers/github"
 	_ "github.com/alist-org/alist/v3/drivers/google_drive"
 	_ "github.com/alist-org/alist/v3/drivers/google_photo"
 	_ "github.com/alist-org/alist/v3/drivers/halalcloud"

--- a/drivers/github/driver.go
+++ b/drivers/github/driver.go
@@ -1,0 +1,410 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/go-resty/resty/v2"
+	"io"
+	stdpath "path"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+type Github struct {
+	model.Storage
+	Addition
+	client        *resty.Client
+	mkdirMsgTmpl  *template.Template
+	deleteMsgTmpl *template.Template
+	putMsgTmpl    *template.Template
+}
+
+func (d *Github) Config() driver.Config {
+	return config
+}
+
+func (d *Github) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *Github) Init(ctx context.Context) error {
+	d.RootFolderPath = utils.FixAndCleanPath(d.RootFolderPath)
+	if d.CommitterName != "" && d.CommitterEmail == "" {
+		return errors.New("committer email is required")
+	}
+	if d.CommitterName == "" && d.CommitterEmail != "" {
+		return errors.New("committer name is required")
+	}
+	if d.AuthorName != "" && d.AuthorEmail == "" {
+		return errors.New("author email is required")
+	}
+	if d.AuthorName == "" && d.AuthorEmail != "" {
+		return errors.New("author name is required")
+	}
+	var err error
+	d.mkdirMsgTmpl, err = template.New("mkdirCommitMsgTemplate").Parse(d.MkdirCommitMsg)
+	if err != nil {
+		return err
+	}
+	d.deleteMsgTmpl, err = template.New("deleteCommitMsgTemplate").Parse(d.DeleteCommitMsg)
+	if err != nil {
+		return err
+	}
+	d.putMsgTmpl, err = template.New("putCommitMsgTemplate").Parse(d.PutCommitMsg)
+	if err != nil {
+		return err
+	}
+	d.client = base.NewRestyClient().
+		SetHeader("Accept", "application/vnd.github.object+json").
+		SetHeader("Authorization", "Bearer "+d.Token).
+		SetHeader("X-GitHub-Api-Version", "2022-11-28")
+	return nil
+}
+
+func (d *Github) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *Github) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	obj, err := d.get(dir.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	if obj.Entries == nil {
+		return nil, errs.NotFolder
+	}
+	ret := make([]model.Obj, 0, len(obj.Entries))
+	for _, entry := range obj.Entries {
+		if entry.Name != ".gitkeep" {
+			ret = append(ret, entry.toModelObj())
+		}
+	}
+	return ret, nil
+}
+
+func (d *Github) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	obj, err := d.get(file.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	return &model.Link{
+		URL: obj.DownloadURL,
+	}, nil
+}
+
+func (d *Github) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	commitMessage, err := getMessage(d.mkdirMsgTmpl, &MessageTemplateVars{
+		UserName:   ctx.Value("user").(*model.User).Username,
+		ObjName:    dirName,
+		ObjPath:    stdpath.Join(parentDir.GetPath(), dirName),
+		ParentName: parentDir.GetName(),
+		ParentPath: parentDir.GetPath(),
+	}, "mkdir")
+	if err != nil {
+		return err
+	}
+	parent, err := d.get(parentDir.GetPath())
+	if err != nil {
+		return err
+	}
+	if parent.Entries == nil {
+		return errs.NotFolder
+	}
+	// if parent folder contains .gitkeep only, mark it and delete .gitkeep later
+	gitKeepSha := ""
+	if len(parent.Entries) == 1 && parent.Entries[0].Name == ".gitkeep" {
+		gitKeepSha = parent.Entries[0].Sha
+	}
+
+	if err = d.createGitKeep(stdpath.Join(parentDir.GetPath(), dirName), commitMessage); err != nil {
+		return err
+	}
+	if gitKeepSha != "" {
+		err = d.delete(stdpath.Join(parentDir.GetPath(), ".gitkeep"), gitKeepSha, commitMessage)
+	}
+	return err
+}
+
+func (d *Github) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, errs.NotSupport
+}
+
+func (d *Github) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	return nil, errs.NotSupport
+}
+
+func (d *Github) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, errs.NotSupport
+}
+
+func (d *Github) Remove(ctx context.Context, obj model.Obj) error {
+	parentDir := stdpath.Dir(obj.GetPath())
+	commitMessage, err := getMessage(d.deleteMsgTmpl, &MessageTemplateVars{
+		UserName:   ctx.Value("user").(*model.User).Username,
+		ObjName:    obj.GetName(),
+		ObjPath:    obj.GetPath(),
+		ParentName: stdpath.Base(parentDir),
+		ParentPath: parentDir,
+	}, "remove")
+	if err != nil {
+		return err
+	}
+	parent, err := d.get(parentDir)
+	if err != nil {
+		return err
+	}
+	if parent.Entries == nil {
+		return errs.ObjectNotFound
+	}
+	sha := ""
+	isDir := false
+	for _, entry := range parent.Entries {
+		if entry.Name == obj.GetName() {
+			sha = entry.Sha
+			isDir = entry.Type == "dir"
+			break
+		}
+	}
+	if isDir {
+		return d.rmdir(obj.GetPath(), commitMessage)
+	}
+	if sha == "" {
+		return errs.ObjectNotFound
+	}
+	// if deleted file is the only child of its parent, create .gitkeep to retain empty folder
+	if parentDir != "/" && len(parent.Entries) == 1 {
+		if err = d.createGitKeep(parentDir, commitMessage); err != nil {
+			return err
+		}
+	}
+	return d.delete(obj.GetPath(), sha, commitMessage)
+}
+
+func (d *Github) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	commitMessage, err := getMessage(d.putMsgTmpl, &MessageTemplateVars{
+		UserName:   ctx.Value("user").(*model.User).Username,
+		ObjName:    stream.GetName(),
+		ObjPath:    stdpath.Join(dstDir.GetPath(), stream.GetName()),
+		ParentName: dstDir.GetName(),
+		ParentPath: dstDir.GetPath(),
+	}, "upload")
+	if err != nil {
+		return nil, err
+	}
+	parent, err := d.get(dstDir.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	if parent.Entries == nil {
+		return nil, errs.NotFolder
+	}
+	uploadSha := ""
+	for _, entry := range parent.Entries {
+		if entry.Name == stream.GetName() {
+			uploadSha = entry.Sha
+			break
+		}
+	}
+	// if parent folder contains .gitkeep only, mark it and delete .gitkeep later
+	gitKeepSha := ""
+	if len(parent.Entries) == 1 && parent.Entries[0].Name == ".gitkeep" {
+		gitKeepSha = parent.Entries[0].Sha
+	}
+
+	path := stdpath.Join(dstDir.GetPath(), stream.GetName())
+	resp, err := d.put(path, uploadSha, commitMessage, ctx, stream, up)
+	if err != nil {
+		return nil, err
+	}
+	if gitKeepSha != "" {
+		err = d.delete(stdpath.Join(dstDir.GetPath(), ".gitkeep"), gitKeepSha, commitMessage)
+	}
+	return resp.Content.toModelObj(), err
+}
+
+var _ driver.Driver = (*Github)(nil)
+
+func (d *Github) getApiUrl(path string) string {
+	path = utils.FixAndCleanPath(path)
+	return fmt.Sprintf("https://api.github.com/repos/%s/%s/contents%s", d.Owner, d.Repo, path)
+}
+
+func (d *Github) get(path string) (*Object, error) {
+	req := d.client.R()
+	if d.Ref != "" {
+		req = req.SetQueryParam("ref", d.Ref)
+	}
+	res, err := req.Get(d.getApiUrl(path))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode() != 200 {
+		return nil, toErr(res)
+	}
+	var resp Object
+	err = utils.Json.Unmarshal(res.Body(), &resp)
+	return &resp, err
+}
+
+func (d *Github) createGitKeep(path, message string) error {
+	body := map[string]interface{}{
+		"message": message,
+		"content": "",
+	}
+	if d.Ref != "" {
+		body["branch"] = d.Ref
+	}
+	d.addCommitterAndAuthor(&body)
+
+	res, err := d.client.R().SetBody(body).Put(d.getApiUrl(stdpath.Join(path, ".gitkeep")))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != 200 && res.StatusCode() != 201 {
+		return toErr(res)
+	}
+	return nil
+}
+
+func (d *Github) put(path, sha, message string, ctx context.Context, stream model.FileStreamer, up driver.UpdateProgress) (*PutResp, error) {
+	beforeContent := strings.Builder{}
+	beforeContent.WriteString("{\"message\":\"")
+	beforeContent.WriteString(message)
+	beforeContent.WriteString("\",")
+	if sha != "" {
+		beforeContent.WriteString("\"sha\":\"")
+		beforeContent.WriteString(sha)
+		beforeContent.WriteString("\",")
+	}
+	if d.Ref != "" {
+		beforeContent.WriteString("\"branch\":\"")
+		beforeContent.WriteString(d.Ref)
+		beforeContent.WriteString("\",")
+	}
+	if d.CommitterName != "" {
+		beforeContent.WriteString("\"committer\":{\"name\":\"")
+		beforeContent.WriteString(d.CommitterName)
+		beforeContent.WriteString("\",\"email\":\"")
+		beforeContent.WriteString(d.CommitterEmail)
+		beforeContent.WriteString("\"},")
+	}
+	if d.AuthorName != "" {
+		beforeContent.WriteString("\"author\":{\"name\":\"")
+		beforeContent.WriteString(d.AuthorName)
+		beforeContent.WriteString("\",\"email\":\"")
+		beforeContent.WriteString(d.AuthorEmail)
+		beforeContent.WriteString("\"},")
+	}
+	beforeContent.WriteString("\"content\":\"")
+
+	length := int64(beforeContent.Len()) + calculateBase64Length(stream.GetSize()) + 2
+	beforeContentReader := strings.NewReader(beforeContent.String())
+	contentReader, contentWriter := io.Pipe()
+	go func() {
+		encoder := base64.NewEncoder(base64.StdEncoding, contentWriter)
+		if _, err := io.Copy(encoder, stream); err != nil {
+			_ = contentWriter.CloseWithError(err)
+			return
+		}
+		_ = encoder.Close()
+		_ = contentWriter.Close()
+	}()
+	afterContentReader := strings.NewReader("\"}")
+	res, err := d.client.R().
+		SetHeader("Content-Length", strconv.FormatInt(length, 10)).
+		SetBody(&ReaderWithCtx{
+			Reader:   io.MultiReader(beforeContentReader, contentReader, afterContentReader),
+			Ctx:      ctx,
+			Length:   length,
+			Progress: up,
+		}).
+		Put(d.getApiUrl(path))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode() != 200 && res.StatusCode() != 201 {
+		return nil, toErr(res)
+	}
+	var resp PutResp
+	if err = utils.Json.Unmarshal(res.Body(), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (d *Github) delete(path, sha, message string) error {
+	body := map[string]interface{}{
+		"message": message,
+		"sha":     sha,
+	}
+	if d.Ref != "" {
+		body["branch"] = d.Ref
+	}
+	d.addCommitterAndAuthor(&body)
+	res, err := d.client.R().SetBody(body).Delete(d.getApiUrl(path))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != 200 {
+		return toErr(res)
+	}
+	return nil
+}
+
+func (d *Github) rmdir(path, message string) error {
+	for { // the number of sub-items returned pre call is limited to a maximum of 1000
+		obj, err := d.get(path)
+		if err != nil { // until 404
+			return nil
+		}
+		if obj.Type != "dir" || obj.Entries == nil {
+			return errs.NotFolder
+		}
+		if len(obj.Entries) == 0 { // maybe never access
+			return nil
+		}
+		if err = d.clearSub(obj, path, message); err != nil {
+			return err
+		}
+	}
+}
+
+func (d *Github) clearSub(obj *Object, path, message string) error {
+	for _, entry := range obj.Entries {
+		var err error
+		if entry.Type == "dir" {
+			err = d.rmdir(stdpath.Join(path, entry.Name), message)
+		} else {
+			err = d.delete(stdpath.Join(path, entry.Name), entry.Sha, message)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Github) addCommitterAndAuthor(m *map[string]interface{}) {
+	if d.CommitterName != "" {
+		committer := map[string]string{
+			"name":  d.CommitterName,
+			"email": d.CommitterEmail,
+		}
+		(*m)["committer"] = committer
+	}
+	if d.AuthorName != "" {
+		author := map[string]string{
+			"name":  d.AuthorName,
+			"email": d.AuthorEmail,
+		}
+		(*m)["author"] = author
+	}
+}

--- a/drivers/github/driver.go
+++ b/drivers/github/driver.go
@@ -457,7 +457,7 @@ func (d *Github) Rename(ctx context.Context, srcObj model.Obj, newName string) e
 		ParentName: stdpath.Base(parentDir),
 		ParentPath: parentDir,
 		TargetName: newName,
-		TargetPath: parentDir,
+		TargetPath: stdpath.Join(parentDir, newName),
 	}, "rename")
 	if err != nil {
 		return err

--- a/drivers/github/meta.go
+++ b/drivers/github/meta.go
@@ -1,0 +1,33 @@
+package github
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	driver.RootPath
+	Token           string `json:"token" type:"string" required:"true"`
+	Owner           string `json:"owner" type:"string" required:"true"`
+	Repo            string `json:"repo" type:"string" required:"true"`
+	Ref             string `json:"ref" type:"string"`
+	CommitterName   string `json:"committer_name" type:"string"`
+	CommitterEmail  string `json:"committer_email" type:"string"`
+	AuthorName      string `json:"author_name" type:"string"`
+	AuthorEmail     string `json:"author_email" type:"string"`
+	MkdirCommitMsg  string `json:"mkdir_commit_message" type:"text" default:"{{.UserName}} mkdir {{.ObjPath}}"`
+	DeleteCommitMsg string `json:"delete_commit_message" type:"text" default:"{{.UserName}} remove {{.ObjPath}}"`
+	PutCommitMsg    string `json:"put_commit_message" type:"text" default:"{{.UserName}} upload {{.ObjPath}}"`
+}
+
+var config = driver.Config{
+	Name:        "GitHub API",
+	LocalSort:   true,
+	DefaultRoot: "/",
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &Github{}
+	})
+}

--- a/drivers/github/meta.go
+++ b/drivers/github/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	Token           string `json:"token" type:"string" required:"true"`
 	Owner           string `json:"owner" type:"string" required:"true"`
 	Repo            string `json:"repo" type:"string" required:"true"`
-	Ref             string `json:"ref" type:"string"`
+	Ref             string `json:"ref" type:"string" help:"A branch, a tag or a commit SHA, main branch by default."`
 	CommitterName   string `json:"committer_name" type:"string"`
 	CommitterEmail  string `json:"committer_email" type:"string"`
 	AuthorName      string `json:"author_name" type:"string"`

--- a/drivers/github/meta.go
+++ b/drivers/github/meta.go
@@ -18,6 +18,9 @@ type Addition struct {
 	MkdirCommitMsg  string `json:"mkdir_commit_message" type:"text" default:"{{.UserName}} mkdir {{.ObjPath}}"`
 	DeleteCommitMsg string `json:"delete_commit_message" type:"text" default:"{{.UserName}} remove {{.ObjPath}}"`
 	PutCommitMsg    string `json:"put_commit_message" type:"text" default:"{{.UserName}} upload {{.ObjPath}}"`
+	RenameCommitMsg string `json:"rename_commit_message" type:"text" default:"{{.UserName}} rename {{.ObjPath}} to {{.TargetName}}"`
+	CopyCommitMsg   string `json:"copy_commit_message" type:"text" default:"{{.UserName}} copy {{.ObjPath}} to {{.TargetPath}}"`
+	MoveCommitMsg   string `json:"move_commit_message" type:"text" default:"{{.UserName}} move {{.ObjPath}} to {{.TargetPath}}"`
 }
 
 var config = driver.Config{

--- a/drivers/github/types.go
+++ b/drivers/github/types.go
@@ -1,0 +1,50 @@
+package github
+
+import (
+	"github.com/alist-org/alist/v3/internal/model"
+	"time"
+)
+
+type Links struct {
+	Git  string `json:"git"`
+	Html string `json:"html"`
+	Self string `json:"self"`
+}
+
+type Object struct {
+	Type            string   `json:"type"`
+	Encoding        string   `json:"encoding" required:"false"`
+	Size            int64    `json:"size"`
+	Name            string   `json:"name"`
+	Path            string   `json:"path"`
+	Content         string   `json:"Content" required:"false"`
+	Sha             string   `json:"sha"`
+	URL             string   `json:"url"`
+	GitURL          string   `json:"git_url"`
+	HtmlURL         string   `json:"html_url"`
+	DownloadURL     string   `json:"download_url"`
+	Entries         []Object `json:"entries" required:"false"`
+	Links           Links    `json:"_links"`
+	SubmoduleGitURL string   `json:"submodule_git_url" required:"false"`
+	Target          string   `json:"target" required:"false"`
+}
+
+func (o *Object) toModelObj() *model.Object {
+	return &model.Object{
+		Name:     o.Name,
+		Size:     o.Size,
+		Modified: time.Unix(0, 0),
+		IsFolder: o.Type == "dir",
+	}
+}
+
+type PutResp struct {
+	Content Object      `json:"Content"`
+	Commit  interface{} `json:"commit"`
+}
+
+type ErrResp struct {
+	Message          string `json:"message"`
+	DocumentationURL string `json:"documentation_url"`
+	Status           string `json:"status"`
+}

--- a/drivers/github/types.go
+++ b/drivers/github/types.go
@@ -38,9 +38,9 @@ func (o *Object) toModelObj() *model.Object {
 	}
 }
 
-type PutResp struct {
-	Content Object      `json:"Content"`
-	Commit  interface{} `json:"commit"`
+type PutBlobResp struct {
+	URL string `json:"url"`
+	Sha string `json:"sha"`
 }
 
 type ErrResp struct {

--- a/drivers/github/types.go
+++ b/drivers/github/types.go
@@ -54,22 +54,21 @@ type TreeObjReq struct {
 	Mode string      `json:"mode"`
 	Type string      `json:"type"`
 	Sha  interface{} `json:"sha"`
-	Size int64       `json:"size" required:"false"`
-}
-
-func (o *TreeObjReq) toModelObj() *model.Object {
-	return &model.Object{
-		Name:     o.Path,
-		Size:     o.Size,
-		Modified: time.Unix(0, 0),
-		IsFolder: o.Type == "tree",
-	}
 }
 
 type TreeObjResp struct {
 	TreeObjReq
 	Size int64  `json:"size" required:"false"`
 	URL  string `json:"url"`
+}
+
+func (o *TreeObjResp) toModelObj() *model.Object {
+	return &model.Object{
+		Name:     o.Path,
+		Size:     o.Size,
+		Modified: time.Unix(0, 0),
+		IsFolder: o.Type == "tree",
+	}
 }
 
 type TreeResp struct {
@@ -96,4 +95,8 @@ type BranchResp struct {
 type UpdateRefReq struct {
 	Sha   string `json:"sha"`
 	Force bool   `json:"force"`
+}
+
+type RepoResp struct {
+	DefaultBranch string `json:"default_branch"`
 }

--- a/drivers/github/types.go
+++ b/drivers/github/types.go
@@ -48,3 +48,52 @@ type ErrResp struct {
 	DocumentationURL string `json:"documentation_url"`
 	Status           string `json:"status"`
 }
+
+type TreeObjReq struct {
+	Path string      `json:"path"`
+	Mode string      `json:"mode"`
+	Type string      `json:"type"`
+	Sha  interface{} `json:"sha"`
+	Size int64       `json:"size" required:"false"`
+}
+
+func (o *TreeObjReq) toModelObj() *model.Object {
+	return &model.Object{
+		Name:     o.Path,
+		Size:     o.Size,
+		Modified: time.Unix(0, 0),
+		IsFolder: o.Type == "tree",
+	}
+}
+
+type TreeObjResp struct {
+	TreeObjReq
+	Size int64  `json:"size" required:"false"`
+	URL  string `json:"url"`
+}
+
+type TreeResp struct {
+	Sha       string        `json:"sha"`
+	URL       string        `json:"url"`
+	Trees     []TreeObjResp `json:"tree"`
+	Truncated bool          `json:"truncated"`
+}
+
+type TreeReq struct {
+	BaseTree string        `json:"base_tree"`
+	Trees    []interface{} `json:"tree"`
+}
+
+type CommitResp struct {
+	Sha string `json:"sha"`
+}
+
+type BranchResp struct {
+	Name   string     `json:"name"`
+	Commit CommitResp `json:"commit"`
+}
+
+type UpdateRefReq struct {
+	Sha   string `json:"sha"`
+	Force bool   `json:"force"`
+}

--- a/drivers/github/util.go
+++ b/drivers/github/util.go
@@ -13,18 +13,17 @@ import (
 	"text/template"
 )
 
-type ReaderWithCtx struct {
+type ReaderWithProgress struct {
 	Reader   io.Reader
-	Ctx      context.Context
 	Length   int64
 	Progress func(percentage float64)
 	offset   int64
 }
 
-func (r *ReaderWithCtx) Read(p []byte) (int, error) {
+func (r *ReaderWithProgress) Read(p []byte) (int, error) {
 	n, err := r.Reader.Read(p)
 	r.offset += int64(n)
-	r.Progress(math.Min(100.0, float64(r.offset)/float64(r.Length)))
+	r.Progress(math.Min(100.0, float64(r.offset)/float64(r.Length)*100.0))
 	return n, err
 }
 

--- a/drivers/github/util.go
+++ b/drivers/github/util.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/go-resty/resty/v2"
+	"io"
+	"math"
+	"strings"
+	"text/template"
+)
+
+type ReaderWithCtx struct {
+	Reader   io.Reader
+	Ctx      context.Context
+	Length   int64
+	Progress func(percentage float64)
+	offset   int64
+}
+
+func (r *ReaderWithCtx) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.offset += int64(n)
+	r.Progress(math.Min(100.0, float64(r.offset)/float64(r.Length)))
+	return n, err
+}
+
+type MessageTemplateVars struct {
+	UserName   string
+	ObjName    string
+	ObjPath    string
+	ParentName string
+	ParentPath string
+}
+
+func getMessage(tmpl *template.Template, vars *MessageTemplateVars, defaultOpStr string) (string, error) {
+	sb := strings.Builder{}
+	if err := tmpl.Execute(&sb, vars); err != nil {
+		return fmt.Sprintf("%s %s %s", vars.UserName, defaultOpStr, vars.ObjPath), err
+	}
+	return sb.String(), nil
+}
+
+func calculateBase64Length(inputLength int64) int64 {
+	return 4 * ((inputLength + 2) / 3)
+}
+
+func toErr(res *resty.Response) error {
+	var errMsg ErrResp
+	if err := utils.Json.Unmarshal(res.Body(), &errMsg); err != nil {
+		return errors.New(res.Status())
+	} else {
+		return fmt.Errorf("%s: %s", res.Status(), errMsg.Message)
+	}
+}

--- a/drivers/github/util.go
+++ b/drivers/github/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 	"io"
@@ -104,4 +105,12 @@ func getPathCommonAncestor(a, b string) (ancestor, aChildName, bChildName, aRest
 	aRest = a[idx+1:]
 	bRest = b[idx+1:]
 	return ancestor, aChildName, bChildName, aRest, bRest
+}
+
+func getUsername(ctx context.Context) string {
+	user, ok := ctx.Value("user").(*model.User)
+	if !ok {
+		return "<system>"
+	}
+	return user.Username
 }

--- a/drivers/github/util.go
+++ b/drivers/github/util.go
@@ -33,6 +33,8 @@ type MessageTemplateVars struct {
 	ObjPath    string
 	ParentName string
 	ParentPath string
+	TargetName string
+	TargetPath string
 }
 
 func getMessage(tmpl *template.Template, vars *MessageTemplateVars, defaultOpStr string) (string, error) {
@@ -54,4 +56,52 @@ func toErr(res *resty.Response) error {
 	} else {
 		return fmt.Errorf("%s: %s", res.Status(), errMsg.Message)
 	}
+}
+
+// Example input:
+// a = /aaa/bbb/ccc
+// b = /aaa/b11/ddd/ccc
+//
+// Output:
+// ancestor = /aaa
+// aChildName = bbb
+// bChildName = b11
+// aRest = bbb/ccc
+// bRest = b11/ddd/ccc
+func getPathCommonAncestor(a, b string) (ancestor, aChildName, bChildName, aRest, bRest string) {
+	a = utils.FixAndCleanPath(a)
+	b = utils.FixAndCleanPath(b)
+	idx := 1
+	for idx < len(a) && idx < len(b) {
+		if a[idx] != b[idx] {
+			break
+		}
+		idx++
+	}
+	aNextIdx := idx
+	for aNextIdx < len(a) {
+		if a[aNextIdx] == '/' {
+			break
+		}
+		aNextIdx++
+	}
+	bNextIdx := idx
+	for bNextIdx < len(b) {
+		if b[bNextIdx] == '/' {
+			break
+		}
+		bNextIdx++
+	}
+	for idx > 0 {
+		if a[idx] == '/' {
+			break
+		}
+		idx--
+	}
+	ancestor = utils.FixAndCleanPath(a[:idx])
+	aChildName = a[idx+1 : aNextIdx]
+	bChildName = b[idx+1 : bNextIdx]
+	aRest = a[idx+1:]
+	bRest = b[idx+1:]
+	return ancestor, aChildName, bChildName, aRest, bRest
 }


### PR DESCRIPTION
Add GitHub driver powered by GitHub API

每个目录下只能显示~~1,000~~ 100,000个子项，不支持操作100M以上大小的文件。
会忽略仓库内的`.gitkeep`文件，驱动全权负责该文件的管理。
没有考虑仓库里有子模块的情况，~~将来补~~ 已实现操作子模块时直接返回错误，将来不补充实现对子模块的访问支持。

~~暂时没有实现重命名、和移动，这两个功能要用别的api，暂时还没研究。~~ 已实现
~~删除目录是手动递归实现的，很耗时，但这就是官方建议的操作方法，没有更好的方法了。~~ 已改用 Tree API 实现
~~`Github.put`函数我的本意是希望文件内容每往AList发一点，AList就往GitHub发一点，同时记录进度。但我试了下好像还是变成浏览器给AList发完之后，AList才开始向GitHub发起请求了，我不知道用resty怎么实现这个功能，如果我写的确实有问题麻烦帮我改改，如果这个功能实现不了的话麻烦帮我改成调用`CacheFullInTempFile`。~~ 已实现

Document part AlistGo/docs#396

