### PR TITLE
fix(ilanzou): directory loading failure issue

### DIFF
--- a/drivers/ilanzou/util.go
+++ b/drivers/ilanzou/util.go
@@ -69,9 +69,10 @@ func (d *ILanZou) request(pathname, method string, callback base.ReqCallback, pr
 
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
-		"Origin":     d.conf.site,
-		"Referer":    d.conf.site + "/",
-		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
+		"Origin":          d.conf.site,
+		"Referer":         d.conf.site + "/",
+		"User-Agent":      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
+		"Accept-Encoding": "gzip, deflate, br, zstd",
 	})
 
 	if callback != nil {


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7759 ：蓝奏优享和飞机盘无法加载出目录

### 问题原因
1. 在调用`/app/record/file/list`接口时，返回的`list`为空
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/b2e3e9a6-10ff-4d66-8dfb-6c366bedc27b" />


### 修复方案
1. 通过抓包模拟，对比`alist`与蓝奏优享网页的请求，发现只有请求头部是有区别的，通过排除法，确定加上`Accept-Encoding`请求头部即可解决。

### 自测
<img width="1572" alt="image" src="https://github.com/user-attachments/assets/b3bca050-8769-4809-9d2a-f3459a3e4627" />

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/061d8be0-c61d-4c95-a7ae-93a18bcf9a42" />

