### PR TITLE
feat(github_releases): add support for github_releases driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/febbox"
 	_ "github.com/alist-org/alist/v3/drivers/ftp"
 	_ "github.com/alist-org/alist/v3/drivers/github"
+	_ "github.com/alist-org/alist/v3/drivers/github_releases"
 	_ "github.com/alist-org/alist/v3/drivers/google_drive"
 	_ "github.com/alist-org/alist/v3/drivers/google_photo"
 	_ "github.com/alist-org/alist/v3/drivers/halalcloud"

--- a/drivers/github_releases/driver.go
+++ b/drivers/github_releases/driver.go
@@ -39,6 +39,7 @@ func (d *GithubReleases) Init(ctx context.Context) error {
 }
 
 func (d *GithubReleases) Drop(ctx context.Context) error {
+	ClearCache()
 	return nil
 }
 

--- a/drivers/github_releases/driver.go
+++ b/drivers/github_releases/driver.go
@@ -1,0 +1,119 @@
+package github_releases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"strings"
+
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+type GithubReleases struct {
+	model.Storage
+	Addition
+
+	repoList []Repo
+}
+
+func (d *GithubReleases) Config() driver.Config {
+	return config
+}
+
+func (d *GithubReleases) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *GithubReleases) Init(ctx context.Context) error {
+	repos, err := ParseRepos(d.Addition.RepoStructure)
+	if err != nil {
+		return err
+	}
+	d.repoList = repos
+	return nil
+}
+
+func (d *GithubReleases) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	files := make([]File, 0)
+	path := fmt.Sprintf("/%s", strings.Trim(dir.GetPath(), "/"))
+
+	for _, repo := range d.repoList {
+		if repo.Path == path { // 与仓库路径相同
+			tempFiles, err := RequestGithubReleases(repo.RepoName, path)
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, tempFiles...)
+			if d.Addition.ShowReadme {
+				tempFiles, err = RequestGithubOtherFile(repo.RepoName, path)
+				if err != nil {
+					return nil, err
+				}
+				files = append(files, tempFiles...)
+			}
+
+		} else if strings.HasPrefix(repo.Path, path) { // 仓库路径是目录的子目录
+			nextDir := GetNextDir(repo.Path, path)
+			if nextDir == "" {
+				continue
+			}
+			files = append(files, File{
+				FileName: nextDir,
+				Size:     0,
+				CreateAt: time.Time{},
+				UpdateAt: time.Now(),
+				Url:      "",
+				Type:     "dir",
+				Path:     fmt.Sprintf("%s/%s", path, nextDir),
+			})
+		}
+	}
+
+	objs := make([]model.Obj, len(files))
+	for i, file := range files {
+		objs[i] = file
+	}
+	return objs, nil
+}
+
+func (d *GithubReleases) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	link := model.Link{
+		URL:    file.GetID(),
+		Header: http.Header{},
+	}
+	return &link, nil
+}
+
+func (d *GithubReleases) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *GithubReleases) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *GithubReleases) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *GithubReleases) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *GithubReleases) Remove(ctx context.Context, obj model.Obj) error {
+	return errs.NotImplement
+}
+
+func (d *GithubReleases) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+var _ driver.Driver = (*GithubReleases)(nil)

