### PR TITLE
fix(s3): escape CopySource request header when copying files

### DIFF
--- a/drivers/s3/util.go
+++ b/drivers/s3/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -198,7 +199,7 @@ func (d *S3) copyFile(ctx context.Context, src string, dst string) error {
 	dstKey := getKey(dst, false)
 	input := &s3.CopyObjectInput{
 		Bucket:     &d.Bucket,
-		CopySource: aws.String("/" + d.Bucket + "/" + srcKey),
+		CopySource: aws.String(url.PathEscape("/" + d.Bucket + "/" + srcKey)),
 		Key:        &dstKey,
 	}
 	_, err := d.client.CopyObject(input)


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7858 ：重命名或复制文件名含有中文的文件，Signature计算错误

### 问题原因
复制文件时，请求头部`X-Amz-Copy-Source`是源文件的路径，计算`Signature`时会用到它；华为云是按转义后的`CopySource`计算`Signature`，而`alist`没有做转义，导致签名不一致报错
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/a7534f90-cd93-4339-8a46-c3588e94ed11" />


其实`AWS`官方也是要求做转义的，不过经过测试腾讯云对象存储`COS`对两种情况都做了兼容，所以没有报错
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/fc09c329-382f-48c4-b9b0-63977077f8c0" />


### 解决方案
对CopySource增加转义操作

### 自测
华为云-重命名含中文的文件 --- OK
<img width="1151" alt="image" src="https://github.com/user-attachments/assets/e7d129af-8807-4797-8dca-7378337dfe20" />

华为云-重命名含中文的目录 --- OK
华为云-重命名英文的文件    --- OK
腾讯云-重命名含中文的文件 --- OK
腾讯云-重命名英文的文件    --- OK
