### PR TITLE
fix(febbox): panic due to slice out of range

### DIFF
--- a/drivers/febbox/util.go
+++ b/drivers/febbox/util.go
@@ -3,6 +3,7 @@ package febbox
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/go-resty/resty/v2"
@@ -134,6 +135,9 @@ func (d *FebBox) getDownloadLink(id string, ip string) (string, error) {
 
 	if err = json.Unmarshal(res, &fileDownloadResp); err != nil {
 		return "", err
+	}
+	if len(fileDownloadResp.Data) == 0 {
+		return "", fmt.Errorf("can not get download link, code:%d, msg:%s", fileDownloadResp.Code, fileDownloadResp.Msg)
 	}
 
 	return fileDownloadResp.Data[0].DownloadURL, nil


### PR DESCRIPTION
### 修复问题
https://github.com/AlistGo/alist/issues/7889


### 问题原因
`/oauth`接口返回的`data`在异常情况下会为空，导致越界发生`panic`

### 解决方案
增加判断`data`切片长度