### PR TITLE
fix(139): use `personal_new` by default

### DIFF
--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -9,7 +9,7 @@ type Addition struct {
 	//Account       string `json:"account" required:"true"`
 	Authorization string `json:"authorization" type:"text" required:"true"`
 	driver.RootID
-	Type                 string `json:"type" type:"select" options:"personal,family,personal_new" default:"personal"`
+	Type                 string `json:"type" type:"select" options:"personal_new,family,group,personal" default:"personal_new"`
 	CloudID              string `json:"cloud_id"`
 	CustomUploadPartSize int64  `json:"custom_upload_part_size" type:"number" default:"0" help:"0 for auto"`
 }


### PR DESCRIPTION
貌似移动去年底基本都迁移到新个人云了，默认老个人云可能不方便操作，另外发现之前的 group 没加，并重新调整了一下顺序