### PR TITLE
fix(139): restore the `Account` handling, partially reverts #7850

### DIFF
--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -2,11 +2,13 @@ package _139
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -69,29 +71,28 @@ func (d *Yun139) Init(ctx context.Context) error {
 	default:
 		return errs.NotImplement
 	}
-	// if d.ref != nil {
-	// 	return nil
-	// }
-	// decode, err := base64.StdEncoding.DecodeString(d.Authorization)
-	// if err != nil {
-	// 	return err
-	// }
-	// decodeStr := string(decode)
-	// splits := strings.Split(decodeStr, ":")
-	// if len(splits) < 2 {
-	// 	return fmt.Errorf("authorization is invalid, splits < 2")
-	// }
-	// d.Account = splits[1]
-	// _, err = d.post("/orchestration/personalCloud/user/v1.0/qryUserExternInfo", base.Json{
-	// 	"qryUserExternInfoReq": base.Json{
-	// 		"commonAccountInfo": base.Json{
-	// 			"account":     d.getAccount(),
-	// 			"accountType": 1,
-	// 		},
-	// 	},
-	// }, nil)
-	// return err
-	return nil
+	if d.ref != nil {
+		return nil
+	}
+	decode, err := base64.StdEncoding.DecodeString(d.Authorization)
+	if err != nil {
+		return err
+	}
+	decodeStr := string(decode)
+	splits := strings.Split(decodeStr, ":")
+	if len(splits) < 2 {
+		return fmt.Errorf("authorization is invalid, splits < 2")
+	}
+	d.Account = splits[1]
+	_, err = d.post("/orchestration/personalCloud/user/v1.0/qryUserExternInfo", base.Json{
+		"qryUserExternInfoReq": base.Json{
+			"commonAccountInfo": base.Json{
+				"account":     d.getAccount(),
+				"accountType": 1,
+			},
+		},
+	}, nil)
+	return err
 }
 
 func (d *Yun139) InitReference(storage driver.Driver) error {


### PR DESCRIPTION
本更新回滚了 #7850 中的部分修改
可能相关的 issue： #7784 

都说是移动 2024 年年底把所有账户都转到了新个人云接口，但我这里按 F12 却仍然只能找到旧的 `getDisk` ，而且**使用新个人云接口上传的文件在官方网页端和客户端里根本看不到**，而且也缺失了很多文件。

无奈只能换回老个人云，结果猛报 `failed get objs: failed to list objs: 用户不存在` ，读代码一看：怎么把 `getAccount` 的逻辑注释了。