### PR TITLE
feat: add `Reference` interface to driver

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -6,12 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -41,12 +42,12 @@ func (d *Pan123) GetAddition() driver.Additional {
 }
 
 func (d *Pan123) Init(ctx context.Context) error {
-	_, err := d.request(UserInfo, http.MethodGet, nil, nil)
+	_, err := d.Request(UserInfo, http.MethodGet, nil, nil)
 	return err
 }
 
 func (d *Pan123) Drop(ctx context.Context) error {
-	_, _ = d.request(Logout, http.MethodPost, func(req *resty.Request) {
+	_, _ = d.Request(Logout, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{})
 	}, nil)
 	return nil
@@ -81,8 +82,8 @@ func (d *Pan123) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 			"size":      f.Size,
 			"type":      f.Type,
 		}
-		resp, err := d.request(DownloadInfo, http.MethodPost, func(req *resty.Request) {
-			
+		resp, err := d.Request(DownloadInfo, http.MethodPost, func(req *resty.Request) {
+
 			req.SetBody(data).SetHeaders(headers)
 		}, nil)
 		if err != nil {
@@ -135,7 +136,7 @@ func (d *Pan123) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 		"size":         0,
 		"type":         1,
 	}
-	_, err := d.request(Mkdir, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(Mkdir, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
 	return err
@@ -146,7 +147,7 @@ func (d *Pan123) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
 		"fileIdList":   []base.Json{{"FileId": srcObj.GetID()}},
 		"parentFileId": dstDir.GetID(),
 	}
-	_, err := d.request(Move, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(Move, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
 	return err
@@ -158,7 +159,7 @@ func (d *Pan123) Rename(ctx context.Context, srcObj model.Obj, newName string) e
 		"fileId":   srcObj.GetID(),
 		"fileName": newName,
 	}
-	_, err := d.request(Rename, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(Rename, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
 	return err
@@ -175,7 +176,7 @@ func (d *Pan123) Remove(ctx context.Context, obj model.Obj) error {
 			"operation":         true,
 			"fileTrashInfoList": []File{f},
 		}
-		_, err := d.request(Trash, http.MethodPost, func(req *resty.Request) {
+		_, err := d.Request(Trash, http.MethodPost, func(req *resty.Request) {
 			req.SetBody(data)
 		}, nil)
 		return err
@@ -213,7 +214,7 @@ func (d *Pan123) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		"type":         0,
 	}
 	var resp UploadResp
-	res, err := d.request(UploadRequest, http.MethodPost, func(req *resty.Request) {
+	res, err := d.Request(UploadRequest, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data).SetContext(ctx)
 	}, &resp)
 	if err != nil {
@@ -248,7 +249,7 @@ func (d *Pan123) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		}
 		_, err = uploader.UploadWithContext(ctx, input)
 	}
-	_, err = d.request(UploadComplete, http.MethodPost, func(req *resty.Request) {
+	_, err = d.Request(UploadComplete, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"fileId": resp.Data.FileId,
 		}).SetContext(ctx)

--- a/drivers/123/upload.go
+++ b/drivers/123/upload.go
@@ -25,7 +25,7 @@ func (d *Pan123) getS3PreSignedUrls(ctx context.Context, upReq *UploadResp, star
 		"StorageNode":     upReq.Data.StorageNode,
 	}
 	var s3PreSignedUrls S3PreSignedURLs
-	_, err := d.request(S3PreSignedUrls, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(S3PreSignedUrls, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data).SetContext(ctx)
 	}, &s3PreSignedUrls)
 	if err != nil {
@@ -44,7 +44,7 @@ func (d *Pan123) getS3Auth(ctx context.Context, upReq *UploadResp, start, end in
 		"uploadId":        upReq.Data.UploadId,
 	}
 	var s3PreSignedUrls S3PreSignedURLs
-	_, err := d.request(S3Auth, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(S3Auth, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data).SetContext(ctx)
 	}, &s3PreSignedUrls)
 	if err != nil {
@@ -63,7 +63,7 @@ func (d *Pan123) completeS3(ctx context.Context, upReq *UploadResp, file model.F
 		"key":         upReq.Data.Key,
 		"uploadId":    upReq.Data.UploadId,
 	}
-	_, err := d.request(UploadCompleteV2, http.MethodPost, func(req *resty.Request) {
+	_, err := d.Request(UploadCompleteV2, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data).SetContext(ctx)
 	}, nil)
 	return err

--- a/drivers/123/util.go
+++ b/drivers/123/util.go
@@ -194,7 +194,9 @@ func (d *Pan123) login() error {
 //	return &authKey, nil
 //}
 
-func (d *Pan123) request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+func (d *Pan123) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	isRetry := false
+do:
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
 		"origin":        "https://www.123pan.com",
@@ -223,12 +225,13 @@ func (d *Pan123) request(url string, method string, callback base.ReqCallback, r
 	body := res.Body()
 	code := utils.Json.Get(body, "code").ToInt()
 	if code != 0 {
-		if code == 401 {
+		if !isRetry && code == 401 {
 			err := d.login()
 			if err != nil {
 				return nil, err
 			}
-			return d.request(url, method, callback, resp)
+			isRetry = true
+			goto do
 		}
 		return nil, errors.New(jsoniter.Get(body, "message").ToString())
 	}
@@ -260,7 +263,7 @@ func (d *Pan123) getFiles(ctx context.Context, parentId string, name string) ([]
 			"operateType":          "4",
 			"inDirectSpace":        "false",
 		}
-		_res, err := d.request(FileList, http.MethodGet, func(req *resty.Request) {
+		_res, err := d.Request(FileList, http.MethodGet, func(req *resty.Request) {
 			req.SetQueryParams(query)
 		}, &resp)
 		if err != nil {

--- a/drivers/123_share/driver.go
+++ b/drivers/123_share/driver.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"golang.org/x/time/rate"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
+	"golang.org/x/time/rate"
+
+	_123 "github.com/alist-org/alist/v3/drivers/123"
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
@@ -23,6 +25,7 @@ type Pan123Share struct {
 	model.Storage
 	Addition
 	apiRateLimit sync.Map
+	ref          *_123.Pan123
 }
 
 func (d *Pan123Share) Config() driver.Config {
@@ -39,7 +42,17 @@ func (d *Pan123Share) Init(ctx context.Context) error {
 	return nil
 }
 
+func (d *Pan123Share) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*_123.Pan123)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return fmt.Errorf("ref: storage is not 123Pan")
+}
+
 func (d *Pan123Share) Drop(ctx context.Context) error {
+	d.ref = nil
 	return nil
 }
 

--- a/drivers/123_share/util.go
+++ b/drivers/123_share/util.go
@@ -53,6 +53,9 @@ func GetApi(rawUrl string) string {
 }
 
 func (d *Pan123Share) request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	if d.ref != nil {
+		return d.ref.Request(url, method, callback, resp)
+	}
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
 		"origin":        "https://www.123pan.com",

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -54,6 +54,9 @@ func getTime(t string) time.Time {
 }
 
 func (d *Yun139) refreshToken() error {
+	if d.ref == nil {
+		return d.ref.refreshToken()
+	}
 	url := "https://aas.caiyun.feixin.10086.cn:443/tellin/authTokenRefresh.do"
 	var resp RefreshTokenResp
 	decode, err := base64.StdEncoding.DecodeString(d.Authorization)
@@ -99,7 +102,7 @@ func (d *Yun139) request(pathname string, method string, callback base.ReqCallba
 	req.SetHeaders(map[string]string{
 		"Accept":         "application/json, text/plain, */*",
 		"CMS-DEVICE":     "default",
-		"Authorization":  "Basic " + d.Authorization,
+		"Authorization":  "Basic " + d.getAuthorization(),
 		"mcloud-channel": "1000101",
 		"mcloud-client":  "10701",
 		//"mcloud-route": "001",
@@ -151,7 +154,7 @@ func (d *Yun139) getFiles(catalogID string) ([]model.Obj, error) {
 			"catalogSortType": 0,
 			"contentSortType": 0,
 			"commonAccountInfo": base.Json{
-				"account":     d.Account,
+				"account":     d.getAccount(),
 				"accountType": 1,
 			},
 		}
@@ -199,7 +202,7 @@ func (d *Yun139) newJson(data map[string]interface{}) base.Json {
 		"cloudID":     d.CloudID,
 		"cloudType":   1,
 		"commonAccountInfo": base.Json{
-			"account":     d.Account,
+			"account":     d.getAccount(),
 			"accountType": 1,
 		},
 	}
@@ -320,7 +323,7 @@ func (d *Yun139) getLink(contentId string) (string, error) {
 		"appName":   "",
 		"contentID": contentId,
 		"commonAccountInfo": base.Json{
-			"account":     d.Account,
+			"account":     d.getAccount(),
 			"accountType": 1,
 		},
 	}
@@ -383,7 +386,7 @@ func (d *Yun139) personalRequest(pathname string, method string, callback base.R
 	}
 	req.SetHeaders(map[string]string{
 		"Accept":               "application/json, text/plain, */*",
-		"Authorization":        "Basic " + d.Authorization,
+		"Authorization":        "Basic " + d.getAuthorization(),
 		"Caller":               "web",
 		"Cms-Device":           "default",
 		"Mcloud-Channel":       "1000101",
@@ -513,4 +516,17 @@ func (d *Yun139) personalGetLink(fileId string) (string, error) {
 	} else {
 		return jsoniter.Get(res, "data", "url").ToString(), nil
 	}
+}
+
+func (d *Yun139) getAuthorization() string {
+	if d.ref != nil {
+		return d.ref.getAuthorization()
+	}
+	return d.Authorization
+}
+func (d *Yun139) getAccount() string {
+	if d.ref != nil {
+		return d.ref.getAccount()
+	}
+	return d.Account
 }

--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -19,12 +19,12 @@ import (
 type AliyundriveOpen struct {
 	model.Storage
 	Addition
-	base string
 
 	DriveId string
 
 	limitList func(ctx context.Context, data base.Json) (*Files, error)
 	limitLink func(ctx context.Context, file model.Obj) (*model.Link, error)
+	ref       *AliyundriveOpen
 }
 
 func (d *AliyundriveOpen) Config() driver.Config {
@@ -58,7 +58,17 @@ func (d *AliyundriveOpen) Init(ctx context.Context) error {
 	return nil
 }
 
+func (d *AliyundriveOpen) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*AliyundriveOpen)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return errs.NotSupport
+}
+
 func (d *AliyundriveOpen) Drop(ctx context.Context) error {
+	d.ref = nil
 	return nil
 }
 

--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -32,11 +32,10 @@ var config = driver.Config{
 	DefaultRoot:       "root",
 	NoOverwriteUpload: true,
 }
+var API_URL = "https://openapi.alipan.com"
 
 func init() {
 	op.RegisterDriver(func() driver.Driver {
-		return &AliyundriveOpen{
-			base: "https://openapi.alipan.com",
-		}
+		return &AliyundriveOpen{}
 	})
 }

--- a/drivers/aliyundrive_open/upload.go
+++ b/drivers/aliyundrive_open/upload.go
@@ -126,7 +126,7 @@ func getProofRange(input string, size int64) (*ProofRange, error) {
 }
 
 func (d *AliyundriveOpen) calProofCode(stream model.FileStreamer) (string, error) {
-	proofRange, err := getProofRange(d.AccessToken, stream.GetSize())
+	proofRange, err := getProofRange(d.getAccessToken(), stream.GetSize())
 	if err != nil {
 		return "", err
 	}

--- a/drivers/aliyundrive_open/util.go
+++ b/drivers/aliyundrive_open/util.go
@@ -19,7 +19,7 @@ import (
 // do others that not defined in Driver interface
 
 func (d *AliyundriveOpen) _refreshToken() (string, string, error) {
-	url := d.base + "/oauth/access_token"
+	url := API_URL + "/oauth/access_token"
 	if d.OauthTokenURL != "" && d.ClientID == "" {
 		url = d.OauthTokenURL
 	}
@@ -74,6 +74,9 @@ func getSub(token string) (string, error) {
 }
 
 func (d *AliyundriveOpen) refreshToken() error {
+	if d.ref != nil {
+		return d.ref.refreshToken()
+	}
 	refresh, access, err := d._refreshToken()
 	for i := 0; i < 3; i++ {
 		if err == nil {
@@ -100,7 +103,7 @@ func (d *AliyundriveOpen) request(uri, method string, callback base.ReqCallback,
 func (d *AliyundriveOpen) requestReturnErrResp(uri, method string, callback base.ReqCallback, retry ...bool) ([]byte, error, *ErrResp) {
 	req := base.RestyClient.R()
 	// TODO check whether access_token is expired
-	req.SetHeader("Authorization", "Bearer "+d.AccessToken)
+	req.SetHeader("Authorization", "Bearer "+d.getAccessToken())
 	if method == http.MethodPost {
 		req.SetHeader("Content-Type", "application/json")
 	}
@@ -109,7 +112,7 @@ func (d *AliyundriveOpen) requestReturnErrResp(uri, method string, callback base
 	}
 	var e ErrResp
 	req.SetError(&e)
-	res, err := req.Execute(method, d.base+uri)
+	res, err := req.Execute(method, API_URL+uri)
 	if err != nil {
 		if res != nil {
 			log.Errorf("[aliyundrive_open] request error: %s", res.String())
@@ -118,7 +121,7 @@ func (d *AliyundriveOpen) requestReturnErrResp(uri, method string, callback base
 	}
 	isRetry := len(retry) > 0 && retry[0]
 	if e.Code != "" {
-		if !isRetry && (utils.SliceContains([]string{"AccessTokenInvalid", "AccessTokenExpired", "I400JD"}, e.Code) || d.AccessToken == "") {
+		if !isRetry && (utils.SliceContains([]string{"AccessTokenInvalid", "AccessTokenExpired", "I400JD"}, e.Code) || d.getAccessToken() == "") {
 			err = d.refreshToken()
 			if err != nil {
 				return nil, err, nil
@@ -175,4 +178,11 @@ func getNowTime() (time.Time, string) {
 	nowTime := time.Now()
 	nowTimeStr := nowTime.Format("2006-01-02T15:04:05.000Z")
 	return nowTime, nowTimeStr
+}
+
+func (d *AliyundriveOpen) getAccessToken() string {
+	if d.ref != nil {
+		return d.ref.getAccessToken()
+	}
+	return d.AccessToken
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -144,3 +144,7 @@ func NewProgress(total int64, up UpdateProgress) *Progress {
 		up:    up,
 	}
 }
+
+type Reference interface {
+	InitReference(storage Driver) error
+}


### PR DESCRIPTION
支持从 `已挂载的存储` 中引用认证、令牌等。支持以下驱动
* 中国移动云盘
* 阿里云盘Open
* 天翼云盘客户端
* 123云盘分享（引用123云盘）
## 使用方法：在存储设置中将`备注(Remark)`的第一行设置为：ref:/挂载路径 
# 注意事项： `ref:/` 为小写英文和符号
## 列子：挂载 `中国移动云盘的家庭云` 引用 `已挂载的中国移动云盘`
* 使用场景：中国移动云盘一个`Authorization`挂载多个路径、云盘类型
![{66034150-6F3E-499E-9CAF-737A3C3F547C}](https://github.com/user-attachments/assets/53759bf9-2f27-4af0-ac68-bfdce0bf6cca)
![{5993456A-88DC-462A-B8ED-8325C7645040}](https://github.com/user-attachments/assets/6bf75449-ca09-493f-9427-91fae729eec2)
