### PR TITLE
fix(traffic): duplicate semaphore release when uploading

### DIFF
--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -520,9 +520,6 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		if utils.IsCanceled(upCtx) {
 			break
 		}
-		if err = sem.Acquire(ctx, 1); err != nil {
-			break
-		}
 		byteData := make([]byte, sliceSize)
 		if i == count {
 			byteData = byteData[:lastPartSize]
@@ -541,6 +538,9 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		partInfo := fmt.Sprintf("%d-%s", i, base64.StdEncoding.EncodeToString(md5Bytes))
 
 		threadG.Go(func(ctx context.Context) error {
+			if err = sem.Acquire(ctx, 1); err != nil {
+				return err
+			}
 			defer sem.Release(1)
 			uploadUrls, err := y.GetMultiUploadUrls(ctx, isFamily, initMultiUpload.Data.UploadFileID, partInfo)
 			if err != nil {

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -266,15 +266,15 @@ func (d *BaiduNetdisk) Put(ctx context.Context, dstDir model.Obj, stream model.F
 		if utils.IsCanceled(upCtx) {
 			break
 		}
-		if err = sem.Acquire(ctx, 1); err != nil {
-			break
-		}
 
 		i, partseq, offset, byteSize := i, partseq, int64(partseq)*sliceSize, sliceSize
 		if partseq+1 == count {
 			byteSize = lastBlockSize
 		}
 		threadG.Go(func(ctx context.Context) error {
+			if err = sem.Acquire(ctx, 1); err != nil {
+				return err
+			}
 			defer sem.Release(1)
 			params := map[string]string{
 				"method":       "upload",

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -321,9 +321,6 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 			if utils.IsCanceled(upCtx) {
 				break
 			}
-			if err = sem.Acquire(ctx, 1); err != nil {
-				break
-			}
 
 			i, partseq, offset, byteSize := i, partseq, int64(partseq)*DEFAULT, DEFAULT
 			if partseq+1 == count {
@@ -331,6 +328,9 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 			}
 
 			threadG.Go(func(ctx context.Context) error {
+				if err = sem.Acquire(ctx, 1); err != nil {
+					return err
+				}
 				defer sem.Release(1)
 				uploadParams := map[string]string{
 					"method":   "upload",


### PR DESCRIPTION
#7948 没有考虑到分片上传失败会重新执行上传函数，导致信号量因被获取一次释放多次而 panic。
现将获取信号量放到线程内部，不好的点是上传过程中可能会创建大量空等待的线程，但总比 panic 要好。errgroup 的 onRetry 回调函数看了看源代码感觉不是很好用。

Fix #8180