### PR TITLE
feat(fs): display the existing filename in error message

### DIFF
--- a/server/handles/fsmanage.go
+++ b/server/handles/fsmanage.go
@@ -90,7 +90,7 @@ func FsMove(c *gin.Context) {
 	if !req.Overwrite {
 		for _, name := range req.Names {
 			if res, _ := fs.Get(c, stdpath.Join(dstDir, name), &fs.GetArgs{NoLog: true}); res != nil {
-				common.ErrorStrResp(c, "file exists", 403)
+				common.ErrorStrResp(c, fmt.Sprintf("file [%s] exists", name), 403)
 				return
 			}
 		}
@@ -133,7 +133,7 @@ func FsCopy(c *gin.Context) {
 	if !req.Overwrite {
 		for _, name := range req.Names {
 			if res, _ := fs.Get(c, stdpath.Join(dstDir, name), &fs.GetArgs{NoLog: true}); res != nil {
-				common.ErrorStrResp(c, "file exists", 403)
+				common.ErrorStrResp(c, fmt.Sprintf("file [%s] exists", name), 403)
 				return
 			}
 		}
@@ -180,7 +180,7 @@ func FsRename(c *gin.Context) {
 		dstPath := stdpath.Join(stdpath.Dir(reqPath), req.Name)
 		if dstPath != reqPath {
 			if res, _ := fs.Get(c, dstPath, &fs.GetArgs{NoLog: true}); res != nil {
-				common.ErrorStrResp(c, "file exists", 403)
+				common.ErrorStrResp(c, fmt.Sprintf("file [%s] exists", req.Name), 403)
 				return
 			}
 		}


### PR DESCRIPTION
Display the existing filename in error message, in order to locate issues during batch operations.
在错误信息中显示已存在的文件名，以便在批量操作时定位问题。