### PR TITLE
fix(ilanzou): add header `X-Forwarded-For` to solve IP ban

### DIFF
--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -6,13 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/alist-org/alist/v3/internal/stream"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/alist-org/alist/v3/internal/stream"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -121,7 +122,7 @@ func (d *ILanZou) Link(ctx context.Context, file model.Obj, args model.LinkArgs)
 	if err != nil {
 		return nil, err
 	}
-	ts, ts_str, err := getTimestamp(d.conf.secret)
+	ts, ts_str, _ := getTimestamp(d.conf.secret)
 
 	params := []string{
 		"uuid=" + url.QueryEscape(d.UUID),

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -151,11 +151,17 @@ func (d *ILanZou) Link(ctx context.Context, file model.Obj, args model.LinkArgs)
 	u.RawQuery = strings.Join(params, "&")
 	realURL := u.String()
 	// get the url after redirect
-	res, err := base.NoRedirectClient.R().SetHeaders(map[string]string{
-		//"Origin":  d.conf.site,
+	req := base.NoRedirectClient.R()
+
+	req.SetHeaders(map[string]string{
 		"Referer":    d.conf.site + "/",
 		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
-	}).Get(realURL)
+	})
+	if d.Addition.Ip != "" {
+		req.SetHeader("X-Forwarded-For", d.Addition.Ip)
+	}
+
+	res, err := req.Get(realURL)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/ilanzou/meta.go
+++ b/drivers/ilanzou/meta.go
@@ -9,6 +9,7 @@ type Addition struct {
 	driver.RootID
 	Username string `json:"username" type:"string" required:"true"`
 	Password string `json:"password" type:"string" required:"true"`
+	Ip       string `json:"ip" type:"string"`
 
 	Token string
 	UUID  string

--- a/drivers/ilanzou/util.go
+++ b/drivers/ilanzou/util.go
@@ -76,6 +76,10 @@ func (d *ILanZou) request(pathname, method string, callback base.ReqCallback, pr
 		"Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,mt;q=0.5",
 	})
 
+	if d.Addition.Ip != "" {
+		req.SetHeader("X-Forwarded-For", d.Addition.Ip)
+	}
+
 	if callback != nil {
 		callback(req)
 	}


### PR DESCRIPTION
resolve #7966, resolve #7581, resolve #7759, resolve #7534

添加 `X-Forwarded-For` 请求头（可选），来避免阿里云 IP 无法获取文件列表
[详见 issue 中讨论](https://github.com/AlistGo/alist/issues/7759#issuecomment-2583503228)

ilanzou（蓝奏云优享版）和小飞机网盘使用相同的驱动。