### PR TITLE
feat(docker release): improve aria2 image, add aio image

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -60,13 +60,15 @@ jobs:
             build_arg: ""
             tag_favor: ""
           - image: "ffmpeg"
-            build_arg: "INSTALL_FFMPEG=true"
+            build_arg: INSTALL_FFMPEG=true
             tag_favor: "suffix=-ffmpeg,onlatest=true"
           - image: "aria2"
-            build_arg: "INSTALL_ARIA2=true"
+            build_arg: INSTALL_ARIA2=true
             tag_favor: "suffix=-aria2,onlatest=true"
           - image: "aio"
-            build_arg: "INSTALL_FFMPEG=true,INSTALL_ARIA2=true"
+            build_arg: |
+              INSTALL_FFMPEG=true
+              INSTALL_ARIA2=true
             tag_favor: "suffix=-aio,onlatest=true"
     steps:
       - name: Checkout

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -5,9 +5,16 @@ on:
     tags:
       - 'v*'
 
+env:
+  IMAGE_REGISTRY: 'xhofe/alist'
+  REGISTRY_USERNAME: 'xhofe'
+  REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  ARTIFACT_NAME: 'binaries_docker_release'
+  RELEASE_PLATFORMS: 'linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64'
+
 jobs:
-  release_docker:
-    name: Release Docker
+  build_binary:
+    name: Build Binaries for Docker Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,11 +38,42 @@ jobs:
       - name: Build go binary
         run: bash build.sh release docker-multiplatform
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          images: xhofe/alist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            build/
+            !build/*.tgz
+            !build/musl-libs/**
+
+  release_docker:
+    needs: build_binary
+    name: Release Docker image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["latest", "ffmpeg", "aria2", "aio"]
+        include:
+          - image: "latest"
+            build_arg: ""
+            tag_favor: ""
+          - image: "ffmpeg"
+            build_arg: "INSTALL_FFMPEG=true"
+            tag_favor: "suffix=-ffmpeg,onlatest=true"
+          - image: "aria2"
+            build_arg: "INSTALL_ARIA2=true"
+            tag_favor: "suffix=-aria2,onlatest=true"
+          - image: "aio"
+            build_arg: "INSTALL_FFMPEG=true,INSTALL_ARIA2=true"
+            tag_favor: "suffix=-aio,onlatest=true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: 'build/'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,8 +84,17 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: xhofe
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}
+          flavor: |
+            latest=true
+            ${{ matrix.tag_favor }}
 
       - name: Build and push
         id: docker_build
@@ -56,53 +103,7 @@ jobs:
           context: .
           file: Dockerfile.ci
           push: true
+          build-args: ${{ matrix.build_arg }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
-
-      - name: Docker meta with ffmpeg
-        id: meta-ffmpeg
-        uses: docker/metadata-action@v5
-        with:
-          images: xhofe/alist
-          flavor: |
-            latest=true
-            suffix=-ffmpeg,onlatest=true
-            
-      - name: Build and push with ffmpeg
-        id: docker_build_ffmpeg
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.ci
-          push: true
-          tags: ${{ steps.meta-ffmpeg.outputs.tags }}
-          labels: ${{ steps.meta-ffmpeg.outputs.labels }}
-          build-args: INSTALL_FFMPEG=true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
-
-  release_docker_with_aria2:
-    needs: release_docker
-    name: Release docker with aria2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          repository: alist-org/with_aria2
-          ref: main
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Add tag
-        run: |
-          git config --local user.email "bot@nn.ci"
-          git config --local user.name "IlaBot"
-          git tag -a ${{ github.ref_name }} -m "release ${{ github.ref_name }}"
-
-      - name: Push tags
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.MY_TOKEN }}
-          branch: main
-          repository: alist-org/with_aria2
+          platforms: ${{ env.RELEASE_PLATFORMS }}

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
+          overwrite: true
           path: |
             build/
             !build/*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apk update && \
 
 COPY --from=builder /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && /entrypoint.sh version
+RUN chmod +x /opt/alist/alist && \
+    chmod +x /entrypoint.sh && /entrypoint.sh version
 
 ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk update && \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
         mkdir -p /opt/aria2/.aria2 && \
         wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
-        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 --strip-components=1 && rm -f /tmp/aria-conf.tar.gz && \
         sed -i 's|rpc-secret|#rpc-secret|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,16 @@ RUN apk update && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
-        mkdir -p /root/.aria2 && \
+        mkdir -p /opt/aria2/.aria2 && \
         wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
-        tar -zxvf /tmp/aria-conf.tar.gz -C /root/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
-        sed -i 's|rpc-secret|#rpc-secret|g' /root/.aria2/aria2.conf && \
-        touch /root/.aria2/aria2.session && \
-        /root/.aria2/tracker.sh ; \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        sed -i 's|rpc-secret|#rpc-secret|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \
+        sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/script.conf && \
+        touch /opt/aria2/.aria2/aria2.session && \
+        /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/bin/alist ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN bash build.sh release docker
 FROM alpine:edge
 
 ARG INSTALL_FFMPEG=false
+ARG INSTALL_ARIA2=false
 LABEL MAINTAINER="i@nn.ci"
 
 WORKDIR /opt/alist/
@@ -18,13 +19,20 @@ RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
+    [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
+        mkdir -p /root/.aria2 && \
+        wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /root/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        sed -i 's|rpc-secret|#rpc-secret|g' /root/.aria2/aria2.conf && \
+        touch /root/.aria2/aria2.session && \
+        /root/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && /entrypoint.sh version
 
-ENV PUID=0 PGID=0 UMASK=022
+ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -12,12 +12,16 @@ RUN apk update && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
-        mkdir -p /root/.aria2 && \
+        mkdir -p /opt/aria2/.aria2 && \
         wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
-        tar -zxvf /tmp/aria-conf.tar.gz -C /root/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
-        sed -i 's|rpc-secret|#rpc-secret|g' /root/.aria2/aria2.conf && \
-        touch /root/.aria2/aria2.session && \
-        /root/.aria2/tracker.sh ; \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        sed -i 's|rpc-secret|#rpc-secret|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \
+        sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/aria2.conf && \
+        sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/script.conf && \
+        touch /opt/aria2/.aria2/aria2.session && \
+        /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
 COPY /build/${TARGETPLATFORM}/alist ./

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,7 +14,7 @@ RUN apk update && \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
         mkdir -p /opt/aria2/.aria2 && \
         wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
-        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /opt/aria2/.aria2 --strip-components=1 && rm -f /tmp/aria-conf.tar.gz && \
         sed -i 's|rpc-secret|#rpc-secret|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,6 +2,7 @@ FROM alpine:edge
 
 ARG TARGETPLATFORM
 ARG INSTALL_FFMPEG=false
+ARG INSTALL_ARIA2=false
 LABEL MAINTAINER="i@nn.ci"
 
 WORKDIR /opt/alist/
@@ -10,13 +11,20 @@ RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
+    [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
+        mkdir -p /root/.aria2 && \
+        wget https://github.com/P3TERX/aria2.conf/archive/refs/heads/master.tar.gz -O /tmp/aria-conf.tar.gz && \
+        tar -zxvf /tmp/aria-conf.tar.gz -C /root/.aria2 && rm -f /tmp/aria-conf.tar.gz && \
+        sed -i 's|rpc-secret|#rpc-secret|g' /root/.aria2/aria2.conf && \
+        touch /root/.aria2/aria2.session && \
+        /root/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
 COPY /build/${TARGETPLATFORM}/alist ./
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && /entrypoint.sh version
 
-ENV PUID=0 PGID=0 UMASK=022
+ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -22,7 +22,8 @@ RUN apk update && \
 
 COPY /build/${TARGETPLATFORM}/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && /entrypoint.sh version
+RUN chmod +x /opt/alist/alist && \
+    chmod +x /entrypoint.sh && /entrypoint.sh version
 
 ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,15 @@ umask ${UMASK}
 if [ "$1" = "version" ]; then
   ./alist version
 else
-  chown -R ${PUID}:${PGID} /opt/alist/
-  
   if [ "$RUN_ARIA2" = "true" ]; then
+    chown -R ${PUID}:${PGID} /opt/aria2/
     exec su-exec ${PUID}:${PGID} nohup aria2c \
       --enable-rpc \
       --rpc-allow-origin-all \
-      --conf-path=/root/.aria2/aria2.conf \
+      --conf-path=/opt/aria2/.aria2/aria2.conf \
       >/dev/null 2>&1 &
   fi
 
+  chown -R ${PUID}:${PGID} /opt/alist/
   exec su-exec ${PUID}:${PGID} ./alist server --no-prefix
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-chown -R ${PUID}:${PGID} /opt/alist/
-
 umask ${UMASK}
-
-if [ "$RUN_ARIA2" = "true" ]; then
-  exec su-exec ${PUID}:${PGID} nohup aria2c \
-    --enable-rpc \
-    --rpc-allow-origin-all \
-    --conf-path=/root/.aria2/aria2.conf \
-    >/dev/null 2>&1 &
-fi
 
 if [ "$1" = "version" ]; then
   ./alist version
 else
+  chown -R ${PUID}:${PGID} /opt/alist/
+  
+  if [ "$RUN_ARIA2" = "true" ]; then
+    exec su-exec ${PUID}:${PGID} nohup aria2c \
+      --enable-rpc \
+      --rpc-allow-origin-all \
+      --conf-path=/root/.aria2/aria2.conf \
+      >/dev/null 2>&1 &
+  fi
+
   exec su-exec ${PUID}:${PGID} ./alist server --no-prefix
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,14 @@ chown -R ${PUID}:${PGID} /opt/alist/
 
 umask ${UMASK}
 
+if [ "$RUN_ARIA2" = "true" ]; then
+  exec su-exec ${PUID}:${PGID} nohup aria2c \
+    --enable-rpc \
+    --rpc-allow-origin-all \
+    --conf-path=/root/.aria2/aria2.conf \
+    >/dev/null 2>&1 &
+fi
+
 if [ "$1" = "version" ]; then
   ./alist version
 else


### PR DESCRIPTION
This PR migrates https://github.com/AlistGo/with_aria2 into this repo with single Dockerfile. Now we can build an image with aria2 easily by adding docker build-arg `INSTALL_ARIA2=true`.

## What's new

### CI/CD

Since four image versions need to be built in a single workflow, CI is now using the GitHub Actions Matrix to build four versions of Docker images simultaneously. Binaries only need to be built once and passed to other jobs through artifacts.

And moreover, all important variables have been moved to the top of the workflow definition file. This makes it easier for forks to change configs.

Tested with action run: https://github.com/Mmx233/alist/actions/runs/12545883543

### Docker images

Besides the original image with aria2, a new image named `aio` that includes both ffmpeg and aria2 has been added.

New images will be  added: `xhofe/alist:latest-aio` `xhofe/alist:latest-aria2` and so on.

Test images: `mmx233/alist:v3.41.0-alpha6` `mmx233/alist:v3.41.0-alpha6-ffmpeg` `mmx233/alist:v3.41.0-alpha6-aria2` `mmx233/alist:v3.41.0-alpha6-aio`

Tested with the aio image.

### Changes in docker image with aria2

Workdir of aria2 is changed from `/root` to `/opt/aria2`. Config files is now in `/opt/aria2/.aria2`. This change is merged from https://github.com/AlistGo/with_aria2/pull/13 in b532a7b58708159efb3b6388cd0b94828c6c9f08. And the issue of aria2 not able to run when PUID PGID is not 0 is also fixed with new logics in `entrypoint.sh`.

Whether to run aria2 in container with the `aio` or `aria2` version image is determined by the `RUN_ARIA2` environment variable. The default value is set to `true` when the `INSTALL_ARIA2` build-arg is set.