### PR TITLE
fix(onedrive): set req.ContentLength

### DIFF
--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -208,7 +208,8 @@ func (d *Cloudreve) upRemote(ctx context.Context, stream model.FileStreamer, u U
 			return err
 		}
 		req = req.WithContext(ctx)
-		req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Authorization", fmt.Sprint(credential))
 		finish += byteSize
 		res, err := base.HttpClient.Do(req)
@@ -247,7 +248,8 @@ func (d *Cloudreve) upOneDrive(ctx context.Context, stream model.FileStreamer, u
 			return err
 		}
 		req = req.WithContext(ctx)
-		req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
 		finish += byteSize
 		res, err := base.HttpClient.Do(req)

--- a/drivers/onedrive/util.go
+++ b/drivers/onedrive/util.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	stdpath "path"
-	"strconv"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -226,7 +225,8 @@ func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.Fil
 			return err
 		}
 		req = req.WithContext(ctx)
-		req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
 		finish += byteSize
 		res, err := base.HttpClient.Do(req)

--- a/drivers/onedrive_app/util.go
+++ b/drivers/onedrive_app/util.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	stdpath "path"
-	"strconv"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -176,7 +175,8 @@ func (d *OnedriveAPP) upBig(ctx context.Context, dstDir model.Obj, stream model.
 			return err
 		}
 		req = req.WithContext(ctx)
-		req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
 		finish += byteSize
 		res, err := base.HttpClient.Do(req)


### PR DESCRIPTION
显式设置 req.ContentLength，防止 http 库自动启用 chunked 传输，导致无法上传

Fix: #8043