### PR TITLE
feat(task): allow retry canceled

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -53,12 +53,13 @@ type TaskConfig struct {
 }
 
 type TasksConfig struct {
-	Download         TaskConfig `json:"download" envPrefix:"DOWNLOAD_"`
-	Transfer         TaskConfig `json:"transfer" envPrefix:"TRANSFER_"`
-	Upload           TaskConfig `json:"upload" envPrefix:"UPLOAD_"`
-	Copy             TaskConfig `json:"copy" envPrefix:"COPY_"`
-	Decompress       TaskConfig `json:"decompress" envPrefix:"DECOMPRESS_"`
-	DecompressUpload TaskConfig `json:"decompress_upload" envPrefix:"DECOMPRESS_UPLOAD_"`
+	Download           TaskConfig `json:"download" envPrefix:"DOWNLOAD_"`
+	Transfer           TaskConfig `json:"transfer" envPrefix:"TRANSFER_"`
+	Upload             TaskConfig `json:"upload" envPrefix:"UPLOAD_"`
+	Copy               TaskConfig `json:"copy" envPrefix:"COPY_"`
+	Decompress         TaskConfig `json:"decompress" envPrefix:"DECOMPRESS_"`
+	DecompressUpload   TaskConfig `json:"decompress_upload" envPrefix:"DECOMPRESS_UPLOAD_"`
+	AllowRetryCanceled bool       `json:"allow_retry_canceled" env:"ALLOW_RETRY_CANCELED"`
 }
 
 type Cors struct {
@@ -180,6 +181,7 @@ func DefaultConfig() *Config {
 				Workers:  5,
 				MaxRetry: 2,
 			},
+			AllowRetryCanceled: false,
 		},
 		Cors: Cors{
 			AllowOrigins: []string{"*"},

--- a/internal/fs/archive.go
+++ b/internal/fs/archive.go
@@ -50,6 +50,7 @@ func (t *ArchiveDownloadTask) GetStatus() string {
 }
 
 func (t *ArchiveDownloadTask) Run() error {
+	t.ReinitCtx()
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()
@@ -144,6 +145,7 @@ func (t *ArchiveContentUploadTask) GetStatus() string {
 }
 
 func (t *ArchiveContentUploadTask) Run() error {
+	t.ReinitCtx()
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()
@@ -235,7 +237,9 @@ func (t *ArchiveContentUploadTask) RunWithNextTaskCallback(f func(nextTsk *Archi
 
 func (t *ArchiveContentUploadTask) Cancel() {
 	t.TaskExtension.Cancel()
-	t.deleteSrcFile()
+	if !conf.Conf.Tasks.AllowRetryCanceled {
+		t.deleteSrcFile()
+	}
 }
 
 func (t *ArchiveContentUploadTask) deleteSrcFile() {

--- a/internal/fs/copy.go
+++ b/internal/fs/copy.go
@@ -39,6 +39,7 @@ func (t *CopyTask) GetStatus() string {
 }
 
 func (t *CopyTask) Run() error {
+	t.ReinitCtx()
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()

--- a/internal/offline_download/tool/download.go
+++ b/internal/offline_download/tool/download.go
@@ -28,6 +28,7 @@ type DownloadTask struct {
 }
 
 func (t *DownloadTask) Run() error {
+	t.ReinitCtx()
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()

--- a/internal/offline_download/tool/transfer.go
+++ b/internal/offline_download/tool/transfer.go
@@ -32,6 +32,7 @@ type TransferTask struct {
 }
 
 func (t *TransferTask) Run() error {
+	t.ReinitCtx()
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()

--- a/internal/task/base.go
+++ b/internal/task/base.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/xhofe/tache"
 	"sync"
@@ -64,6 +65,20 @@ func (t *TaskExtension) Ctx() context.Context {
 		t.ctxInitMutex.Unlock()
 	}
 	return t.ctx
+}
+
+func (t *TaskExtension) ReinitCtx() {
+	if !conf.Conf.Tasks.AllowRetryCanceled {
+		return
+	}
+	select {
+	case <-t.Base.Ctx().Done():
+		ctx, cancel := context.WithCancel(context.Background())
+		t.SetCtx(ctx)
+		t.SetCancelFunc(cancel)
+		t.ctx = nil
+	default:
+	}
 }
 
 type TaskExtensionInfo interface {


### PR DESCRIPTION
允许用户重试之前取消的任务，但考虑到使用习惯的问题，这一特性默认关闭，需要在 `config.json` 中启用。
不能重试上传任务。