### PR TITLE
feat(alias): add `DownloadConcurrency` and `DownloadPartSize` option

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -110,6 +110,16 @@ func (d *Alias) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 	for _, dst := range dsts {
 		link, err := d.link(ctx, dst, sub, args)
 		if err == nil {
+			if args.Proxy && len(link.URL) > 0 {
+				// 正常情况下 多并发 仅支持返回URL的驱动
+				// alias套娃alias 可以让crypt、mega等驱动(不返回URL的) 支持并发
+				if d.DownloadConcurrency > 0 {
+					link.Concurrency = d.DownloadConcurrency
+				}
+				if d.DownloadPartSize > 0 {
+					link.PartSize = d.DownloadPartSize * utils.KB
+				}
+			}
 			return link, nil
 		}
 	}

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -110,7 +110,7 @@ func (d *Alias) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 	for _, dst := range dsts {
 		link, err := d.link(ctx, dst, sub, args)
 		if err == nil {
-			if args.Proxy && len(link.URL) > 0 {
+			if !args.Redirect && len(link.URL) > 0 {
 				// 正常情况下 多并发 仅支持返回URL的驱动
 				// alias套娃alias 可以让crypt、mega等驱动(不返回URL的) 支持并发
 				if d.DownloadConcurrency > 0 {

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -9,8 +9,10 @@ type Addition struct {
 	// Usually one of two
 	// driver.RootPath
 	// define other
-	Paths           string `json:"paths" required:"true" type:"text"`
-	ProtectSameName bool   `json:"protect_same_name" default:"true" required:"false" help:"Protects same-name files from Delete or Rename"`
+	Paths               string `json:"paths" required:"true" type:"text"`
+	ProtectSameName     bool   `json:"protect_same_name" default:"true" required:"false" help:"Protects same-name files from Delete or Rename"`
+	DownloadConcurrency int    `json:"download_concurrency" default:"0" required:"false" type:"number" help:"Need to enable proxy"`
+	DownloadPartSize    int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 }
 
 var config = driver.Config{

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/internal/sign"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/alist-org/alist/v3/server/common"
@@ -94,9 +95,14 @@ func (d *Alias) list(ctx context.Context, dst, sub string, args *fs.ListArgs) ([
 
 func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) (*model.Link, error) {
 	reqPath := stdpath.Join(dst, sub)
-	storage, err := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
+	// 参考 crypt 驱动
+	storage, reqActualPath, err := op.GetStorageAndActualPath(reqPath)
 	if err != nil {
 		return nil, err
+	}
+	if _, ok := storage.(*Alias); !ok && args.Proxy {
+		link, _, err := op.Link(ctx, storage, reqActualPath, args)
+		return link, err
 	}
 	_, err = fs.Get(ctx, reqPath, &fs.GetArgs{NoLog: true})
 	if err != nil {
@@ -114,7 +120,7 @@ func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) 
 		}
 		return link, nil
 	}
-	link, _, err := fs.Link(ctx, reqPath, args)
+	link, _, err := op.Link(ctx, storage, reqActualPath, args)
 	return link, err
 }
 

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -100,7 +100,7 @@ func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) 
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := storage.(*Alias); !ok && args.Proxy {
+	if _, ok := storage.(*Alias); !ok && !args.Redirect {
 		link, _, err := op.Link(ctx, storage, reqActualPath, args)
 		return link, err
 	}

--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -275,7 +275,6 @@ func (d *Crypt) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 			rrc = converted
 		}
 		if rrc != nil {
-			//remoteRangeReader, err :=
 			remoteReader, err := rrc.RangeRead(ctx, http_range.Range{Start: underlyingOffset, Length: length})
 			remoteClosers.AddClosers(rrc.GetClosers())
 			if err != nil {
@@ -288,10 +287,8 @@ func (d *Crypt) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 			if err != nil {
 				return nil, err
 			}
-			//remoteClosers.Add(remoteLink.MFile)
-			//keep reuse same MFile and close at last.
-			remoteClosers.Add(remoteLink.MFile)
-			return io.NopCloser(remoteLink.MFile), nil
+			// 可以直接返回，读取完也不会调用Close，直到连接断开Close
+			return remoteLink.MFile, nil
 		}
 
 		return nil, errs.NotSupport

--- a/drivers/github/driver.go
+++ b/drivers/github/driver.go
@@ -5,6 +5,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	stdpath "path"
+	"strings"
+	"sync"
+	"text/template"
+
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
@@ -12,12 +19,6 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
-	"io"
-	"net/http"
-	stdpath "path"
-	"strings"
-	"sync"
-	"text/template"
 )
 
 type Github struct {
@@ -656,7 +657,7 @@ func (d *Github) putBlob(ctx context.Context, stream model.FileStreamer, up driv
 	contentReader, contentWriter := io.Pipe()
 	go func() {
 		encoder := base64.NewEncoder(base64.StdEncoding, contentWriter)
-		if _, err := io.Copy(encoder, stream); err != nil {
+		if _, err := utils.CopyWithBuffer(encoder, stream); err != nil {
 			_ = contentWriter.CloseWithError(err)
 			return
 		}

--- a/drivers/mega/driver.go
+++ b/drivers/mega/driver.go
@@ -84,7 +84,6 @@ func (d *Mega) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*
 		//}
 
 		size := file.GetSize()
-		var finalClosers utils.Closers
 		resultRangeReader := func(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
 			length := httpRange.Length
 			if httpRange.Length >= 0 && httpRange.Start+httpRange.Length >= size {
@@ -103,11 +102,10 @@ func (d *Mega) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*
 				d:    down,
 				skip: httpRange.Start,
 			}
-			finalClosers.Add(oo)
 
 			return readers.NewLimitedReadCloser(oo, length), nil
 		}
-		resultRangeReadCloser := &model.RangeReadCloser{RangeReader: resultRangeReader, Closers: finalClosers}
+		resultRangeReadCloser := &model.RangeReadCloser{RangeReader: resultRangeReader}
 		resultLink := &model.Link{
 			RangeReadCloser: resultRangeReadCloser,
 		}

--- a/drivers/netease_music/types.go
+++ b/drivers/netease_music/types.go
@@ -64,7 +64,6 @@ func (lrc *LyricObj) getLyricLink() *model.Link {
 				sr := io.NewSectionReader(reader, httpRange.Start, httpRange.Length)
 				return io.NopCloser(sr), nil
 			},
-			Closers: utils.EmptyClosers(),
 		},
 	}
 }

--- a/drivers/netease_music/upload.go
+++ b/drivers/netease_music/upload.go
@@ -47,7 +47,7 @@ func (u *uploader) init(stream model.FileStreamer) error {
 	}
 
 	h := md5.New()
-	io.Copy(h, stream)
+	utils.CopyWithBuffer(h, stream)
 	u.md5 = hex.EncodeToString(h.Sum(nil))
 	_, err := u.file.Seek(0, io.SeekStart)
 	if err != nil {

--- a/drivers/quqi/util.go
+++ b/drivers/quqi/util.go
@@ -300,9 +300,7 @@ func (d *Quqi) linkFromCDN(id string) (*model.Link, error) {
 		bufferReader := bufio.NewReader(decryptReader)
 		bufferReader.Discard(int(decryptedOffset))
 
-		return utils.NewReadCloser(bufferReader, func() error {
-			return nil
-		}), nil
+		return io.NopCloser(bufferReader), nil
 	}
 
 	return &model.Link{

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alist-org/alist/v3/cmd/flags"
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/net"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/caarlos0/env/v9"
 	log "github.com/sirupsen/logrus"
@@ -62,6 +63,9 @@ func InitConfig() {
 		if err != nil {
 			log.Fatalf("update config struct error: %+v", err)
 		}
+	}
+	if conf.Conf.MaxConcurrency > 0 {
+		net.DefaultConcurrencyLimit = &net.ConcurrencyLimit{Limit: conf.Conf.MaxConcurrency}
 	}
 	if !conf.Conf.Force {
 		confFromEnv()

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	Log                   LogConfig   `json:"log"`
 	DelayedStart          int         `json:"delayed_start" env:"DELAYED_START"`
 	MaxConnections        int         `json:"max_connections" env:"MAX_CONNECTIONS"`
+	MaxConcurrency        int         `json:"max_concurrency" env:"MAX_CONCURRENCY"`
 	TlsInsecureSkipVerify bool        `json:"tls_insecure_skip_verify" env:"TLS_INSECURE_SKIP_VERIFY"`
 	Tasks                 TasksConfig `json:"tasks" envPrefix:"TASKS_"`
 	Cors                  Cors        `json:"cors" envPrefix:"CORS_"`
@@ -151,6 +152,7 @@ func DefaultConfig() *Config {
 			MaxAge:     28,
 		},
 		MaxConnections:        0,
+		MaxConcurrency:        64,
 		TlsInsecureSkipVerify: true,
 		Tasks: TasksConfig{
 			Download: TaskConfig{

--- a/internal/model/args.go
+++ b/internal/model/args.go
@@ -21,6 +21,7 @@ type LinkArgs struct {
 	Header  http.Header
 	Type    string
 	HttpReq *http.Request
+	Proxy   bool
 }
 
 type Link struct {

--- a/internal/model/args.go
+++ b/internal/model/args.go
@@ -88,7 +88,7 @@ type RangeReadCloser struct {
 	utils.Closers
 }
 
-func (r RangeReadCloser) RangeRead(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
+func (r *RangeReadCloser) RangeRead(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
 	rc, err := r.RangeReader(ctx, httpRange)
 	r.Closers.Add(rc)
 	return rc, err

--- a/internal/model/args.go
+++ b/internal/model/args.go
@@ -17,11 +17,11 @@ type ListArgs struct {
 }
 
 type LinkArgs struct {
-	IP      string
-	Header  http.Header
-	Type    string
-	HttpReq *http.Request
-	Proxy   bool
+	IP       string
+	Header   http.Header
+	Type     string
+	HttpReq  *http.Request
+	Redirect bool
 }
 
 type Link struct {

--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -193,11 +193,12 @@ func (d *downloader) finishBuf(id int) (isLast bool, buf *Buf) {
 	if id >= len(d.chunks)-1 {
 		return true, nil
 	}
-	if d.nextChunk > id+1 {
-		return false, d.getBuf(id + 1)
+
+	if d.nextChunk < len(d.chunks) {
+		d.sendChunkTask()
 	}
-	ch := d.sendChunkTask()
-	return false, ch.buf
+
+	return false, d.getBuf(id + 1)
 }
 
 // downloadPart is an individual goroutine worker reading from the ch channel

--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -385,10 +385,10 @@ func (d *downloader) tryDownloadChunk(params *HttpRequestParams, ch *chunk) (int
 			switch resp.StatusCode {
 			default:
 				return 0, err
-			case 429:
-			case 502:
-			case 503:
-			case 504:
+			case http.StatusTooManyRequests:
+			case http.StatusBadGateway:
+			case http.StatusServiceUnavailable:
+			case http.StatusGatewayTimeout:
 			}
 			<-time.After(time.Millisecond * 200)
 			return 0, &errNeedRetry{err: err}

--- a/internal/net/util.go
+++ b/internal/net/util.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"fmt"
-	"github.com/alist-org/alist/v3/pkg/utils"
 	"io"
 	"math"
 	"mime/multipart"
@@ -10,6 +9,8 @@ import (
 	"net/textproto"
 	"strings"
 	"time"
+
+	"github.com/alist-org/alist/v3/pkg/utils"
 
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	log "github.com/sirupsen/logrus"

--- a/internal/offline_download/transmission/client.go
+++ b/internal/offline_download/transmission/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/offline_download/tool"
 	"github.com/alist-org/alist/v3/internal/setting"
+	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/hekmon/transmissionrpc/v3"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -92,7 +92,7 @@ func (t *Transmission) AddURL(args *tool.AddUrlArgs) (string, error) {
 		buffer := new(bytes.Buffer)
 		encoder := base64.NewEncoder(base64.StdEncoding, buffer)
 		// Stream file to the encoder
-		if _, err = io.Copy(encoder, resp.Body); err != nil {
+		if _, err = utils.CopyWithBuffer(encoder, resp.Body); err != nil {
 			return "", errors.Wrap(err, "can't copy file content into the base64 encoder")
 		}
 		// Flush last bytes

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/net"
 	"github.com/alist-org/alist/v3/pkg/http_range"
@@ -17,7 +16,6 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 	if len(link.URL) == 0 {
 		return nil, fmt.Errorf("can't create RangeReadCloser since URL is empty in link")
 	}
-	//remoteClosers := utils.EmptyClosers()
 	rangeReaderFunc := func(ctx context.Context, r http_range.Range) (io.ReadCloser, error) {
 		if link.Concurrency != 0 || link.PartSize != 0 {
 			header := net.ProcessHeader(http.Header{}, link.Header)
@@ -35,31 +33,26 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 			return rc, err
 
 		}
-		if len(link.URL) > 0 {
-			response, err := RequestRangedHttp(ctx, link, r.Start, r.Length)
+		response, err := RequestRangedHttp(ctx, link, r.Start, r.Length)
+		if err != nil {
+			if response == nil {
+				return nil, fmt.Errorf("http request failure, err:%s", err)
+			}
+			return nil, err
+		}
+		if r.Start == 0 && (r.Length == -1 || r.Length == size) || response.StatusCode == http.StatusPartialContent ||
+			checkContentRange(&response.Header, r.Start) {
+			return response.Body, nil
+		} else if response.StatusCode == http.StatusOK {
+			log.Warnf("remote http server not supporting range request, expect low perfromace!")
+			readCloser, err := net.GetRangedHttpReader(response.Body, r.Start, r.Length)
 			if err != nil {
-				if response == nil {
-					return nil, fmt.Errorf("http request failure, err:%s", err)
-				}
 				return nil, err
 			}
-			if r.Start == 0 && (r.Length == -1 || r.Length == size) || response.StatusCode == http.StatusPartialContent ||
-				checkContentRange(&response.Header, r.Start) {
-				return response.Body, nil
-			} else if response.StatusCode == http.StatusOK {
-				log.Warnf("remote http server not supporting range request, expect low perfromace!")
-				readCloser, err := net.GetRangedHttpReader(response.Body, r.Start, r.Length)
-				if err != nil {
-					return nil, err
-				}
-				return readCloser, nil
-
-			}
-
-			return response.Body, nil
+			return readCloser, nil
 		}
 
-		return nil, errs.NotSupport
+		return response.Body, nil
 	}
 	resultRangeReadCloser := model.RangeReadCloser{RangeReader: rangeReaderFunc}
 	return &resultRangeReadCloser, nil

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -32,10 +32,7 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 				HeaderRef: header,
 			}
 			rc, err := down.Download(ctx, req)
-			if err != nil {
-				return nil, errs.NewErr(err, "GetReadCloserFromLink failed")
-			}
-			return rc, nil
+			return rc, err
 
 		}
 		if len(link.URL) > 0 {

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -44,7 +44,7 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 				if response == nil {
 					return nil, fmt.Errorf("http request failure, err:%s", err)
 				}
-				return nil, fmt.Errorf("http request failure,status: %d err:%s", response.StatusCode, err)
+				return nil, err
 			}
 			if r.Start == 0 && (r.Length == -1 || r.Length == size) || response.StatusCode == http.StatusPartialContent ||
 				checkContentRange(&response.Header, r.Start) {

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -27,16 +27,11 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		return nil
 	} else if link.RangeReadCloser != nil {
 		attachFileName(w, file)
-		net.ServeHTTP(w, r, file.GetName(), file.ModTime(), file.GetSize(), link.RangeReadCloser.RangeRead)
-		defer func() {
-			_ = link.RangeReadCloser.Close()
-		}()
+		net.ServeHTTP(w, r, file.GetName(), file.ModTime(), file.GetSize(), link.RangeReadCloser)
 		return nil
 	} else if link.Concurrency != 0 || link.PartSize != 0 {
 		attachFileName(w, file)
 		size := file.GetSize()
-		//var finalClosers model.Closers
-		finalClosers := utils.EmptyClosers()
 		header := net.ProcessHeader(r.Header, link.Header)
 		rangeReader := func(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
 			down := net.NewDownloader(func(d *net.Downloader) {
@@ -50,16 +45,14 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 				HeaderRef: header,
 			}
 			rc, err := down.Download(ctx, req)
-			finalClosers.Add(rc)
 			return rc, err
 		}
-		net.ServeHTTP(w, r, file.GetName(), file.ModTime(), file.GetSize(), rangeReader)
-		defer finalClosers.Close()
+		net.ServeHTTP(w, r, file.GetName(), file.ModTime(), file.GetSize(), &model.RangeReadCloser{RangeReader: rangeReader})
 		return nil
 	} else {
 		//transparent proxy
 		header := net.ProcessHeader(r.Header, link.Header)
-		res, err := net.RequestHttp(context.Background(), r.Method, header, link.URL)
+		res, err := net.RequestHttp(r.Context(), r.Method, header, link.URL)
 		if err != nil {
 			return err
 		}
@@ -72,7 +65,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		if r.Method == http.MethodHead {
 			return nil
 		}
-		_, err = io.Copy(w, res.Body)
+		_, err = utils.CopyWithBuffer(w, res.Body)
 		if err != nil {
 			return err
 		}

--- a/server/handles/archive.go
+++ b/server/handles/archive.go
@@ -281,10 +281,11 @@ func ArchiveDown(c *gin.Context) {
 		link, _, err := fs.ArchiveDriverExtract(c, archiveRawPath, model.ArchiveInnerArgs{
 			ArchiveArgs: model.ArchiveArgs{
 				LinkArgs: model.LinkArgs{
-					IP:      c.ClientIP(),
-					Header:  c.Request.Header,
-					Type:    c.Query("type"),
-					HttpReq: c.Request,
+					IP:       c.ClientIP(),
+					Header:   c.Request.Header,
+					Type:     c.Query("type"),
+					HttpReq:  c.Request,
+					Redirect: true,
 				},
 				Password: password,
 			},

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -31,10 +31,11 @@ func Down(c *gin.Context) {
 		return
 	} else {
 		link, _, err := fs.Link(c, rawPath, model.LinkArgs{
-			IP:      c.ClientIP(),
-			Header:  c.Request.Header,
-			Type:    c.Query("type"),
-			HttpReq: c.Request,
+			IP:       c.ClientIP(),
+			Header:   c.Request.Header,
+			Type:     c.Query("type"),
+			HttpReq:  c.Request,
+			Redirect: true,
 		})
 		if err != nil {
 			common.ErrorResp(c, err, 500)
@@ -69,7 +70,6 @@ func Proxy(c *gin.Context) {
 			Header:  c.Request.Header,
 			Type:    c.Query("type"),
 			HttpReq: c.Request,
-			Proxy:   true,
 		})
 		if err != nil {
 			common.ErrorResp(c, err, 500)

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -69,6 +69,7 @@ func Proxy(c *gin.Context) {
 			Header:  c.Request.Header,
 			Type:    c.Query("type"),
 			HttpReq: c.Request,
+			Proxy:   true,
 		})
 		if err != nil {
 			common.ErrorResp(c, err, 500)

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -243,7 +243,7 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 	storage, _ := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
 	downProxyUrl := storage.GetStorage().DownProxyUrl
 	if storage.GetStorage().WebdavNative() || (storage.GetStorage().WebdavProxy() && downProxyUrl == "") {
-		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{Header: r.Header, HttpReq: r})
+		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{Header: r.Header, HttpReq: r, Proxy: true})
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -243,7 +243,7 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 	storage, _ := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
 	downProxyUrl := storage.GetStorage().DownProxyUrl
 	if storage.GetStorage().WebdavNative() || (storage.GetStorage().WebdavProxy() && downProxyUrl == "") {
-		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{Header: r.Header, HttpReq: r, Proxy: true})
+		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{Header: r.Header, HttpReq: r})
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -263,7 +263,7 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 		w.Header().Set("Cache-Control", "max-age=0, no-cache, no-store, must-revalidate")
 		http.Redirect(w, r, u, http.StatusFound)
 	} else {
-		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{IP: utils.ClientIP(r), Header: r.Header, HttpReq: r})
+		link, _, err := fs.Link(ctx, reqPath, model.LinkArgs{IP: utils.ClientIP(r), Header: r.Header, HttpReq: r, Redirect: true})
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}


### PR DESCRIPTION
## 别名(alist)驱动添加两个选项。需要开启代理才有效
* Download concurrency(下载并发)
* Download part size(下载分片大小。单位KB)
## 有什么用？
* 设置：别名驱动
本地代理
下载并发：10
下载分片大小：1024
路径：云盘的挂载路径
* 效果 ：
客户端 > alist别名驱动 ：1个连接
alist别名驱动 > 云盘 ：10 个连接并发
实际并发看云盘限制
`单线程速度慢`但`支持并发`的云盘 通过`别名`的多并发 
    1. 在线看视频、下载等 可以提速
    2. 从 别名 复制到 其他驱动 也可以提速

# 温馨提示：请不要滥用，否则云盘账号异常 后果自负

## 配置文件添加新选项：max_concurrency
限制本地代理的最大并发，默认为64，0为不限制