### PR TITLE
refactor(cmd): use std `runtime` package to get go version info

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -94,7 +94,6 @@ jobs:
           out-dir: build
           x-flags: |
             github.com/alist-org/alist/v3/internal/conf.BuiltAt=$built_at
-            github.com/alist-org/alist/v3/internal/conf.GoVersion=$go_version
             github.com/alist-org/alist/v3/internal/conf.GitAuthor=Xhofe
             github.com/alist-org/alist/v3/internal/conf.GitCommit=$git_commit
             github.com/alist-org/alist/v3/internal/conf.Version=$tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
           out-dir: build
           x-flags: |
             github.com/alist-org/alist/v3/internal/conf.BuiltAt=$built_at
-            github.com/alist-org/alist/v3/internal/conf.GoVersion=$go_version
             github.com/alist-org/alist/v3/internal/conf.GitAuthor=Xhofe
             github.com/alist-org/alist/v3/internal/conf.GitCommit=$git_commit
             github.com/alist-org/alist/v3/internal/conf.Version=$tag

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 appName="alist"
 builtAt="$(date +'%F %T %z')"
-goVersion=$(go version | sed 's/go version //')
 gitAuthor="Xhofe <i@nn.ci>"
 gitCommit=$(git log --pretty=format:"%h" -1)
 
@@ -22,7 +21,6 @@ echo "frontend version: $webVersion"
 ldflags="\
 -w -s \
 -X 'github.com/alist-org/alist/v3/internal/conf.BuiltAt=$builtAt' \
--X 'github.com/alist-org/alist/v3/internal/conf.GoVersion=$goVersion' \
 -X 'github.com/alist-org/alist/v3/internal/conf.GitAuthor=$gitAuthor' \
 -X 'github.com/alist-org/alist/v3/internal/conf.GitCommit=$gitCommit' \
 -X 'github.com/alist-org/alist/v3/internal/conf.Version=$version' \

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/spf13/cobra"
@@ -16,14 +17,15 @@ var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show current version of AList",
 	Run: func(cmd *cobra.Command, args []string) {
+		goVersion := fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
 		fmt.Printf(`Built At: %s
 Go Version: %s
 Author: %s
 Commit ID: %s
 Version: %s
 WebVersion: %s
-`,
-			conf.BuiltAt, conf.GoVersion, conf.GitAuthor, conf.GitCommit, conf.Version, conf.WebVersion)
+`, conf.BuiltAt, goVersion, conf.GitAuthor, conf.GitCommit, conf.Version, conf.WebVersion)
 		os.Exit(0)
 	},
 }

--- a/internal/conf/var.go
+++ b/internal/conf/var.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	BuiltAt    string
-	GoVersion  string
 	GitAuthor  string
 	GitCommit  string
 	Version    string = "dev"


### PR DESCRIPTION
- Remove the `GoVersion` variable
- Remove overriding `GoVersion` by ldflags in `build.sh` and ci workflows.
- Get go version, OS and arch from the constants in the std `runtime` package instead of compile time.