### PR TITLE
feat(alias): support writing to non-ambiguous paths

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -3,6 +3,7 @@ package alias
 import (
 	"context"
 	"errors"
+	stdpath "path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -126,8 +127,46 @@ func (d *Alias) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 	return nil, errs.ObjectNotFound
 }
 
+func (d *Alias) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	reqPath, err := d.getReqPath(ctx, parentDir, true)
+	if err == nil {
+		return fs.MakeDir(ctx, stdpath.Join(*reqPath, dirName))
+	}
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name dirs cannot make sub-dir")
+	}
+	return err
+}
+
+func (d *Alias) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	srcPath, err := d.getReqPath(ctx, srcObj, false)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name files cannot be moved")
+	}
+	if err != nil {
+		return err
+	}
+	dstPath, err := d.getReqPath(ctx, dstDir, true)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name dirs cannot be moved to")
+	}
+	if err != nil {
+		return err
+	}
+	return fs.Move(ctx, *srcPath, *dstPath)
+}
+
 func (d *Alias) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
-	reqPath, err := d.getReqPath(ctx, srcObj)
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	reqPath, err := d.getReqPath(ctx, srcObj, false)
 	if err == nil {
 		return fs.Rename(ctx, *reqPath, newName)
 	}
@@ -137,14 +176,137 @@ func (d *Alias) Rename(ctx context.Context, srcObj model.Obj, newName string) er
 	return err
 }
 
+func (d *Alias) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	srcPath, err := d.getReqPath(ctx, srcObj, false)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name files cannot be copied")
+	}
+	if err != nil {
+		return err
+	}
+	dstPath, err := d.getReqPath(ctx, dstDir, true)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name dirs cannot be copied to")
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fs.Copy(ctx, *srcPath, *dstPath)
+	return err
+}
+
 func (d *Alias) Remove(ctx context.Context, obj model.Obj) error {
-	reqPath, err := d.getReqPath(ctx, obj)
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	reqPath, err := d.getReqPath(ctx, obj, false)
 	if err == nil {
 		return fs.Remove(ctx, *reqPath)
 	}
 	if errs.IsNotImplement(err) {
 		return errors.New("same-name files cannot be Delete")
 	}
+	return err
+}
+
+func (d *Alias) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	reqPath, err := d.getReqPath(ctx, dstDir, true)
+	if err == nil {
+		return fs.PutDirectly(ctx, *reqPath, s)
+	}
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name dirs cannot be Put")
+	}
+	return err
+}
+
+func (d *Alias) PutURL(ctx context.Context, dstDir model.Obj, name, url string) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	reqPath, err := d.getReqPath(ctx, dstDir, true)
+	if err == nil {
+		return fs.PutURL(ctx, *reqPath, name, url)
+	}
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name files cannot offline download")
+	}
+	return err
+}
+
+func (d *Alias) GetArchiveMeta(ctx context.Context, obj model.Obj, args model.ArchiveArgs) (model.ArchiveMeta, error) {
+	root, sub := d.getRootAndPath(obj.GetPath())
+	dsts, ok := d.pathMap[root]
+	if !ok {
+		return nil, errs.ObjectNotFound
+	}
+	for _, dst := range dsts {
+		meta, err := d.getArchiveMeta(ctx, dst, sub, args)
+		if err == nil {
+			return meta, nil
+		}
+	}
+	return nil, errs.NotImplement
+}
+
+func (d *Alias) ListArchive(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) ([]model.Obj, error) {
+	root, sub := d.getRootAndPath(obj.GetPath())
+	dsts, ok := d.pathMap[root]
+	if !ok {
+		return nil, errs.ObjectNotFound
+	}
+	for _, dst := range dsts {
+		l, err := d.listArchive(ctx, dst, sub, args)
+		if err == nil {
+			return l, nil
+		}
+	}
+	return nil, errs.NotImplement
+}
+
+func (d *Alias) Extract(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) (*model.Link, error) {
+	// alias的两个驱动，一个支持驱动提取，一个不支持，如何兼容？
+	// 如果访问的是不支持驱动提取的驱动内的压缩文件，GetArchiveMeta就会返回errs.NotImplement，提取URL前缀就会是/ae，Extract就不会被调用
+	// 如果访问的是支持驱动提取的驱动内的压缩文件，GetArchiveMeta就会返回有效值，提取URL前缀就会是/ad，Extract就会被调用
+	root, sub := d.getRootAndPath(obj.GetPath())
+	dsts, ok := d.pathMap[root]
+	if !ok {
+		return nil, errs.ObjectNotFound
+	}
+	for _, dst := range dsts {
+		l, err := d.extract(ctx, dst, sub, args)
+		if err == nil {
+			return l, nil
+		}
+	}
+	return nil, errs.NotImplement
+}
+
+func (d *Alias) ArchiveDecompress(ctx context.Context, srcObj, dstDir model.Obj, args model.ArchiveDecompressArgs) error {
+	if !d.Writable {
+		return errs.PermissionDenied
+	}
+	srcPath, err := d.getReqPath(ctx, srcObj, false)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name files cannot be decompressed")
+	}
+	if err != nil {
+		return err
+	}
+	dstPath, err := d.getReqPath(ctx, dstDir, true)
+	if errs.IsNotImplement(err) {
+		return errors.New("same-name dirs cannot be decompressed to")
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fs.ArchiveDecompress(ctx, *srcPath, *dstPath, args)
 	return err
 }
 

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -280,9 +280,17 @@ func (d *Alias) Extract(ctx context.Context, obj model.Obj, args model.ArchiveIn
 		return nil, errs.ObjectNotFound
 	}
 	for _, dst := range dsts {
-		l, err := d.extract(ctx, dst, sub, args)
+		link, err := d.extract(ctx, dst, sub, args)
 		if err == nil {
-			return l, nil
+			if !args.Redirect && len(link.URL) > 0 {
+				if d.DownloadConcurrency > 0 {
+					link.Concurrency = d.DownloadConcurrency
+				}
+				if d.DownloadPartSize > 0 {
+					link.PartSize = d.DownloadPartSize * utils.KB
+				}
+			}
+			return link, nil
 		}
 	}
 	return nil, errs.NotImplement

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -13,13 +13,14 @@ type Addition struct {
 	ProtectSameName     bool   `json:"protect_same_name" default:"true" required:"false" help:"Protects same-name files from Delete or Rename"`
 	DownloadConcurrency int    `json:"download_concurrency" default:"0" required:"false" type:"number" help:"Need to enable proxy"`
 	DownloadPartSize    int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
+	Writable            bool   `json:"writable" type:"bool" default:"false"`
 }
 
 var config = driver.Config{
 	Name:             "Alias",
 	LocalSort:        true,
 	NoCache:          true,
-	NoUpload:         true,
+	NoUpload:         false,
 	DefaultRoot:      "/",
 	ProxyRangeOption: true,
 }

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -6,6 +6,7 @@ import (
 	stdpath "path"
 	"strings"
 
+	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -125,9 +126,9 @@ func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) 
 	return link, err
 }
 
