### PR TITLE
feat(patch): upgrade patch module

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -19,6 +19,7 @@ func Init() {
 	bootstrap.InitDB()
 	data.InitData()
 	bootstrap.InitIndex()
+	bootstrap.InitUpgradePatch()
 }
 
 func Release() {

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -34,6 +34,7 @@ func InitConfig() {
 			log.Fatalf("failed to create config file: %+v", err)
 		}
 		conf.Conf = conf.DefaultConfig()
+		LastLaunchedVersion = conf.Version
 		conf.Conf.LastLaunchedVersion = conf.Version
 		if !utils.WriteJsonToFile(configPath, conf.Conf) {
 			log.Fatalf("failed to create default config file")
@@ -47,6 +48,10 @@ func InitConfig() {
 		err = utils.Json.Unmarshal(configBytes, conf.Conf)
 		if err != nil {
 			log.Fatalf("load config error: %+v", err)
+		}
+		LastLaunchedVersion = conf.Conf.LastLaunchedVersion
+		if conf.Version != "dev" || LastLaunchedVersion == "" {
+			conf.Conf.LastLaunchedVersion = conf.Version
 		}
 		// update config.json struct
 		confBody, err := utils.Json.MarshalIndent(conf.Conf, "", "  ")

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -34,6 +34,7 @@ func InitConfig() {
 			log.Fatalf("failed to create config file: %+v", err)
 		}
 		conf.Conf = conf.DefaultConfig()
+		conf.Conf.LastLaunchedVersion = conf.Version
 		if !utils.WriteJsonToFile(configPath, conf.Conf) {
 			log.Fatalf("failed to create default config file")
 		}

--- a/internal/bootstrap/data/user.go
+++ b/internal/bootstrap/data/user.go
@@ -64,39 +64,4 @@ func initUser() {
 			utils.Log.Fatalf("[init user] Failed to get guest user: %v", err)
 		}
 	}
-	hashPwdForOldVersion()
-	updateAuthnForOldVersion()
-}
-
-func hashPwdForOldVersion() {
-	users, _, err := op.GetUsers(1, -1)
-	if err != nil {
-		utils.Log.Fatalf("[hash pwd for old version] failed get users: %v", err)
-	}
-	for i := range users {
-		user := users[i]
-		if user.PwdHash == "" {
-			user.SetPassword(user.Password)
-			user.Password = ""
-			if err := db.UpdateUser(&user); err != nil {
-				utils.Log.Fatalf("[hash pwd for old version] failed update user: %v", err)
-			}
-		}
-	}
-}
-
-func updateAuthnForOldVersion() {
-	users, _, err := op.GetUsers(1, -1)
-	if err != nil {
-		utils.Log.Fatalf("[update authn for old version] failed get users: %v", err)
-	}
-	for i := range users {
-		user := users[i]
-		if user.Authn == "" {
-			user.Authn = "[]"
-			if err := db.UpdateUser(&user); err != nil {
-				utils.Log.Fatalf("[update authn for old version] failed update user: %v", err)
-			}
-		}
-	}
 }

--- a/internal/bootstrap/patch.go
+++ b/internal/bootstrap/patch.go
@@ -1,0 +1,74 @@
+package bootstrap
+
+import (
+	"fmt"
+	"github.com/alist-org/alist/v3/cmd/flags"
+	"github.com/alist-org/alist/v3/internal/bootstrap/patch"
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"path/filepath"
+)
+
+func safeCall(v string, i int, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			utils.Log.Errorf("Recovered from patch (version: %s, index: %d) panic: %v", v, i, r)
+		}
+	}()
+
+	f()
+}
+
+func getVersion(v string) (major, minor, patchNum int, err error) {
+	_, err = fmt.Sscanf(v, "v%d.%d.%d", &major, &minor, &patchNum)
+	return major, minor, patchNum, err
+}
+
+func compareVersion(majorA, minorA, patchNumA, majorB, minorB, patchNumB int) bool {
+	if majorA != majorB {
+		return majorA > majorB
+	}
+	if minorA != minorB {
+		return minorA > minorB
+	}
+	if patchNumA != patchNumB {
+		return patchNumA > patchNumB
+	}
+	return true
+}
+
+func InitUpgradePatch() {
+	if conf.Version == "dev" {
+		return
+	}
+	lastLaunchedVersion := conf.Conf.LastLaunchedVersion
+	if lastLaunchedVersion == "" {
+		lastLaunchedVersion = "v3.41.0"
+	}
+	if lastLaunchedVersion == conf.Version {
+		return
+	}
+	major, minor, patchNum, err := getVersion(lastLaunchedVersion)
+	if err != nil {
+		utils.Log.Errorf("Failed to get last launched version: %v", err)
+		return
+	}
+	for _, vp := range patch.UpgradePatches {
+		ma, mi, pn, err := getVersion(vp.Version)
+		if err != nil {
+			utils.Log.Errorf("Skip invalid version %s patches: %v", vp.Version, err)
+			continue
+		}
+		if compareVersion(ma, mi, pn, major, minor, patchNum) {
+			for i, p := range vp.Patches {
+				safeCall(vp.Version, i, p)
+			}
+		}
+	}
+	conf.Conf.LastLaunchedVersion = conf.Version
+	configPath := filepath.Join(flags.DataDir, "config.json")
+	if !utils.WriteJsonToFile(configPath, conf.Conf) {
+		log.Fatalf("failed to create default config file")
+	}
+}

