### PR TITLE
feat: support upload persist

### DIFF
--- a/internal/bootstrap/data/task.go
+++ b/internal/bootstrap/data/task.go
@@ -24,6 +24,7 @@ func InitialTasks() []model.TaskItem {
 		{Key: "copy", PersistData: "[]"},
 		{Key: "download", PersistData: "[]"},
 		{Key: "transfer", PersistData: "[]"},
+		{Key: "upload", PersistData: "[]"},
 	}
 	return initialTaskItems
 }

--- a/internal/bootstrap/task.go
+++ b/internal/bootstrap/task.go
@@ -18,7 +18,7 @@ func taskFilterNegative(num int) int64 {
 }
 
 func InitTaskManager() {
-	fs.UploadTaskManager = tache.NewManager[*fs.UploadTask](tache.WithWorks(setting.GetInt(conf.TaskUploadThreadsNum, conf.Conf.Tasks.Upload.Workers)), tache.WithMaxRetry(conf.Conf.Tasks.Upload.MaxRetry)) //upload will not support persist
+	fs.UploadTaskManager = tache.NewManager[*fs.UploadTask](tache.WithWorks(setting.GetInt(conf.TaskUploadThreadsNum, conf.Conf.Tasks.Upload.Workers)), tache.WithPersistFunction(db.GetTaskDataFunc("upload", conf.Conf.Tasks.Upload.TaskPersistant), db.UpdateTaskDataFunc("upload", conf.Conf.Tasks.Upload.TaskPersistant)), tache.WithMaxRetry(conf.Conf.Tasks.Upload.MaxRetry))
 	op.RegisterSettingChangingCallback(func() {
 		fs.UploadTaskManager.SetWorkersNumActive(taskFilterNegative(setting.GetInt(conf.TaskUploadThreadsNum, conf.Conf.Tasks.Upload.Workers)))
 	})

--- a/internal/fs/put.go
+++ b/internal/fs/put.go
@@ -16,12 +16,14 @@ import (
 type UploadTask struct {
 	task.TaskExtension
 	storage          driver.Driver
-	dstDirActualPath string
+	FileName         string `json:"file_name"`
+	DstStorageMp     string `json:"dst_storage_mp"`
+	DstDirActualPath string `json:"dst_dir_actual_path"`
 	file             model.FileStreamer
 }
 
 func (t *UploadTask) GetName() string {
-	return fmt.Sprintf("upload %s to [%s](%s)", t.file.GetName(), t.storage.GetStorage().MountPath, t.dstDirActualPath)
+	return fmt.Sprintf("upload %s to [%s](%s)", t.FileName, t.DstStorageMp, t.DstDirActualPath)
 }
 
 func (t *UploadTask) GetStatus() string {
@@ -32,7 +34,7 @@ func (t *UploadTask) Run() error {
 	t.ClearEndTime()
 	t.SetStartTime(time.Now())
 	defer func() { t.SetEndTime(time.Now()) }()
-	return op.Put(t.Ctx(), t.storage, t.dstDirActualPath, t.file, t.SetProgress, true)
+	return op.Put(t.Ctx(), t.storage, t.DstDirActualPath, t.file, t.SetProgress, true)
 }
 
 var UploadTaskManager *tache.Manager[*UploadTask]
@@ -60,7 +62,9 @@ func putAsTask(ctx context.Context, dstDirPath string, file model.FileStreamer) 
 			Creator: taskCreator,
 		},
 		storage:          storage,
-		dstDirActualPath: dstDirActualPath,
+		DstStorageMp:     storage.GetStorage().MountPath,
+		DstDirActualPath: dstDirActualPath,
+		FileName:         file.GetName(),
 		file:             file,
 	}
 	t.SetTotalBytes(file.GetSize())


### PR DESCRIPTION
## 目的
Fixes: #8145 解决上传任务没有持久化的问题，而这个在文档配置项中是支持的，从用户角度来看，持久化上传任务能快速在服务崩溃后重启时回顾之前的状态

## 修改内容

参考CopyTask的代码格式，新增了UploadTask的字段做持久化，测试状态正常，重启后上传任务仍存在

<img width="841" alt="image" src="https://github.com/user-attachments/assets/f352c1f9-6159-4832-bed1-cff8c2877652" />

