### PR TITLE
chore(README): formatting spacing in `README` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ---
 
-English | [中文](./README_cn.md)| [日本語](./README_ja.md) | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
+English | [中文](./README_cn.md) | [日本語](./README_ja.md) | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 
 ## Features
 


### PR DESCRIPTION
漏了一个空格 增加以和
https://github.com/AlistGo/alist/blob/c2633dd4436a2337246979a9d866f7e408e6c2ea/README_cn.md?plain=1#L42
https://github.com/AlistGo/alist/blob/c2633dd4436a2337246979a9d866f7e408e6c2ea/README_ja.md?plain=1#L42
链接间距相同

![image](https://github.com/user-attachments/assets/8b3dc2f7-684b-4468-a2bd-358d037a9ff7)