--- a/internal/bootstrap/patch.go
+++ b/internal/bootstrap/patch.go
@@ -50,21 +50,21 @@ func InitUpgradePatch() {
 		return
 	}
 	major, minor, patchNum, err := getVersion(lastLaunchedVersion)
-	if err != nil {
-		utils.Log.Errorf("Failed to get last launched version: %v", err)
-		return
-	}
-	for _, vp := range patch.UpgradePatches {
-		ma, mi, pn, err := getVersion(vp.Version)
-		if err != nil {
-			utils.Log.Errorf("Skip invalid version %s patches: %v", vp.Version, err)
-			continue
-		}
-		if compareVersion(ma, mi, pn, major, minor, patchNum) {
-			for i, p := range vp.Patches {
-				safeCall(vp.Version, i, p)
+	if err == nil {
+		for _, vp := range patch.UpgradePatches {
+			ma, mi, pn, err := getVersion(vp.Version)
+			if err != nil {
+				utils.Log.Errorf("Skip invalid version %s patches: %v", vp.Version, err)
+				continue
+			}
+			if compareVersion(ma, mi, pn, major, minor, patchNum) {
+				for i, p := range vp.Patches {
+					safeCall(vp.Version, i, p)
+				}
 			}
 		}
+	} else {
+		utils.Log.Warnf("Failed to parse last launched version %s: %v, skipping all patches and rewrite last launched version", lastLaunchedVersion, err)
 	}
 	conf.Conf.LastLaunchedVersion = conf.Version
 	configPath := filepath.Join(flags.DataDir, "config.json")

--- a/internal/bootstrap/patch/all.go
+++ b/internal/bootstrap/patch/all.go
@@ -1,13 +1,31 @@
 package patch
 
-import "github.com/alist-org/alist/v3/internal/bootstrap/patch/v3_41_0"
+import (
+	"github.com/alist-org/alist/v3/internal/bootstrap/patch/v3_24_0"
+	"github.com/alist-org/alist/v3/internal/bootstrap/patch/v3_32_0"
+	"github.com/alist-org/alist/v3/internal/bootstrap/patch/v3_41_0"
+)
 
 type VersionPatches struct {
+	// Version means if the system is upgraded from Version or an earlier one
+	// to the current version, all patches in Patches will be executed.
 	Version string
 	Patches []func()
 }
 
 var UpgradePatches = []VersionPatches{
+	{
+		Version: "v3.24.0",
+		Patches: []func(){
+			v3_24_0.HashPwdForOldVersion,
+		},
+	},
+	{
+		Version: "v3.32.0",
+		Patches: []func(){
+			v3_32_0.UpdateAuthnForOldVersion,
+		},
+	},
 	{
 		Version: "v3.41.0",
 		Patches: []func(){

--- a/internal/bootstrap/patch/all.go
+++ b/internal/bootstrap/patch/all.go
@@ -1,0 +1,17 @@
+package patch
+
+import "github.com/alist-org/alist/v3/internal/bootstrap/patch/v3_41_0"
+
+type VersionPatches struct {
+	Version string
+	Patches []func()
+}
+
+var UpgradePatches = []VersionPatches{
+	{
+		Version: "v3.41.0",
+		Patches: []func(){
+			v3_41_0.GrantAdminPermissions,
+		},
+	},
+}

--- a/internal/bootstrap/patch/v3_24_0/hash_password.go
+++ b/internal/bootstrap/patch/v3_24_0/hash_password.go
@@ -1,0 +1,26 @@
+package v3_24_0
+
+import (
+	"github.com/alist-org/alist/v3/internal/db"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/pkg/utils"
+)
+
+// HashPwdForOldVersion encode passwords using SHA256
+// First published: 75acbcc perf: sha256 for user's password (close #3552) by Andy Hsu
+func HashPwdForOldVersion() {
+	users, _, err := op.GetUsers(1, -1)
+	if err != nil {
+		utils.Log.Fatalf("[hash pwd for old version] failed get users: %v", err)
+	}
+	for i := range users {
+		user := users[i]
+		if user.PwdHash == "" {
+			user.SetPassword(user.Password)
+			user.Password = ""
+			if err := db.UpdateUser(&user); err != nil {
+				utils.Log.Fatalf("[hash pwd for old version] failed update user: %v", err)
+			}
+		}
+	}
+}

--- a/internal/bootstrap/patch/v3_32_0/update_authn.go
+++ b/internal/bootstrap/patch/v3_32_0/update_authn.go
@@ -1,0 +1,25 @@
+package v3_32_0
+
+import (
+	"github.com/alist-org/alist/v3/internal/db"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/pkg/utils"
+)
+
+// UpdateAuthnForOldVersion updates users' authn
+// First published: bdfc159 fix: webauthn logspam (#6181) by itsHenry
+func UpdateAuthnForOldVersion() {
+	users, _, err := op.GetUsers(1, -1)
+	if err != nil {
+		utils.Log.Fatalf("[update authn for old version] failed get users: %v", err)
+	}
+	for i := range users {
+		user := users[i]
+		if user.Authn == "" {
+			user.Authn = "[]"
+			if err := db.UpdateUser(&user); err != nil {
+				utils.Log.Fatalf("[update authn for old version] failed update user: %v", err)
+			}
+		}
+	}
+}

--- a/internal/bootstrap/patch/v3_41_0/grant_permission.go
+++ b/internal/bootstrap/patch/v3_41_0/grant_permission.go
@@ -1,0 +1,20 @@
+package v3_41_0
+
+import (
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/pkg/utils"
+)
+
+func GrantAdminPermissions() {
+	admin, err := op.GetAdmin()
+	if err != nil {
+		utils.Log.Errorf("Cannot grant permissions to admin: %v", err)
+	}
+	if (admin.Permission & 0x3FF) == 0 {
+		admin.Permission |= 0x3FF
+	}
+	err = op.UpdateUser(admin)
+	if err != nil {
+		utils.Log.Errorf("Cannot grant permissions to admin: %v", err)
+	}
+}

--- a/internal/bootstrap/patch/v3_41_0/grant_permission.go
+++ b/internal/bootstrap/patch/v3_41_0/grant_permission.go
@@ -5,6 +5,8 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
+// GrantAdminPermissions gives admin Permission 0(can see hidden) - 9(webdav manage)
+// This patch is written to help users upgrading from older version better adapt to PR AlistGo/alist#7705.
 func GrantAdminPermissions() {
 	admin, err := op.GetAdmin()
 	if err != nil {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -110,6 +110,7 @@ type Config struct {
 	S3                    S3          `json:"s3" envPrefix:"S3_"`
 	FTP                   FTP         `json:"ftp" envPrefix:"FTP_"`
 	SFTP                  SFTP        `json:"sftp" envPrefix:"SFTP_"`
+	LastLaunchedVersion   string      `json:"last_launched_version"`
 }
 
 func DefaultConfig() *Config {
@@ -195,5 +196,6 @@ func DefaultConfig() *Config {
 			Enable: false,
 			Listen: ":5222",
 		},
+		LastLaunchedVersion: "",
 	}
 }


### PR DESCRIPTION
Add upgrade patch module, which allows for the execution of a function during the first startup after a user upgrades from an older version.
Add a patch from v3.41.0: if admin does not have Permission 0(can see hidden) - 9(webdav manage), grant them. This patch is written to help users upgrading from older version better adapt to PR #7705.