### PR TITLE
perf(upload): support rapid upload on web

### DIFF
--- a/drivers/alist_v3/driver.go
+++ b/drivers/alist_v3/driver.go
@@ -189,6 +189,15 @@ func (d *AListV3) Put(ctx context.Context, dstDir model.Obj, stream model.FileSt
 	req.Header.Set("Authorization", d.Token)
 	req.Header.Set("File-Path", path.Join(dstDir.GetPath(), stream.GetName()))
 	req.Header.Set("Password", d.MetaPassword)
+	if md5 := stream.GetHash().GetHash(utils.MD5); len(md5) > 0 {
+		req.Header.Set("X-File-Md5", md5)
+	}
+	if sha1 := stream.GetHash().GetHash(utils.SHA1); len(sha1) > 0 {
+		req.Header.Set("X-File-Sha1", sha1)
+	}
+	if sha256 := stream.GetHash().GetHash(utils.SHA256); len(sha256) > 0 {
+		req.Header.Set("X-File-Sha256", sha256)
+	}
 
 	req.ContentLength = stream.GetSize()
 	// client := base.NewHttpClient()

--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -2,6 +2,7 @@ package handles
 
 import (
 	"github.com/alist-org/alist/v3/internal/task"
+	"github.com/alist-org/alist/v3/pkg/utils"
 	"io"
 	"net/url"
 	stdpath "path"
@@ -55,11 +56,22 @@ func FsStream(c *gin.Context) {
 		common.ErrorResp(c, err, 400)
 		return
 	}
+	h := make(map[*utils.HashType]string)
+	if md5 := c.GetHeader("X-File-Md5"); md5 != "" {
+		h[utils.MD5] = md5
+	}
+	if sha1 := c.GetHeader("X-File-Sha1"); sha1 != "" {
+		h[utils.SHA1] = sha1
+	}
+	if sha256 := c.GetHeader("X-File-Sha256"); sha256 != "" {
+		h[utils.SHA256] = sha256
+	}
 	s := &stream.FileStream{
 		Obj: &model.Object{
 			Name:     name,
 			Size:     size,
 			Modified: getLastModified(c),
+			HashInfo: utils.NewHashInfoByMap(h),
 		},
 		Reader:       c.Request.Body,
 		Mimetype:     c.GetHeader("Content-Type"),
@@ -128,11 +140,22 @@ func FsForm(c *gin.Context) {
 	}
 	defer f.Close()
 	dir, name := stdpath.Split(path)
+	h := make(map[*utils.HashType]string)
+	if md5 := c.GetHeader("X-File-Md5"); md5 != "" {
+		h[utils.MD5] = md5
+	}
+	if sha1 := c.GetHeader("X-File-Sha1"); sha1 != "" {
+		h[utils.SHA1] = sha1
+	}
+	if sha256 := c.GetHeader("X-File-Sha256"); sha256 != "" {
+		h[utils.SHA256] = sha256
+	}
 	s := stream.FileStream{
 		Obj: &model.Object{
 			Name:     name,
 			Size:     file.Size,
 			Modified: getLastModified(c),
+			HashInfo: utils.NewHashInfoByMap(h),
 		},
 		Reader:       f,
 		Mimetype:     file.Header.Get("Content-Type"),


### PR DESCRIPTION
在前端新增一个上传选项`Try rapid`，当选中时，前端会计算文件的 MD5、SHA1 和 SHA256，并通过`X-File-Md5`、`X-File-Sha1`、`X-File-Sha256`三个请求头传输给后端，这将避免驱动将文件缓存在服务端计算哈希，且在触发秒传时避免前端传输无用的文件流。