### PR TITLE
fix: static page to limit request method

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -102,6 +102,10 @@ func Static(r *gin.RouterGroup, noRoute func(handlers ...gin.HandlerFunc)) {
 	}
 
 	noRoute(func(c *gin.Context) {
+		if c.Request.Method != "GET" && c.Request.Method != "POST" {
+			c.Status(405)
+			return
+		}
 		c.Header("Content-Type", "text/html")
 		c.Status(200)
 		if strings.HasPrefix(c.Request.URL.Path, "/@manage") {


### PR DESCRIPTION
* fix #7667
* fix #6306

由于alist处理错误请求都返回200状态码，而tampermonkey会发起非webdav标准的```SUBSCRIBE```请求方法，就会导致tampermonkey一直发起请求
tampermonkey发起```SUBSCRIBE```请求方法是要监听```请求的目录```并返回```变动的文件```来实现多端实时同步，我水平不行实现不了，但基础的同步功能是可以正常工作的