### PR TITLE
fix(sftp-server): postgre cannot store control characters

### DIFF
--- a/internal/op/sshkey.go
+++ b/internal/op/sshkey.go
@@ -17,7 +17,6 @@ func CreateSSHPublicKey(k *model.SSHPublicKey) (error, bool) {
 	if err != nil {
 		return err, false
 	}
-	k.KeyStr = string(pubKey.Marshal())
 	k.Fingerprint = ssh.FingerprintSHA256(pubKey)
 	k.AddedTime = time.Now()
 	k.LastUsedTime = k.AddedTime

--- a/server/handles/sshkey.go
+++ b/server/handles/sshkey.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alist-org/alist/v3/server/common"
 	"github.com/gin-gonic/gin"
 	"strconv"
+	"strings"
 )
 
 type SSHKeyAddReq struct {
@@ -30,7 +31,7 @@ func AddMyPublicKey(c *gin.Context) {
 	}
 	key := &model.SSHPublicKey{
 		Title:  req.Title,
-		KeyStr: req.Key,
+		KeyStr: strings.TrimSpace(req.Key),
 		UserId: userObj.ID,
 	}
 	err, parsed := op.CreateSSHPublicKey(key)


### PR DESCRIPTION
在数据库中存储原始 SSH 公钥，以解决 Postgre 无法存储 Marshal 后的公钥的问题。

Close #8186