### PR TITLE
feat(webdav): support `oc:checksums`

### DIFF
--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"iter"
 
 	"github.com/alist-org/alist/v3/internal/errs"
 	log "github.com/sirupsen/logrus"
@@ -225,4 +226,14 @@ func (hi HashInfo) GetHash(ht *HashType) string {
 
 func (hi HashInfo) Export() map[*HashType]string {
 	return hi.h
+}
+
+func (hi HashInfo) All() iter.Seq2[*HashType, string] {
+	return func(yield func(*HashType, string) bool) {
+		for hashType, hashValue := range hi.h {
+			if !yield(hashType, hashValue) {
+				return
+			}
+		}
+	}
 }


### PR DESCRIPTION
实现 #7472 的功能。

相比该 issue 中提出的 `al:checksums`，这个 PR 实现的是 ownCloud 的 `oc:checksums`，这样可以兼容现有支持该属性的软件（如 rclone）。

Closes #7472