### PR TITLE
feat(index): add `disable index` option for storages

### DIFF
--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -1,6 +1,8 @@
 package model
 
-import "time"
+import (
+	"time"
+)
 
 type Storage struct {
 	ID              uint      `json:"id" gorm:"primaryKey"`                        // unique key
@@ -13,6 +15,7 @@ type Storage struct {
 	Remark          string    `json:"remark"`
 	Modified        time.Time `json:"modified"`
 	Disabled        bool      `json:"disabled"` // if disabled
+	DisableIndex    bool      `json:"disable_index"`
 	EnableSign      bool      `json:"enable_sign"`
 	Sort
 	Proxy

--- a/internal/op/driver.go
+++ b/internal/op/driver.go
@@ -134,6 +134,12 @@ func getMainItems(config driver.Config) []driver.Item {
 		Options: "front,back",
 	})
 	items = append(items, driver.Item{
+		Name:     "disable_index",
+		Type:     conf.TypeBool,
+		Default:  "false",
+		Required: true,
+	})
+	items = append(items, driver.Item{
 		Name:     "enable_sign",
 		Type:     conf.TypeBool,
 		Default:  "false",

--- a/internal/search/build.go
+++ b/internal/search/build.go
@@ -157,6 +157,11 @@ func BuildIndex(ctx context.Context, indexPaths, ignorePaths []string, maxDepth 
 					return filepath.SkipDir
 				}
 			}
+			if storage, _, err := op.GetStorageAndActualPath(indexPath); err == nil {
+				if storage.GetStorage().DisableIndex {
+					return filepath.SkipDir
+				}
+			}
 			// ignore root
 			if indexPath == "/" {
 				return nil


### PR DESCRIPTION
Allow users to disable storage indexing.
允许用户禁用存储索引。