--- a/drivers/github_releases/driver.go
+++ b/drivers/github_releases/driver.go
@@ -48,14 +48,14 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 
 	for _, repo := range d.repoList {
 		if repo.Path == path { // 与仓库路径相同
-			resp, err := GetRepoReleaseInfo(repo.RepoName, path, d.Storage.CacheExpiration)
+			resp, err := GetRepoReleaseInfo(repo.RepoName, path, d.Storage.CacheExpiration, d.Addition.Token)
 			if err != nil {
 				return nil, err
 			}
 			files = append(files, resp.Files...)
 
 			if d.Addition.ShowReadme {
-				resp, err := GetGithubOtherFile(repo.RepoName, path, d.Storage.CacheExpiration)
+				resp, err := GetGithubOtherFile(repo.RepoName, path, d.Storage.CacheExpiration, d.Addition.Token)
 				if err != nil {
 					return nil, err
 				}
@@ -67,7 +67,7 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 			if nextDir == "" {
 				continue
 			}
-			repo, _ := GetRepoReleaseInfo(repo.RepoName, path, d.Storage.CacheExpiration)
+			repo, _ := GetRepoReleaseInfo(repo.RepoName, path, d.Storage.CacheExpiration, d.Addition.Token)
 
 			hasSameDir := false
 			for index, file := range files {

--- a/drivers/github_releases/meta.go
+++ b/drivers/github_releases/meta.go
@@ -7,9 +7,10 @@ import (
 
 type Addition struct {
 	driver.RootID
-	RepoStructure string `json:"repo_structure" type:"text" required:"true" default:"/path/to/alist-gh:alistGo/alist\n/path/to2/alist-web-gh:AlistGo/alist-web" help:"structure:[path:]org/repo"`
-	ShowReadme    bool   `json:"show_readme" type:"bool" default:"true" help:"show README、LICENSE file"`
-	Token         string `json:"token" type:"string" required:"false" help:"GitHub token, if you want to access private repositories or increase the rate limit"`
+	RepoStructure  string `json:"repo_structure" type:"text" required:"true" default:"/path/to/alist-gh:alistGo/alist\n/path/to2/alist-web-gh:AlistGo/alist-web" help:"structure:[path:]org/repo"`
+	ShowReadme     bool   `json:"show_readme" type:"bool" default:"true" help:"show README、LICENSE file"`
+	Token          string `json:"token" type:"string" required:"false" help:"GitHub token, if you want to access private repositories or increase the rate limit"`
+	ShowAllVersion bool   `json:"show_all_version" type:"bool" default:"false" help:"show all versions"`
 }
 
 var config = driver.Config{

--- a/drivers/github_releases/meta.go
+++ b/drivers/github_releases/meta.go
@@ -9,6 +9,7 @@ type Addition struct {
 	driver.RootID
 	RepoStructure string `json:"repo_structure" type:"text" required:"true" default:"/path/to/alist-gh:alistGo/alist\n/path/to2/alist-web-gh:AlistGo/alist-web" help:"structure:[path:]org/repo"`
 	ShowReadme    bool   `json:"show_readme" type:"bool" default:"true" help:"show README、LICENSE file"`
+	Token         string `json:"token" type:"string" required:"false" help:"GitHub token, if you want to access private repositories or increase the rate limit"`
 }
 
 var config = driver.Config{

--- a/drivers/github_releases/meta.go
+++ b/drivers/github_releases/meta.go
@@ -1,0 +1,32 @@
+package github_releases
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	driver.RootID
+	RepoStructure string `json:"repo_structure" type:"text" required:"true" default:"/path/to/alist-gh:alistGo/alist\n/path/to2/alist-web-gh:AlistGo/alist-web" help:"structure:[path:]org/repo"`
+	ShowReadme    bool   `json:"show_readme" type:"bool" default:"true" help:"show README、LICENSE file"`
+}
+
+var config = driver.Config{
+	Name:              "GitHub Releases",
+	LocalSort:         false,
+	OnlyLocal:         false,
+	OnlyProxy:         false,
+	NoCache:           false,
+	NoUpload:          false,
+	NeedMs:            false,
+	DefaultRoot:       "",
+	CheckStatus:       false,
+	Alert:             "",
+	NoOverwriteUpload: false,
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &GithubReleases{}
+	})
+}

--- a/drivers/github_releases/types.go
+++ b/drivers/github_releases/types.go
@@ -1,0 +1,53 @@
+package github_releases
+
+import (
+	"time"
+
+	"github.com/alist-org/alist/v3/pkg/utils"
+)
+
+type File struct {
+	FileName string    `json:"name"`
+	Size     int64     `json:"size"`
+	CreateAt time.Time `json:"time"`
+	UpdateAt time.Time `json:"chtime"`
+	Url      string    `json:"url"`
+	Type     string    `json:"type"`
+	Path     string    `json:"path"`
+}
+
+func (f File) GetHash() utils.HashInfo {
+	return utils.HashInfo{}
+}
+
+func (f File) GetPath() string {
+	return f.Path
+}
+
+func (f File) GetSize() int64 {
+	return f.Size
+}
+
+func (f File) GetName() string {
+	return f.FileName
+}
+
+func (f File) ModTime() time.Time {
+	return f.UpdateAt
+}
+
+func (f File) CreateTime() time.Time {
+	return f.CreateAt
+}
+
+func (f File) IsDir() bool {
+	return f.Type == "dir"
+}
+
+func (f File) GetID() string {
+	return f.Url
+}
+
+func (f File) Thumb() string {
+	return ""
+}

--- a/drivers/github_releases/types.go
+++ b/drivers/github_releases/types.go
@@ -52,7 +52,7 @@ func (f File) Thumb() string {
 	return ""
 }
 
-type GithubReleasesData struct {
+type ReleasesData struct {
 	Files    []File    `json:"files"`
 	Size     int64     `json:"size"`
 	UpdateAt time.Time `json:"chtime"`
@@ -60,7 +60,9 @@ type GithubReleasesData struct {
 	Url      string    `json:"url"`
 }
 
-type Repo struct {
-	Path     string
-	RepoName string
+type Release struct {
+	Path     string // 挂载路径
+	RepoName string // 仓库名称
+	Version  string // 版本号, tag
+	ID       string // 版本ID
 }

--- a/drivers/github_releases/types.go
+++ b/drivers/github_releases/types.go
@@ -51,3 +51,16 @@ func (f File) GetID() string {
 func (f File) Thumb() string {
 	return ""
 }
+
+type GithubReleasesData struct {
+	Files    []File    `json:"files"`
+	Size     int64     `json:"size"`
+	UpdateAt time.Time `json:"chtime"`
+	CreateAt time.Time `json:"time"`
+	Url      string    `json:"url"`
+}
+
+type Repo struct {
+	Path     string
+	RepoName string
+}

--- a/drivers/github_releases/util.go
+++ b/drivers/github_releases/util.go
@@ -30,19 +30,24 @@ func ParseRepos(text string, allVersion bool) ([]Release, error) {
 			continue
 		}
 		parts := strings.Split(line, ":")
-		if len(parts) != 2 {
+		path, repo := "", ""
+		if len(parts) == 1 {
+			path = "/"
+			repo = parts[0]
+		} else if len(parts) == 2 {
+			path = fmt.Sprintf("/%s", strings.Trim(parts[0], "/"))
+			repo = parts[1]
+		} else {
 			return nil, fmt.Errorf("invalid format: %s", line)
 		}
 
-		path := fmt.Sprintf("/%s", strings.Trim(parts[0], "/"))
-
 		if allVersion {
-			releases, _ := GetAllVersion(parts[1], path)
+			releases, _ := GetAllVersion(repo, path)
 			repos = append(repos, *releases...)
 		} else {
 			repos = append(repos, Release{
 				Path:     path,
-				RepoName: parts[1],
+				RepoName: repo,
 				Version:  "latest",
 				ID:       "latest",
 			})

--- a/drivers/github_releases/util.go
+++ b/drivers/github_releases/util.go
@@ -1,0 +1,123 @@
+package github_releases
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	jsoniter "github.com/json-iterator/go"
+)
+
+type Repo struct {
+	Path     string
+	RepoName string
+}
+
+// 解析仓库列表
+func ParseRepos(text string) ([]Repo, error) {
+	lines := strings.Split(text, "\n")
+	var repos []Repo
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid format: %s", line)
+		}
+		repos = append(repos, Repo{
+			Path:     fmt.Sprintf("/%s", strings.Trim(parts[0], "/")),
+			RepoName: parts[1],
+		})
+	}
+	return repos, nil
+}
+
+// 获取 Github Releases
+func RequestGithubReleases(repo string, basePath string) ([]File, error) {
+	req := base.RestyClient.R()
+	res, err := req.Get(fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", strings.Trim(repo, "/")))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode() != 200 {
+		return nil, fmt.Errorf("request failed: %s", res.Status())
+	}
+	assets := jsoniter.Get(res.Body(), "assets")
+	var files []File
+
+	for i := 0; i < assets.Size(); i++ {
+		filename := assets.Get(i, "name").ToString()
+
+		files = append(files, File{
+			FileName: filename,
+			Size:     assets.Get(i, "size").ToInt64(),
+			Url:      assets.Get(i, "browser_download_url").ToString(),
+			Type:     assets.Get(i, "content_type").ToString(),
+			Path:     fmt.Sprintf("%s/%s", basePath, filename),
+
+			CreateAt: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, assets.Get(i, "created_at").ToString())
+				return t
+			}(),
+			UpdateAt: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, assets.Get(i, "updated_at").ToString())
+				return t
+			}(),
+		})
+	}
+	return files, nil
+}
+
+// 获取 README、LICENSE 等文件
+func RequestGithubOtherFile(repo string, basePath string) ([]File, error) {
+	req := base.RestyClient.R()
+	res, err := req.Get(fmt.Sprintf("https://api.github.com/repos/%s/contents/", strings.Trim(repo, "/")))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode() != 200 {
+		return nil, fmt.Errorf("request failed: %s", res.Status())
+	}
+	body := jsoniter.Get(res.Body())
+	var files []File
+	for i := 0; i < body.Size(); i++ {
+		filename := body.Get(i, "name").ToString()
+
+		re := regexp.MustCompile(`(?i)^(.*\.md|LICENSE)$`)
+
+		if !re.MatchString(filename) {
+			continue
+		}
+
+		files = append(files, File{
+			FileName: filename,
+			Size:     body.Get(i, "size").ToInt64(),
+			CreateAt: time.Time{},
+			UpdateAt: time.Now(),
+			Url:      body.Get(i, "download_url").ToString(),
+			Type:     body.Get(i, "type").ToString(),
+			Path:     fmt.Sprintf("%s/%s", basePath, filename),
+		})
+	}
+	return files, nil
+}
+
+// 获取下一级目录
+func GetNextDir(wholePath string, basePath string) string {
+	if !strings.HasSuffix(basePath, "/") {
+		basePath += "/"
+	}
+	if !strings.HasPrefix(wholePath, basePath) {
+		return ""
+	}
+	remainingPath := strings.TrimLeft(strings.TrimPrefix(wholePath, basePath), "/")
+	if remainingPath != "" {
+		parts := strings.Split(remainingPath, "/")
+		return parts[0]
+	}
+	return ""
+}

--- a/drivers/github_releases/util.go
+++ b/drivers/github_releases/util.go
@@ -17,12 +17,13 @@ var (
 	cache   = make(map[string]*resty.Response)
 	created = make(map[string]time.Time)
 	mu      sync.Mutex
+	req     *resty.Request
 )
 
 // 解析仓库列表
-func ParseRepos(text string) ([]Repo, error) {
+func ParseRepos(text string, allVersion bool) ([]Release, error) {
 	lines := strings.Split(text, "\n")
-	var repos []Repo
+	var repos []Release
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -32,10 +33,21 @@ func ParseRepos(text string) ([]Repo, error) {
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid format: %s", line)
 		}
-		repos = append(repos, Repo{
-			Path:     fmt.Sprintf("/%s", strings.Trim(parts[0], "/")),
-			RepoName: parts[1],
-		})
+
+		path := fmt.Sprintf("/%s", strings.Trim(parts[0], "/"))
+
+		if allVersion {
+			releases, _ := GetAllVersion(parts[1], path)
+			repos = append(repos, *releases...)
+		} else {
+			repos = append(repos, Release{
+				Path:     path,
+				RepoName: parts[1],
+				Version:  "latest",
+				ID:       "latest",
+			})
+		}
+
 	}
 	return repos, nil
 }
@@ -57,7 +69,7 @@ func GetNextDir(wholePath string, basePath string) string {
 }
 
 // 发送 GET 请求
-func GetRequest(url string, cacheExpiration int, token string) (*resty.Response, error) {
+func GetRequest(url string, cacheExpiration int) (*resty.Response, error) {
 	mu.Lock()
 	if res, ok := cache[url]; ok && time.Now().Before(created[url].Add(time.Duration(cacheExpiration)*time.Minute)) {
 		mu.Unlock()
@@ -65,12 +77,6 @@ func GetRequest(url string, cacheExpiration int, token string) (*resty.Response,
 	}
 	mu.Unlock()
 
-	req := base.RestyClient.R()
-	if token != "" {
-		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
-	}
-	req.SetHeader("Accept", "application/vnd.github+json")
-	req.SetHeader("X-GitHub-Api-Version", "2022-11-28")
 	res, err := req.Get(url)
 	if err != nil {
 		return nil, err
@@ -88,12 +94,9 @@ func GetRequest(url string, cacheExpiration int, token string) (*resty.Response,
 }
 
 // 获取 README、LICENSE 等文件
-func GetGithubOtherFile(repo string, basePath string, cacheExpiration int, token string) (*[]File, error) {
-	res, _ := GetRequest(
-		fmt.Sprintf("https://api.github.com/repos/%s/contents/", strings.Trim(repo, "/")),
-		cacheExpiration,
-		token,
-	)
+func GetGithubOtherFile(repo string, basePath string, cacheExpiration int) (*[]File, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/contents/", strings.Trim(repo, "/"))
+	res, _ := GetRequest(url, cacheExpiration)
 	body := jsoniter.Get(res.Body())
 	var files []File
 	for i := 0; i < body.Size(); i++ {
@@ -119,13 +122,13 @@ func GetGithubOtherFile(repo string, basePath string, cacheExpiration int, token
 }
 
 // 获取 GitHub Release 详细信息
-func GetRepoReleaseInfo(repo string, basePath string, cacheExpiration int, token string) (*GithubReleasesData, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", strings.Trim(repo, "/"))
-	res, _ := GetRequest(url, cacheExpiration, token)
+func GetRepoReleaseInfo(repo string, version string, basePath string, cacheExpiration int) (*ReleasesData, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/%s", strings.Trim(repo, "/"), version)
+	res, _ := GetRequest(url, cacheExpiration)
 	body := res.Body()
 
 	if jsoniter.Get(res.Body(), "status").ToInt64() != 0 {
-		return &GithubReleasesData{}, fmt.Errorf("%s", res.String())
+		return &ReleasesData{}, fmt.Errorf("%s", res.String())
 	}
 
 	assets := jsoniter.Get(res.Body(), "assets")
@@ -152,7 +155,7 @@ func GetRepoReleaseInfo(repo string, basePath string, cacheExpiration int, token
 		})
 	}
 
-	return &GithubReleasesData{
+	return &ReleasesData{
 		Files: files,
 		Url:   jsoniter.Get(body, "html_url").ToString(),
 
@@ -174,9 +177,36 @@ func GetRepoReleaseInfo(repo string, basePath string, cacheExpiration int, token
 	}, nil
 }
 
+// 获取所有的版本号
+func GetAllVersion(repo string, path string) (*[]Release, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", strings.Trim(repo, "/"))
+	res, _ := GetRequest(url, 0)
+	body := jsoniter.Get(res.Body())
+	releases := make([]Release, 0)
+	for i := 0; i < body.Size(); i++ {
+		version := body.Get(i, "tag_name").ToString()
+		releases = append(releases, Release{
+			Path:     fmt.Sprintf("%s/%s", path, version),
+			Version:  version,
+			RepoName: repo,
+			ID:       body.Get(i, "id").ToString(),
+		})
+	}
+	return &releases, nil
+}
+
 func ClearCache() {
 	mu.Lock()
 	cache = make(map[string]*resty.Response)
 	created = make(map[string]time.Time)
 	mu.Unlock()
+}
+
+func SetHeader(token string) {
+	req = base.RestyClient.R()
+	if token != "" {
+		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+	req.SetHeader("Accept", "application/vnd.github+json")
+	req.SetHeader("X-GitHub-Api-Version", "2022-11-28")
 }


### PR DESCRIPTION
resolve #7842 

添加对 GitHub Releases 的支持，将多个仓库的最新版 Releases 挂载到 AList，方便不了解 GitHub 的用户下载。
同时可选是否获取仓库根目录下的 `*.md` 和 `LICENSE` 文件。

配置项：
| 配置项 | 类型 | 是否必填 | 描述 |
| ---- | ---- | ---- | ---- |
| RepoStructure | text | 是 | 仓库结构 |
| ShowReadme | bool | 是 | 是否显示 `*.md` 和 `LICENSE` 文件 |
| Token | string | 否 | GitHub 访问令牌，用于私有仓库 和 避免访问速率限制 |
| ShowAllVersion | bool | 是 | 开启后以子目录的形式显示所有版本 |

RepoStructure 使用类似地址树的方式，但不使用缩进表示目录，支持多级路径。
![image](https://github.com/user-attachments/assets/dc2da165-5e8f-4ea0-9e0f-6d8f050089cc)

效果示例（不显示所有版本）：
![image](https://github.com/user-attachments/assets/7fd0b000-8865-4cc6-b9cc-49c9e38c8d10)

效果示例（显示所有版本）：
![image](https://github.com/user-attachments/assets/c308849e-5ab7-47ef-ac08-706a17202e1f)


补充说明：
+ 目录大小由子目录相加得到，未计算 `*.md` 和 `LICENSE` 文件的大小。
+ 使用 `map` 缓存接口响应，减少访问速率限制的影响。