-func (d *Alias) getReqPath(ctx context.Context, obj model.Obj) (*string, error) {
+func (d *Alias) getReqPath(ctx context.Context, obj model.Obj, isParent bool) (*string, error) {
 	root, sub := d.getRootAndPath(obj.GetPath())
-	if sub == "" {
+	if sub == "" && !isParent {
 		return nil, errs.NotSupport
 	}
 	dsts, ok := d.pathMap[root]
@@ -155,4 +156,68 @@ func (d *Alias) getReqPath(ctx context.Context, obj model.Obj) (*string, error) 
 		return nil, errs.ObjectNotFound
 	}
 	return reqPath, nil
+}
+
+func (d *Alias) getArchiveMeta(ctx context.Context, dst, sub string, args model.ArchiveArgs) (model.ArchiveMeta, error) {
+	reqPath := stdpath.Join(dst, sub)
+	storage, reqActualPath, err := op.GetStorageAndActualPath(reqPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := storage.(driver.ArchiveReader); ok {
+		return op.GetArchiveMeta(ctx, storage, reqActualPath, model.ArchiveMetaArgs{
+			ArchiveArgs: args,
+			Refresh:     true,
+		})
+	}
+	return nil, errs.NotImplement
+}
+
+func (d *Alias) listArchive(ctx context.Context, dst, sub string, args model.ArchiveInnerArgs) ([]model.Obj, error) {
+	reqPath := stdpath.Join(dst, sub)
+	storage, reqActualPath, err := op.GetStorageAndActualPath(reqPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := storage.(driver.ArchiveReader); ok {
+		return op.ListArchive(ctx, storage, reqActualPath, model.ArchiveListArgs{
+			ArchiveInnerArgs: args,
+			Refresh:          true,
+		})
+	}
+	return nil, errs.NotImplement
+}
+
+func (d *Alias) extract(ctx context.Context, dst, sub string, args model.ArchiveInnerArgs) (*model.Link, error) {
+	reqPath := stdpath.Join(dst, sub)
+	storage, reqActualPath, err := op.GetStorageAndActualPath(reqPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := storage.(driver.ArchiveReader); ok {
+		if _, ok := storage.(*Alias); !ok && !args.Redirect {
+			link, _, err := op.DriverExtract(ctx, storage, reqActualPath, args)
+			return link, err
+		}
+		_, err = fs.Get(ctx, reqPath, &fs.GetArgs{NoLog: true})
+		if err != nil {
+			return nil, err
+		}
+		if common.ShouldProxy(storage, stdpath.Base(sub)) {
+			link := &model.Link{
+				URL: fmt.Sprintf("%s/ap%s?inner=%s&sign=%s",
+					common.GetApiUrl(args.HttpReq),
+					utils.EncodePath(reqPath, true),
+					utils.EncodePath(args.InnerPath, true),
+					sign.SignArchive(reqPath)),
+			}
+			if args.HttpReq != nil && d.ProxyRange {
+				link.RangeReadCloser = common.NoProxyRange
+			}
+			return link, nil
+		}
+		link, _, err := op.DriverExtract(ctx, storage, reqActualPath, args)
+		return link, err
+	}
+	return nil, errs.NotImplement
 }

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -3,6 +3,7 @@ package alias
 import (
 	"context"
 	"fmt"
+	"net/url"
 	stdpath "path"
 	"strings"
 
@@ -205,10 +206,11 @@ func (d *Alias) extract(ctx context.Context, dst, sub string, args model.Archive
 		}
 		if common.ShouldProxy(storage, stdpath.Base(sub)) {
 			link := &model.Link{
-				URL: fmt.Sprintf("%s/ap%s?inner=%s&sign=%s",
+				URL: fmt.Sprintf("%s/ap%s?inner=%s&pass=%s&sign=%s",
 					common.GetApiUrl(args.HttpReq),
 					utils.EncodePath(reqPath, true),
 					utils.EncodePath(args.InnerPath, true),
+					url.QueryEscape(args.Password),
 					sign.SignArchive(reqPath)),
 			}
 			if args.HttpReq != nil && d.ProxyRange {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2,12 +2,15 @@ package fs
 
 import (
 	"context"
+	log "github.com/sirupsen/logrus"
+	"io"
+
 	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/internal/task"
-	log "github.com/sirupsen/logrus"
-	"io"
+	"github.com/pkg/errors"
 )
 
 // the param named path of functions in this package is a mount path
@@ -167,4 +170,20 @@ func Other(ctx context.Context, args model.FsOtherArgs) (interface{}, error) {
 		log.Errorf("failed remove %s: %+v", args.Path, err)
 	}
 	return res, err
+}
+
+func PutURL(ctx context.Context, path, dstName, urlStr string) error {
+	storage, dstDirActualPath, err := op.GetStorageAndActualPath(path)
+	if err != nil {
+		return errors.WithMessage(err, "failed get storage")
+	}
+	if storage.Config().NoUpload {
+		return errors.WithStack(errs.UploadNotSupported)
+	}
+	_, ok := storage.(driver.PutURL)
+	_, okResult := storage.(driver.PutURLResult)
+	if !ok && !okResult {
+		return errs.NotImplement
+	}
+	return op.PutURL(ctx, storage, dstDirActualPath, dstName, urlStr)
 }

--- a/internal/op/archive.go
+++ b/internal/op/archive.go
@@ -84,7 +84,7 @@ func getArchiveMeta(ctx context.Context, storage driver.Driver, path string, arg
 		meta, err := storageAr.GetArchiveMeta(ctx, obj, args.ArchiveArgs)
 		if !errors.Is(err, errs.NotImplement) {
 			archiveMetaProvider := &model.ArchiveMetaProvider{ArchiveMeta: meta, DriverProviding: true}
-			if meta.GetTree() != nil {
+			if meta != nil && meta.GetTree() != nil {
 				archiveMetaProvider.Sort = &storage.GetStorage().Sort
 			}
 			if !storage.Config().NoCache {


### PR DESCRIPTION
别名驱动支持所有不冲突路径的写入操作。

举例说明：假设 A，B 两驱动的内容如下：
```
A
└ dir1
  ├ file1
  ├ file2
  └ dir2

B
├ dir1
│ └ file1
└ dir3
```
现将它们引入到一个别名驱动内，**打开别名驱动的“可写”和“同名保护”两个选项**，则
- `/dir1`下不可以上传文件、创建文件夹，也不能作为驱动内复制、移动、解压操作的目标文件夹（以下称“写入操作”），因为 A、B 两驱动都有路径`/dir1`，不能确定在此处进行写入操作时应该写入到哪个驱动。
- `/`下不可以进行写入操作，原因同上， A、B 两驱动都有根目录`/`。
- `/dir1/dir2`下可以进行写入操作，因为只有驱动 A 有文件夹`dir2`，在此处写入不存在歧义，如果手动在驱动 B 的文件夹`dir1`下创建文件夹`dir2`，则`/dir1/dir2`会重新变得不可写入。
- `/dir3`下可以进行写入操作，原因同上。
- `/dir1/file1`不可以作为驱动内复制、移动、解压操作的源文件，也不可以删除或重命名，因为不能确定进行操作的文件来自哪个驱动。
- `/dir1`不可以被复制、移动、解压、删除、重命名，原因同上。
- `/dir1/file2`可以被复制、移动、解压、删除、重命名（请注意，此处对删除和重命名操作的支持并不来源于这个 PR，而是来源于 #6478），因为对其操作是无歧义的。

对于不展开用法，例如如下配置：
```
a:驱动1路径
a:驱动2路径
b:驱动3路径
```
则
- `/`目录不可写
- `/a`目录不可写，原因与展开用法的`/`不可写一致
- `/b`目录可以作为驱动内复制、移动、解压操作的目标文件夹，可以上传子文件和创建子文件夹，但不可以被复制、移动、删除、重命名

关闭“同名保护”时，所有冲突操作优先对排序在上的驱动进行，这种用法的稳定性未知，不建议这么使用。

alias 驱动新加入配置选项“可写”，只有打开时这个 PR 提供的特性才会发生作用，此外，原 #6478 提供的特性现在也必须打开“可写”才能使用。