### PR TITLE
feat(github): support github proxy

### DIFF
--- a/drivers/github/meta.go
+++ b/drivers/github/meta.go
@@ -7,10 +7,11 @@ import (
 
 type Addition struct {
 	driver.RootPath
-	Token           string `json:"token" type:"string" required:"true"`
+	Token           string `json:"token" type:"string"`
 	Owner           string `json:"owner" type:"string" required:"true"`
 	Repo            string `json:"repo" type:"string" required:"true"`
 	Ref             string `json:"ref" type:"string" help:"A branch, a tag or a commit SHA, main branch by default."`
+	GitHubProxy     string `json:"gh_proxy" type:"string" help:"GitHub proxy, e.g. https://ghproxy.net/raw.githubusercontent.com or https://gh-proxy.com/raw.githubusercontent.com"`
 	CommitterName   string `json:"committer_name" type:"string"`
 	CommitterEmail  string `json:"committer_email" type:"string"`
 	AuthorName      string `json:"author_name" type:"string"`


### PR DESCRIPTION
GitHub API 驱动支持 GitHub 专用代理。

考虑到 GitHub Releases 驱动已经实现这一特性，该 PR 会关闭提出这一需求的 issue。
Close #7963

需要注意的是，该驱动返回的下载 URL 是 raw.githubusercontent.com 域名下的，因此填写代理参数时与 GitHub Releases 驱动也有所不同，比如要将`https://gh-proxy.com/github.com`改为`https://gh-proxy.com/raw.githubusercontent.com`。