### PR TITLE
fix: missing args when using alias driver

### DIFF
--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -303,9 +303,10 @@ func FsGet(c *gin.Context) {
 			} else {
 				// if storage is not proxy, use raw url by fs.Link
 				link, _, err := fs.Link(c, reqPath, model.LinkArgs{
-					IP:      c.ClientIP(),
-					Header:  c.Request.Header,
-					HttpReq: c.Request,
+					IP:       c.ClientIP(),
+					Header:   c.Request.Header,
+					HttpReq:  c.Request,
+					Redirect: true,
 				})
 				if err != nil {
 					common.ErrorResp(c, err, 500)


### PR DESCRIPTION
fix:[7932](https://github.com/AlistGo/alist/issues/7932)，当使用alias驱动，302获取rawURL错误。
