### PR TITLE
fix(s3): incorrectly added slash before the Bucket name

### DIFF
--- a/drivers/s3/util.go
+++ b/drivers/s3/util.go
@@ -199,7 +199,7 @@ func (d *S3) copyFile(ctx context.Context, src string, dst string) error {
 	dstKey := getKey(dst, false)
 	input := &s3.CopyObjectInput{
 		Bucket:     &d.Bucket,
-		CopySource: aws.String(url.PathEscape("/" + d.Bucket + "/" + srcKey)),
+		CopySource: aws.String(url.PathEscape(d.Bucket + "/" + srcKey)),
 		Key:        &dstKey,
 	}
 	_, err := d.client.CopyObject(input)


### PR DESCRIPTION
# 背景

该Bug主要涉及到Issue #8001，Error可复现，表现为S3存储无法重命名文件

## 复现环境

后端使用Master分支，Commit 370a6c15，启动后进行一次重命名，在页面上会报错
<img width="765" alt="Snipaste_2025-03-04_22-21-41" src="https://github.com/user-attachments/assets/7c899654-bb13-4fc3-bf49-8284e219059b" /> 

同时查看日志有：

```bash
ERRO[2025-03-04 22:21:28] /alist/internal/fs/fs.go:84 github.com/alist-org/alist/v3/internal/fs.Rename() failed rename /R2/c.app to e.app: InvalidArgument: copy source bucket name
	status code: 400, request id: , host id: 
github.com/alist-org/alist/v3/internal/op.Rename
	/Users/xiejiangzhao/alist/internal/op/fs.go:428
github.com/alist-org/alist/v3/internal/fs.rename
	/Users/xiejiangzhao/alist/internal/fs/other.go:40
github.com/alist-org/alist/v3/internal/fs.Rename
	/Users/xiejiangzhao/alist/internal/fs/fs.go:82
github.com/alist-org/alist/v3/server/handles.FsRename
	/Users/xiejiangzhao/alist/server/handles/fsmanage.go:188
github.com/gin-gonic/gin.(*Context).Next
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/context.go:185
github.com/alist-org/alist/v3/server/middlewares.Auth
	/Users/xiejiangzhao/alist/server/middlewares/auth.go:73
github.com/gin-gonic/gin.(*Context).Next
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/context.go:185
github.com/alist-org/alist/v3/server/middlewares.StoragesLoaded
	/Users/xiejiangzhao/alist/server/middlewares/check.go:14
github.com/gin-gonic/gin.(*Context).Next
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/context.go:185
github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/recovery.go:102
github.com/gin-gonic/gin.(*Context).Next
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/context.go:185
github.com/gin-gonic/gin.LoggerWithConfig.func1
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/logger.go:249
github.com/gin-gonic/gin.(*Context).Next
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/context.go:185
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/gin.go:633
github.com/gin-gonic/gin.(*Engine).ServeHTTP
	/Users/xiejiangzhao/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/gin.go:589
net/http.serverHandler.ServeHTTP
	/opt/homebrew/opt/go/libexec/src/net/http/server.go:3210
net/http.(*conn).serve
	/opt/homebrew/opt/go/libexec/src/net/http/server.go:2092
runtime.goexit
	/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223 
```

## 解决方案
跟进实际执行的逻辑，使用了s3 client的CopyObject接口，逻辑实现位于 `drivers/s3/util.go`的copyFile函数:
```go
func (d *S3) copyFile(ctx context.Context, src string, dst string) error {
	srcKey := getKey(src, false)
	dstKey := getKey(dst, false)
	input := &s3.CopyObjectInput{
		Bucket:     &d.Bucket,
		CopySource: aws.String(url.PathEscape("/" + d.Bucket + "/" + srcKey)),
		Key:        &dstKey,
	}
	_, err := d.client.CopyObject(input)
	return err
}
```

问题在于CopySource的参数值不应该在Bucket前面再添加斜杠，参考官方文档[https://docs.aws.amazon.com/code-library/latest/ug/go_2_s3_code_examples.html](https://docs.aws.amazon.com/code-library/latest/ug/go_2_s3_code_examples.html)同样没有在前面添加斜杠，而是`aws.String(fmt.Sprintf("%v/%v", sourceBucket, objectKey))`，对该行修改后重新启动后端，问题解决，并且在R2中验证正确：

<img width="949" alt="Snipaste_2025-03-04_22-24-45" src="https://github.com/user-attachments/assets/0b42edd1-b7f6-41a3-96e6-d48eeea1f074" />
