### PR TITLE
perf: optimize IO read/write usage

### DIFF
--- a/drivers/115/driver.go
+++ b/drivers/115/driver.go
@@ -8,6 +8,7 @@ import (
 	driver115 "github.com/SheltonZhu/115driver/pkg/driver"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/pkg/errors"
@@ -149,7 +150,7 @@ func (d *Pan115) Remove(ctx context.Context, obj model.Obj) error {
 	return d.client.Delete(obj.GetID())
 }
 
-func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
 	if err := d.WaitLimit(ctx); err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	if ok, err := d.client.UploadAvailable(); err != nil || !ok {
 		return nil, err
 	}
-	if stream.GetSize() > d.client.UploadMetaInfo.SizeLimit {
+	if s.GetSize() > d.client.UploadMetaInfo.SizeLimit {
 		return nil, driver115.ErrUploadTooLarge
 	}
 	//if digest, err = d.client.GetDigestResult(stream); err != nil {
@@ -171,10 +172,10 @@ func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 
 	const PreHashSize int64 = 128 * utils.KB
 	hashSize := PreHashSize
-	if stream.GetSize() < PreHashSize {
-		hashSize = stream.GetSize()
+	if s.GetSize() < PreHashSize {
+		hashSize = s.GetSize()
 	}
-	reader, err := stream.RangeRead(http_range.Range{Start: 0, Length: hashSize})
+	reader, err := s.RangeRead(http_range.Range{Start: 0, Length: hashSize})
 	if err != nil {
 		return nil, err
 	}
@@ -183,13 +184,9 @@ func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		return nil, err
 	}
 	preHash = strings.ToUpper(preHash)
-	fullHash := stream.GetHash().GetHash(utils.SHA1)
-	if len(fullHash) <= 0 {
-		tmpF, err := stream.CacheFullInTempFile()
-		if err != nil {
-			return nil, err
-		}
-		fullHash, err = utils.HashFile(utils.SHA1, tmpF)
+	fullHash := s.GetHash().GetHash(utils.SHA1)
+	if len(fullHash) != utils.SHA1.Width {
+		_, fullHash, err = stream.CacheFullInTempFileAndHash(s, utils.SHA1)
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +196,7 @@ func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	// rapid-upload
 	// note that 115 add timeout for rapid-upload,
 	// and "sig invalid" err is thrown even when the hash is correct after timeout.
-	if fastInfo, err = d.rapidUpload(stream.GetSize(), stream.GetName(), dirID, preHash, fullHash, stream); err != nil {
+	if fastInfo, err = d.rapidUpload(s.GetSize(), s.GetName(), dirID, preHash, fullHash, s); err != nil {
 		return nil, err
 	}
 	if matched, err := fastInfo.Ok(); err != nil {
@@ -214,13 +211,13 @@ func (d *Pan115) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 
 	var uploadResult *UploadResult
 	// 闪传失败，上传
-	if stream.GetSize() <= 10*utils.MB { // 文件大小小于10MB，改用普通模式上传
-		if uploadResult, err = d.UploadByOSS(ctx, &fastInfo.UploadOSSParams, stream, dirID, up); err != nil {
+	if s.GetSize() <= 10*utils.MB { // 文件大小小于10MB，改用普通模式上传
+		if uploadResult, err = d.UploadByOSS(ctx, &fastInfo.UploadOSSParams, s, dirID, up); err != nil {
 			return nil, err
 		}
 	} else {
 		// 分片上传
-		if uploadResult, err = d.UploadByMultipart(ctx, &fastInfo.UploadOSSParams, stream.GetSize(), stream, dirID, up); err != nil {
+		if uploadResult, err = d.UploadByMultipart(ctx, &fastInfo.UploadOSSParams, s.GetSize(), s, dirID, up); err != nil {
 			return nil, err
 		}
 	}

--- a/drivers/115_open/driver.go
+++ b/drivers/115_open/driver.go
@@ -185,26 +185,26 @@ func (d *Open115) Remove(ctx context.Context, obj model.Obj) error {
 	return nil
 }
 
-func (d *Open115) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
+func (d *Open115) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
 	// cal full sha1
-	sha1 := s.GetHash().GetHash(utils.SHA1)
+	sha1 := file.GetHash().GetHash(utils.SHA1)
 	var tempF model.File
 	var err error
 	if len(sha1) != utils.SHA1.Width {
-		tempF, sha1, err = stream.CacheFullInTempFileAndHash(s, utils.SHA1)
+		tempF, sha1, err = stream.CacheFullInTempFileAndHash(file, utils.SHA1)
 		if err != nil {
 			return err
 		}
 	} else {
-		tempF, err = s.CacheFullInTempFile()
+		tempF, err = file.CacheFullInTempFile()
 		if err != nil {
 			return err
 		}
 	}
 	// pre 128k sha1
 	const PreHashSize int64 = 128 * utils.KB
-	hashSize := min(s.GetSize(), PreHashSize)
-	reader, err := s.RangeRead(http_range.Range{Start: 0, Length: hashSize})
+	hashSize := min(file.GetSize(), PreHashSize)
+	reader, err := file.RangeRead(http_range.Range{Start: 0, Length: hashSize})
 	if err != nil {
 		return err
 	}
@@ -214,8 +214,8 @@ func (d *Open115) Put(ctx context.Context, dstDir model.Obj, s model.FileStreame
 	}
 	// 1. Init
 	resp, err := d.client.UploadInit(ctx, &sdk.UploadInitReq{
-		FileName: s.GetName(),
-		FileSize: s.GetSize(),
+		FileName: file.GetName(),
+		FileSize: file.GetSize(),
 		Target:   dstDir.GetID(),
 		FileID:   strings.ToUpper(sha1),
 		PreID:    strings.ToUpper(sha1128k),
@@ -250,8 +250,8 @@ func (d *Open115) Put(ctx context.Context, dstDir model.Obj, s model.FileStreame
 			return err
 		}
 		resp, err = d.client.UploadInit(ctx, &sdk.UploadInitReq{
-			FileName: s.GetName(),
-			FileSize: s.GetSize(),
+			FileName: file.GetName(),
+			FileSize: file.GetSize(),
 			Target:   dstDir.GetID(),
 			FileID:   strings.ToUpper(sha1),
 			PreID:    strings.ToUpper(sha1128k),

--- a/drivers/115_open/driver.go
+++ b/drivers/115_open/driver.go
@@ -15,6 +15,8 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	sdk "github.com/xhofe/115-sdk-go"
@@ -183,33 +185,37 @@ func (d *Open115) Remove(ctx context.Context, obj model.Obj) error {
 	return nil
 }
 
-func (d *Open115) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
-	tempF, err := file.CacheFullInTempFile()
-	if err != nil {
-		return err
-	}
+func (d *Open115) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
 	// cal full sha1
-	sha1, err := utils.HashReader(utils.SHA1, tempF)
-	if err != nil {
-		return err
-	}
-	_, err = tempF.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
+	sha1 := s.GetHash().GetHash(utils.SHA1)
+	var tempF model.File
+	var err error
+	if len(sha1) != utils.SHA1.Width {
+		tempF, sha1, err = stream.CacheFullInTempFileAndHash(s, utils.SHA1)
+		if err != nil {
+			return err
+		}
+	} else {
+		tempF, err = s.CacheFullInTempFile()
+		if err != nil {
+			return err
+		}
 	}
 	// pre 128k sha1
-	sha1128k, err := utils.HashReader(utils.SHA1, io.LimitReader(tempF, 128*1024))
+	const PreHashSize int64 = 128 * utils.KB
+	hashSize := min(s.GetSize(), PreHashSize)
+	reader, err := s.RangeRead(http_range.Range{Start: 0, Length: hashSize})
 	if err != nil {
 		return err
 	}
-	_, err = tempF.Seek(0, io.SeekStart)
+	sha1128k, err := utils.HashReader(utils.SHA1, reader)
 	if err != nil {
 		return err
 	}
 	// 1. Init
 	resp, err := d.client.UploadInit(ctx, &sdk.UploadInitReq{
-		FileName: file.GetName(),
-		FileSize: file.GetSize(),
+		FileName: s.GetName(),
+		FileSize: s.GetSize(),
 		Target:   dstDir.GetID(),
 		FileID:   strings.ToUpper(sha1),
 		PreID:    strings.ToUpper(sha1128k),
@@ -244,8 +250,8 @@ func (d *Open115) Put(ctx context.Context, dstDir model.Obj, file model.FileStre
 			return err
 		}
 		resp, err = d.client.UploadInit(ctx, &sdk.UploadInitReq{
-			FileName: file.GetName(),
-			FileSize: file.GetSize(),
+			FileName: s.GetName(),
+			FileSize: s.GetSize(),
 			Target:   dstDir.GetID(),
 			FileID:   strings.ToUpper(sha1),
 			PreID:    strings.ToUpper(sha1128k),

--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -2,11 +2,8 @@ package _123
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -18,6 +15,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -187,25 +185,12 @@ func (d *Pan123) Remove(ctx context.Context, obj model.Obj) error {
 
 func (d *Pan123) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
 	etag := file.GetHash().GetHash(utils.MD5)
-	if len(etag) < utils.MD5.Width {
-		// const DEFAULT int64 = 10485760
-		h := md5.New()
-		// need to calculate md5 of the full content
-		tempFile, err := file.CacheFullInTempFile()
+	var err error
+	if len(etag) != utils.MD5.Width {
+		_, etag, err = stream.CacheFullInTempFileAndHash(file, utils.MD5)
 		if err != nil {
 			return err
 		}
-		defer func() {
-			_ = tempFile.Close()
-		}()
-		if _, err = utils.CopyWithBuffer(h, tempFile); err != nil {
-			return err
-		}
-		_, err = tempFile.Seek(0, io.SeekStart)
-		if err != nil {
-			return err
-		}
-		etag = hex.EncodeToString(h.Sum(nil))
 	}
 	data := base.Json{
 		"driveId":      0,

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -2,13 +2,11 @@ package _139
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -72,28 +70,29 @@ func (d *Yun139) Init(ctx context.Context) error {
 	default:
 		return errs.NotImplement
 	}
-	if d.ref != nil {
-		return nil
-	}
-	decode, err := base64.StdEncoding.DecodeString(d.Authorization)
-	if err != nil {
-		return err
-	}
-	decodeStr := string(decode)
-	splits := strings.Split(decodeStr, ":")
-	if len(splits) < 2 {
-		return fmt.Errorf("authorization is invalid, splits < 2")
-	}
-	d.Account = splits[1]
-	_, err = d.post("/orchestration/personalCloud/user/v1.0/qryUserExternInfo", base.Json{
-		"qryUserExternInfoReq": base.Json{
-			"commonAccountInfo": base.Json{
-				"account":     d.getAccount(),
-				"accountType": 1,
-			},
-		},
-	}, nil)
-	return err
+	// if d.ref != nil {
+	// 	return nil
+	// }
+	// decode, err := base64.StdEncoding.DecodeString(d.Authorization)
+	// if err != nil {
+	// 	return err
+	// }
+	// decodeStr := string(decode)
+	// splits := strings.Split(decodeStr, ":")
+	// if len(splits) < 2 {
+	// 	return fmt.Errorf("authorization is invalid, splits < 2")
+	// }
+	// d.Account = splits[1]
+	// _, err = d.post("/orchestration/personalCloud/user/v1.0/qryUserExternInfo", base.Json{
+	// 	"qryUserExternInfoReq": base.Json{
+	// 		"commonAccountInfo": base.Json{
+	// 			"account":     d.getAccount(),
+	// 			"accountType": 1,
+	// 		},
+	// 	},
+	// }, nil)
+	// return err
+	return nil
 }
 
 func (d *Yun139) InitReference(storage driver.Driver) error {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/stream"
+	streamPkg "github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/cron"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/alist-org/alist/v3/pkg/utils/random"
@@ -522,21 +522,21 @@ func (d *Yun139) getPartSize(size int64) int64 {
 	return 100 * MB
 }
 
-func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
+func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
 	switch d.Addition.Type {
 	case MetaPersonalNew:
 		var err error
-		fullHash := s.GetHash().GetHash(utils.SHA256)
+		fullHash := stream.GetHash().GetHash(utils.SHA256)
 		if len(fullHash) != utils.SHA256.Width {
-			_, fullHash, err = stream.CacheFullInTempFileAndHash(s, utils.SHA256)
+			_, fullHash, err = streamPkg.CacheFullInTempFileAndHash(stream, utils.SHA256)
 			if err != nil {
 				return err
 			}
 		}
 
 		partInfos := []PartInfo{}
-		var partSize = d.getPartSize(s.GetSize())
-		part := (s.GetSize() + partSize - 1) / partSize
+		var partSize = d.getPartSize(stream.GetSize())
+		part := (stream.GetSize() + partSize - 1) / partSize
 		if part == 0 {
 			part = 1
 		}
@@ -545,7 +545,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 				return ctx.Err()
 			}
 			start := i * partSize
-			byteSize := s.GetSize() - start
+			byteSize := stream.GetSize() - start
 			if byteSize > partSize {
 				byteSize = partSize
 			}
@@ -573,9 +573,9 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			"contentType":          "application/octet-stream",
 			"parallelUpload":       false,
 			"partInfos":            firstPartInfos,
-			"size":                 s.GetSize(),
+			"size":                 stream.GetSize(),
 			"parentFileId":         dstDir.GetID(),
-			"name":                 s.GetName(),
+			"name":                 stream.GetName(),
 			"type":                 "file",
 			"fileRenameMode":       "auto_rename",
 		}
@@ -626,9 +626,9 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			}
 
 			// Progress
-			p := driver.NewProgress(s.GetSize(), up)
+			p := driver.NewProgress(stream.GetSize(), up)
 
-			rateLimited := driver.NewLimitedUploadStream(ctx, s)
+			rateLimited := driver.NewLimitedUploadStream(ctx, stream)
 			// 上传所有分片
 			for _, uploadPartInfo := range uploadPartInfos {
 				index := uploadPartInfo.PartNumber - 1
@@ -674,8 +674,8 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 		}
 
 		// 处理冲突
-		if resp.Data.FileName != s.GetName() {
-			log.Debugf("[139] conflict detected: %s != %s", resp.Data.FileName, s.GetName())
+		if resp.Data.FileName != stream.GetName() {
+			log.Debugf("[139] conflict detected: %s != %s", resp.Data.FileName, stream.GetName())
 			// 给服务器一定时间处理数据，避免无法刷新文件列表
 			time.Sleep(time.Millisecond * 500)
 			// 刷新并获取文件列表
@@ -685,10 +685,10 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			}
 			// 删除旧文件
 			for _, file := range files {
-				if file.GetName() == s.GetName() {
+				if file.GetName() == stream.GetName() {
 					log.Debugf("[139] conflict: removing old: %s", file.GetName())
 					// 删除前重命名旧文件，避免仍旧冲突
-					err = d.Rename(ctx, file, s.GetName()+random.String(4))
+					err = d.Rename(ctx, file, stream.GetName()+random.String(4))
 					if err != nil {
 						return err
 					}
@@ -702,8 +702,8 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			// 重命名新文件
 			for _, file := range files {
 				if file.GetName() == resp.Data.FileName {
-					log.Debugf("[139] conflict: renaming new: %s => %s", file.GetName(), s.GetName())
-					err = d.Rename(ctx, file, s.GetName())
+					log.Debugf("[139] conflict: renaming new: %s => %s", file.GetName(), stream.GetName())
+					err = d.Rename(ctx, file, stream.GetName())
 					if err != nil {
 						return err
 					}
@@ -723,10 +723,10 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 		}
 		// 删除旧文件
 		for _, file := range files {
-			if file.GetName() == s.GetName() {
+			if file.GetName() == stream.GetName() {
 				log.Debugf("[139] conflict: removing old: %s", file.GetName())
 				// 删除前重命名旧文件，避免仍旧冲突
-				err = d.Rename(ctx, file, s.GetName()+random.String(4))
+				err = d.Rename(ctx, file, stream.GetName()+random.String(4))
 				if err != nil {
 					return err
 				}
@@ -743,7 +743,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			"fileCount":    1,
 			"totalSize":    0, // 去除上传大小限制
 			"uploadContentList": []base.Json{{
-				"contentName": s.GetName(),
+				"contentName": stream.GetName(),
 				"contentSize": 0, // 去除上传大小限制
 				// "digest": "5a3231986ce7a6b46e408612d385bafa"
 			}},
@@ -764,7 +764,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 				"seqNo":        random.String(32), //序列号不能为空
 				"totalSize":    0,
 				"uploadContentList": []base.Json{{
-					"contentName": s.GetName(),
+					"contentName": stream.GetName(),
 					"contentSize": 0,
 					// "digest": "5a3231986ce7a6b46e408612d385bafa"
 				}},
@@ -778,21 +778,21 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 		}
 
 		// Progress
-		p := driver.NewProgress(s.GetSize(), up)
+		p := driver.NewProgress(stream.GetSize(), up)
 
-		var partSize = d.getPartSize(s.GetSize())
-		part := (s.GetSize() + partSize - 1) / partSize
+		var partSize = d.getPartSize(stream.GetSize())
+		part := (stream.GetSize() + partSize - 1) / partSize
 		if part == 0 {
 			part = 1
 		}
-		rateLimited := driver.NewLimitedUploadStream(ctx, s)
+		rateLimited := driver.NewLimitedUploadStream(ctx, stream)
 		for i := int64(0); i < part; i++ {
 			if utils.IsCanceled(ctx) {
 				return ctx.Err()
 			}
 
 			start := i * partSize
-			byteSize := s.GetSize() - start
+			byteSize := stream.GetSize() - start
 			if byteSize > partSize {
 				byteSize = partSize
 			}
@@ -806,8 +806,8 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 			}
 
 			req = req.WithContext(ctx)
-			req.Header.Set("Content-Type", "text/plain;name="+unicode(s.GetName()))
-			req.Header.Set("contentSize", strconv.FormatInt(s.GetSize(), 10))
+			req.Header.Set("Content-Type", "text/plain;name="+unicode(stream.GetName()))
+			req.Header.Set("contentSize", strconv.FormatInt(stream.GetSize(), 10))
 			req.Header.Set("range", fmt.Sprintf("bytes=%d-%d", start, start+byteSize-1))
 			req.Header.Set("uploadtaskID", resp.Data.UploadResult.UploadTaskID)
 			req.Header.Set("rangeType", "0")

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -75,6 +75,7 @@ func (d *Yun139) refreshToken() error {
 	if err != nil {
 		return fmt.Errorf("authorization is invalid")
 	}
+	d.Account = splits[1]
 	expiration -= time.Now().UnixMilli()
 	if expiration > 1000*60*60*24*15 {
 		// Authorization有效期大于15天无需刷新

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -525,7 +525,7 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 			break
 		}
 		byteData := make([]byte, sliceSize)
-		if i == count {
+		if i == count && lastSliceSize > 0 {
 			byteData = byteData[:lastSliceSize]
 		}
 
@@ -632,6 +632,8 @@ func (y *Cloud189PC) FastUpload(ctx context.Context, dstDir model.Obj, file mode
 	lastSliceSize := size % sliceSize
 	if lastSliceSize > 0 {
 		count++
+	} else {
+		lastSliceSize = sliceSize
 	}
 
 	//step.1 优先计算所需信息

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -3,16 +3,15 @@ package _189pc
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/internal/setting"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/errgroup"
 	"github.com/alist-org/alist/v3/pkg/utils"
 
@@ -473,12 +473,8 @@ func (y *Cloud189PC) refreshSession() (err error) {
 // 普通上传
 // 无法上传大小为0的文件
 func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress, isFamily bool, overwrite bool) (model.Obj, error) {
-	var sliceSize = partSize(file.GetSize())
-	count := int(math.Ceil(float64(file.GetSize()) / float64(sliceSize)))
-	lastPartSize := file.GetSize() % sliceSize
-	if file.GetSize() > 0 && lastPartSize == 0 {
-		lastPartSize = sliceSize
-	}
+	size := file.GetSize()
+	sliceSize := partSize(size)
 
 	params := Params{
 		"parentFolderId": dstDir.GetID(),
@@ -512,8 +508,13 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		retry.DelayType(retry.BackOffDelay))
 	sem := semaphore.NewWeighted(3)
 
-	fileMd5 := md5.New()
-	silceMd5 := md5.New()
+	count := int(size / sliceSize)
+	lastSliceSize := size % sliceSize
+	if lastSliceSize > 0 {
+		count++
+	}
+	fileMd5 := utils.MD5.NewFunc()
+	silceMd5 := utils.MD5.NewFunc()
 	silceMd5Hexs := make([]string, 0, count)
 
 	for i := 1; i <= count; i++ {
@@ -525,7 +526,7 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		}
 		byteData := make([]byte, sliceSize)
 		if i == count {
-			byteData = byteData[:lastPartSize]
+			byteData = byteData[:lastSliceSize]
 		}
 
 		// 读取块
@@ -607,24 +608,37 @@ func (y *Cloud189PC) RapidUpload(ctx context.Context, dstDir model.Obj, stream m
 
 // 快传
 func (y *Cloud189PC) FastUpload(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress, isFamily bool, overwrite bool) (model.Obj, error) {
-	tempFile, err := file.CacheFullInTempFile()
-	if err != nil {
-		return nil, err
+	var readerAt io.ReaderAt = file.GetCache()
+	var (
+		tmpF *os.File
+		err  error
+	)
+	writers := make([]io.Writer, 0, 3)
+	size := file.GetSize()
+	if _, ok := readerAt.(*os.File); !ok && size > 0 {
+		tmpF, err = os.CreateTemp(conf.Conf.TempDir, "file-*")
+		if err != nil {
+			return nil, err
+		}
+		writers = append(writers, tmpF)
+		readerAt = tmpF
 	}
-
-	var sliceSize = partSize(file.GetSize())
-	count := int(math.Ceil(float64(file.GetSize()) / float64(sliceSize)))
-	lastSliceSize := file.GetSize() % sliceSize
-	if file.GetSize() > 0 && lastSliceSize == 0 {
-		lastSliceSize = sliceSize
+	sliceSize := partSize(size)
+	count := int(size / sliceSize)
+	lastSliceSize := size % sliceSize
+	if lastSliceSize > 0 {
+		count++
 	}
 
 	//step.1 优先计算所需信息
 	byteSize := sliceSize
-	fileMd5 := md5.New()
-	silceMd5 := md5.New()
+	fileMd5 := utils.MD5.NewFunc()
+	silceMd5 := utils.MD5.NewFunc()
 	silceMd5Hexs := make([]string, 0, count)
 	partInfos := make([]string, 0, count)
+	writers = append(writers, fileMd5, silceMd5)
+	written := int64(0)
+	var w io.Writer
 	for i := 1; i <= count; i++ {
 		if utils.IsCanceled(ctx) {
 			return nil, ctx.Err()
@@ -634,18 +648,39 @@ func (y *Cloud189PC) FastUpload(ctx context.Context, dstDir model.Obj, file mode
 			byteSize = lastSliceSize
 		}
 
-		silceMd5.Reset()
-		if _, err := utils.CopyWithBufferN(io.MultiWriter(fileMd5, silceMd5), tempFile, byteSize); err != nil && err != io.EOF {
+		if w == nil {
+			w = io.MultiWriter(writers...)
+		}
+		n, err := utils.CopyWithBufferN(w, file, byteSize)
+		written += n
+		if err != nil && err != io.EOF {
+			if tmpF != nil {
+				_ = os.Remove(tmpF.Name())
+			}
 			return nil, err
 		}
 		md5Byte := silceMd5.Sum(nil)
 		silceMd5Hexs = append(silceMd5Hexs, strings.ToUpper(hex.EncodeToString(md5Byte)))
 		partInfos = append(partInfos, fmt.Sprint(i, "-", base64.StdEncoding.EncodeToString(md5Byte)))
+		silceMd5.Reset()
+	}
+
+	if tmpF != nil {
+		if size > 0 && written != size {
+			_ = os.Remove(tmpF.Name())
+			return nil, errs.NewErr(err, "CreateTempFile failed, incoming stream actual size= %d, expect = %d ", written, size)
+		}
+		_, err = tmpF.Seek(0, io.SeekStart)
+		if err != nil {
+			_ = os.Remove(tmpF.Name())
+			return nil, errs.NewErr(err, "CreateTempFile failed, can't seek to 0 ")
+		}
+		file.SetTmpFile(tmpF)
 	}
 
 	fileMd5Hex := strings.ToUpper(hex.EncodeToString(fileMd5.Sum(nil)))
 	sliceMd5Hex := fileMd5Hex
-	if file.GetSize() > sliceSize {
+	if size > sliceSize {
 		sliceMd5Hex = strings.ToUpper(utils.GetMD5EncodeStr(strings.Join(silceMd5Hexs, "\n")))
 	}
 
@@ -712,7 +747,7 @@ func (y *Cloud189PC) FastUpload(ctx context.Context, dstDir model.Obj, file mode
 				}
 
 				// step.4 上传切片
-				_, err = y.put(ctx, uploadUrl.RequestURL, uploadUrl.Headers, false, io.NewSectionReader(tempFile, offset, byteSize), isFamily)
+				_, err = y.put(ctx, uploadUrl.RequestURL, uploadUrl.Headers, false, io.NewSectionReader(readerAt, offset, byteSize), isFamily)
 				if err != nil {
 					return err
 				}
@@ -794,11 +829,7 @@ func (y *Cloud189PC) GetMultiUploadUrls(ctx context.Context, isFamily bool, uplo
 
 // 旧版本上传，家庭云不支持覆盖
 func (y *Cloud189PC) OldUpload(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress, isFamily bool, overwrite bool) (model.Obj, error) {
-	tempFile, err := file.CacheFullInTempFile()
-	if err != nil {
-		return nil, err
-	}
-	fileMd5, err := utils.HashFile(utils.MD5, tempFile)
+	tempFile, fileMd5, err := stream.CacheFullInTempFileAndHash(file, utils.MD5)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/aliyundrive_open/upload.go
+++ b/drivers/aliyundrive_open/upload.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/stream"
+	streamPkg "github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/avast/retry-go"
@@ -144,32 +144,32 @@ func (d *AliyundriveOpen) calProofCode(stream model.FileStreamer) (string, error
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
-func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
 	// 1. create
 	// Part Size Unit: Bytes, Default: 20MB,
 	// Maximum number of slices 10,000, ≈195.3125GB
-	var partSize = calPartSize(file.GetSize())
+	var partSize = calPartSize(stream.GetSize())
 	const dateFormat = "2006-01-02T15:04:05.000Z"
-	mtimeStr := file.ModTime().UTC().Format(dateFormat)
-	ctimeStr := file.CreateTime().UTC().Format(dateFormat)
+	mtimeStr := stream.ModTime().UTC().Format(dateFormat)
+	ctimeStr := stream.CreateTime().UTC().Format(dateFormat)
 
 	createData := base.Json{
 		"drive_id":          d.DriveId,
 		"parent_file_id":    dstDir.GetID(),
-		"name":              file.GetName(),
+		"name":              stream.GetName(),
 		"type":              "file",
 		"check_name_mode":   "ignore",
 		"local_modified_at": mtimeStr,
 		"local_created_at":  ctimeStr,
 	}
-	count := int(math.Ceil(float64(file.GetSize()) / float64(partSize)))
+	count := int(math.Ceil(float64(stream.GetSize()) / float64(partSize)))
 	createData["part_info_list"] = makePartInfos(count)
 	// rapid upload
-	rapidUpload := !file.IsForceStreamUpload() && file.GetSize() > 100*utils.KB && d.RapidUpload
+	rapidUpload := !stream.IsForceStreamUpload() && stream.GetSize() > 100*utils.KB && d.RapidUpload
 	if rapidUpload {
 		log.Debugf("[aliyundrive_open] start cal pre_hash")
 		// read 1024 bytes to calculate pre hash
-		reader, err := file.RangeRead(http_range.Range{Start: 0, Length: 1024})
+		reader, err := stream.RangeRead(http_range.Range{Start: 0, Length: 1024})
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, file mod
 		if err != nil {
 			return nil, err
 		}
-		createData["size"] = file.GetSize()
+		createData["size"] = stream.GetSize()
 		createData["pre_hash"] = hash
 	}
 	var createResp CreateResp
@@ -190,9 +190,9 @@ func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, file mod
 		}
 		log.Debugf("[aliyundrive_open] pre_hash matched, start rapid upload")
 
-		hash := file.GetHash().GetHash(utils.SHA1)
+		hash := stream.GetHash().GetHash(utils.SHA1)
 		if len(hash) != utils.SHA1.Width {
-			_, hash, err = stream.CacheFullInTempFileAndHash(file, utils.SHA1)
+			_, hash, err = streamPkg.CacheFullInTempFileAndHash(stream, utils.SHA1)
 			if err != nil {
 				return nil, err
 			}
@@ -202,7 +202,7 @@ func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, file mod
 		createData["proof_version"] = "v1"
 		createData["content_hash_name"] = "sha1"
 		createData["content_hash"] = hash
-		createData["proof_code"], err = d.calProofCode(file)
+		createData["proof_code"], err = d.calProofCode(stream)
 		if err != nil {
 			return nil, fmt.Errorf("cal proof code error: %s", err.Error())
 		}
@@ -233,12 +233,12 @@ func (d *AliyundriveOpen) upload(ctx context.Context, dstDir model.Obj, file mod
 				}
 				preTime = time.Now()
 			}
-			if remain := file.GetSize() - offset; length > remain {
+			if remain := stream.GetSize() - offset; length > remain {
 				length = remain
 			}
-			rd := utils.NewMultiReadable(io.LimitReader(file, partSize))
+			rd := utils.NewMultiReadable(io.LimitReader(stream, partSize))
 			if rapidUpload {
-				srd, err := file.RangeRead(http_range.Range{Start: offset, Length: length})
+				srd, err := stream.RangeRead(http_range.Range{Start: offset, Length: length})
 				if err != nil {
 					return nil, err
 				}

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -221,6 +221,9 @@ func (d *BaiduNetdisk) Put(ctx context.Context, dstDir model.Obj, file model.Fil
 
 	for i := 1; i <= count; i++ {
 		if utils.IsCanceled(ctx) {
+			if tmpF != nil {
+				_ = os.Remove(tmpF.Name())
+			}
 			return nil, ctx.Err()
 		}
 		if i == count {
@@ -229,6 +232,9 @@ func (d *BaiduNetdisk) Put(ctx context.Context, dstDir model.Obj, file model.Fil
 		n, err := utils.CopyWithBufferN(io.MultiWriter(fileMd5H, sliceMd5H, slicemd5H2Write), file, byteSize)
 		written += n
 		if err != nil && err != io.EOF {
+			if tmpF != nil {
+				_ = os.Remove(tmpF.Name())
+			}
 			return nil, err
 		}
 		blockList = append(blockList, hex.EncodeToString(sliceMd5H.Sum(nil)))

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
-	"math"
 	"net/url"
 	"os"
 	stdpath "path"
@@ -186,9 +185,11 @@ func (d *BaiduNetdisk) Put(ctx context.Context, dstDir model.Obj, stream model.F
 
 	streamSize := stream.GetSize()
 	sliceSize := d.getSliceSize(streamSize)
-	count := int(math.Max(math.Ceil(float64(streamSize)/float64(sliceSize)), 1))
+	count := int(streamSize / sliceSize)
 	lastBlockSize := streamSize % sliceSize
-	if streamSize > 0 && lastBlockSize == 0 {
+	if lastBlockSize > 0 {
+		count++
+	} else {
 		lastBlockSize = sliceSize
 	}
 

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -233,26 +235,35 @@ func (d *BaiduPhoto) Remove(ctx context.Context, obj model.Obj) error {
 	return errs.NotSupport
 }
 
-func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
 	// 不支持大小为0的文件
-	if stream.GetSize() == 0 {
+	if file.GetSize() == 0 {
 		return nil, fmt.Errorf("file size cannot be zero")
 	}
 
 	// TODO:
 	// 暂时没有找到妙传方式
 
-	// 需要获取完整文件md5,必须支持 io.Seek
-	tempFile, err := stream.CacheFullInTempFile()
-	if err != nil {
-		return nil, err
+	var readerAt = file.GetCache()
+	var (
+		tmpF *os.File
+		err  error
+	)
+	writers := make([]io.Writer, 0, 4)
+	if _, ok := readerAt.(io.ReaderAt); !ok {
+		tmpF, err = os.CreateTemp(conf.Conf.TempDir, "file-*")
+		if err != nil {
+			return nil, err
+		}
+		writers = append(writers, tmpF)
+		readerAt = tmpF
 	}
 
 	const DEFAULT int64 = 1 << 22
 	const SliceSize int64 = 1 << 18
 
 	// 计算需要的数据
-	streamSize := stream.GetSize()
+	streamSize := file.GetSize()
 	count := int(math.Ceil(float64(streamSize) / float64(DEFAULT)))
 	lastBlockSize := streamSize % DEFAULT
 	if lastBlockSize == 0 {
@@ -266,6 +277,8 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 	sliceMd5H := md5.New()
 	sliceMd5H2 := md5.New()
 	slicemd5H2Write := utils.LimitWriter(sliceMd5H2, SliceSize)
+	writers = append(writers, fileMd5H, sliceMd5H, slicemd5H2Write)
+	written := int64(0)
 	for i := 1; i <= count; i++ {
 		if utils.IsCanceled(ctx) {
 			return nil, ctx.Err()
@@ -273,12 +286,28 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 		if i == count {
 			byteSize = lastBlockSize
 		}
-		_, err := utils.CopyWithBufferN(io.MultiWriter(fileMd5H, sliceMd5H, slicemd5H2Write), tempFile, byteSize)
+		n, err := utils.CopyWithBufferN(io.MultiWriter(writers...), file, byteSize)
+		written += n
 		if err != nil && err != io.EOF {
+			if tmpF != nil {
+				_ = os.Remove(tmpF.Name())
+			}
 			return nil, err
 		}
 		sliceMD5List = append(sliceMD5List, hex.EncodeToString(sliceMd5H.Sum(nil)))
 		sliceMd5H.Reset()
+	}
+	if tmpF != nil {
+		if written != streamSize {
+			_ = os.Remove(tmpF.Name())
+			return nil, errs.NewErr(err, "CreateTempFile failed, incoming stream actual size= %d, expect = %d ", written, streamSize)
+		}
+		_, err = tmpF.Seek(0, io.SeekStart)
+		if err != nil {
+			_ = os.Remove(tmpF.Name())
+			return nil, errs.NewErr(err, "CreateTempFile failed, can't seek to 0 ")
+		}
+		file.SetTmpFile(tmpF)
 	}
 	contentMd5 := hex.EncodeToString(fileMd5H.Sum(nil))
 	sliceMd5 := hex.EncodeToString(sliceMd5H2.Sum(nil))
@@ -290,8 +319,8 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 		"isdir":       "0",
 		"rtype":       "1",
 		"ctype":       "11",
-		"path":        fmt.Sprintf("/%s", stream.GetName()),
-		"size":        fmt.Sprint(stream.GetSize()),
+		"path":        fmt.Sprintf("/%s", file.GetName()),
+		"size":        fmt.Sprint(streamSize),
 		"slice-md5":   sliceMd5,
 		"content-md5": contentMd5,
 		"block_list":  blockListStr,
@@ -342,8 +371,8 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 				_, err = d.Post("https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2", func(r *resty.Request) {
 					r.SetContext(ctx)
 					r.SetQueryParams(uploadParams)
-					r.SetFileReader("file", stream.GetName(),
-						driver.NewLimitedUploadStream(ctx, io.NewSectionReader(tempFile, offset, byteSize)))
+					r.SetFileReader("file", file.GetName(),
+						driver.NewLimitedUploadStream(ctx, io.NewSectionReader(readerAt, offset, byteSize)))
 				}, nil)
 				if err != nil {
 					return err

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -281,6 +281,9 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 	written := int64(0)
 	for i := 1; i <= count; i++ {
 		if utils.IsCanceled(ctx) {
+			if tmpF != nil {
+				_ = os.Remove(tmpF.Name())
+			}
 			return nil, ctx.Err()
 		}
 		if i == count {

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -244,21 +244,6 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 	// TODO:
 	// 暂时没有找到妙传方式
 
-	var readerAt = file.GetCache()
-	var (
-		tmpF *os.File
-		err  error
-	)
-	writers := make([]io.Writer, 0, 4)
-	if _, ok := readerAt.(io.ReaderAt); !ok {
-		tmpF, err = os.CreateTemp(conf.Conf.TempDir, "file-*")
-		if err != nil {
-			return nil, err
-		}
-		writers = append(writers, tmpF)
-		readerAt = tmpF
-	}
-
 	const DEFAULT int64 = 1 << 22
 	const SliceSize int64 = 1 << 18
 
@@ -277,13 +262,28 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 	sliceMd5H := md5.New()
 	sliceMd5H2 := md5.New()
 	slicemd5H2Write := utils.LimitWriter(sliceMd5H2, SliceSize)
+	var (
+		cache = file.GetFile()
+		tmpF  *os.File
+		err   error
+	)
+	writers := make([]io.Writer, 0, 4)
+	if _, ok := cache.(io.ReaderAt); !ok {
+		tmpF, err = os.CreateTemp(conf.Conf.TempDir, "file-*")
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = tmpF.Close()
+			_ = os.Remove(tmpF.Name())
+		}()
+		cache = tmpF
+		writers = append(writers, tmpF)
+	}
 	writers = append(writers, fileMd5H, sliceMd5H, slicemd5H2Write)
 	written := int64(0)
 	for i := 1; i <= count; i++ {
 		if utils.IsCanceled(ctx) {
-			if tmpF != nil {
-				_ = os.Remove(tmpF.Name())
-			}
 			return nil, ctx.Err()
 		}
 		if i == count {
@@ -292,9 +292,6 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 		n, err := utils.CopyWithBufferN(io.MultiWriter(writers...), file, byteSize)
 		written += n
 		if err != nil && err != io.EOF {
-			if tmpF != nil {
-				_ = os.Remove(tmpF.Name())
-			}
 			return nil, err
 		}
 		sliceMD5List = append(sliceMD5List, hex.EncodeToString(sliceMd5H.Sum(nil)))
@@ -302,15 +299,12 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 	}
 	if tmpF != nil {
 		if written != streamSize {
-			_ = os.Remove(tmpF.Name())
 			return nil, errs.NewErr(err, "CreateTempFile failed, incoming stream actual size= %d, expect = %d ", written, streamSize)
 		}
 		_, err = tmpF.Seek(0, io.SeekStart)
 		if err != nil {
-			_ = os.Remove(tmpF.Name())
 			return nil, errs.NewErr(err, "CreateTempFile failed, can't seek to 0 ")
 		}
-		file.SetTmpFile(tmpF)
 	}
 	contentMd5 := hex.EncodeToString(fileMd5H.Sum(nil))
 	sliceMd5 := hex.EncodeToString(sliceMd5H2.Sum(nil))
@@ -375,7 +369,7 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 					r.SetContext(ctx)
 					r.SetQueryParams(uploadParams)
 					r.SetFileReader("file", file.GetName(),
-						driver.NewLimitedUploadStream(ctx, io.NewSectionReader(readerAt, offset, byteSize)))
+						driver.NewLimitedUploadStream(ctx, io.NewSectionReader(cache, offset, byteSize)))
 				}, nil)
 				if err != nil {
 					return err

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -249,9 +248,11 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 
 	// 计算需要的数据
 	streamSize := stream.GetSize()
-	count := int(math.Ceil(float64(streamSize) / float64(DEFAULT)))
+	count := int(streamSize / DEFAULT)
 	lastBlockSize := streamSize % DEFAULT
-	if lastBlockSize == 0 {
+	if lastBlockSize > 0 {
+		count++
+	} else {
 		lastBlockSize = DEFAULT
 	}
 

--- a/drivers/github/util.go
+++ b/drivers/github/util.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"text/template"
 	"time"
@@ -159,7 +158,7 @@ func signCommit(m *map[string]interface{}, entity *openpgp.Entity) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if _, err = io.Copy(armorWriter, &sigBuffer); err != nil {
+	if _, err = utils.CopyWithBuffer(armorWriter, &sigBuffer); err != nil {
 		return "", err
 	}
 	_ = armorWriter.Close()

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -17,6 +16,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/foxxorcat/mopan-sdk-go"
 	"github.com/go-resty/resty/v2"
@@ -273,23 +273,14 @@ func (d *ILanZou) Remove(ctx context.Context, obj model.Obj) error {
 const DefaultPartSize = 1024 * 1024 * 8
 
 func (d *ILanZou) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
-	h := md5.New()
-	// need to calculate md5 of the full content
-	tempFile, err := s.CacheFullInTempFile()
-	if err != nil {
-		return nil, err
+	etag := s.GetHash().GetHash(utils.MD5)
+	var err error
+	if len(etag) != utils.MD5.Width {
+		_, etag, err = stream.CacheFullInTempFileAndHash(s, utils.MD5)
+		if err != nil {
+			return nil, err
+		}
 	}
-	defer func() {
-		_ = tempFile.Close()
-	}()
-	if _, err = utils.CopyWithBuffer(h, tempFile); err != nil {
-		return nil, err
-	}
-	_, err = tempFile.Seek(0, io.SeekStart)
-	if err != nil {
-		return nil, err
-	}
-	etag := hex.EncodeToString(h.Sum(nil))
 	// get upToken
 	res, err := d.proved("/7n/getUpToken", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{
@@ -309,7 +300,7 @@ func (d *ILanZou) Put(ctx context.Context, dstDir model.Obj, s model.FileStreame
 	key := fmt.Sprintf("disk/%d/%d/%d/%s/%016d", now.Year(), now.Month(), now.Day(), d.account, now.UnixMilli())
 	reader := driver.NewLimitedUploadStream(ctx, &driver.ReaderUpdatingProgress{
 		Reader: &driver.SimpleReaderWithSize{
-			Reader: tempFile,
+			Reader: s,
 			Size:   s.GetSize(),
 		},
 		UpdateProgress: up,

--- a/drivers/mopan/driver.go
+++ b/drivers/mopan/driver.go
@@ -269,9 +269,6 @@ func (d *MoPan) Put(ctx context.Context, dstDir model.Obj, stream model.FileStre
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = file.Close()
-	}()
 
 	// step.1
 	uploadPartData, err := mopan.InitUploadPartData(ctx, mopan.UpdloadFileParam{

--- a/drivers/netease_music/util.go
+++ b/drivers/netease_music/util.go
@@ -227,7 +227,6 @@ func (d *NeteaseMusic) putSongStream(ctx context.Context, stream model.FileStrea
 	if err != nil {
 		return err
 	}
-	defer tmp.Close()
 
 	u := uploader{driver: d, file: tmp}
 

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	hash_extend "github.com/alist-org/alist/v3/pkg/utils/hash"
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 type PikPak struct {
@@ -209,16 +211,11 @@ func (d *PikPak) Remove(ctx context.Context, obj model.Obj) error {
 	return err
 }
 
-func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
-	hi := stream.GetHash()
-	sha1Str := hi.GetHash(hash_extend.GCID)
-	if len(sha1Str) < hash_extend.GCID.Width {
-		tFile, err := stream.CacheFullInTempFile()
-		if err != nil {
-			return err
-		}
-
-		sha1Str, err = utils.HashFile(hash_extend.GCID, tFile, stream.GetSize())
+func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
+	gcid := file.GetHash().GetHash(hash_extend.GCID)
+	var err error
+	if len(gcid) != hash_extend.GCID.Width {
+		_, gcid, err = stream.CacheFullInTempFileAndHash(file, hash_extend.GCID, file.GetSize())
 		if err != nil {
 			return err
 		}
@@ -228,9 +225,9 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	res, err := d.request("https://api-drive.mypikpak.net/drive/v1/files", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"kind":        "drive#file",
-			"name":        stream.GetName(),
-			"size":        stream.GetSize(),
-			"hash":        strings.ToUpper(sha1Str),
+			"name":        file.GetName(),
+			"size":        file.GetSize(),
+			"hash":        strings.ToUpper(gcid),
 			"upload_type": "UPLOAD_TYPE_RESUMABLE",
 			"objProvider": base.Json{"provider": "UPLOAD_TYPE_UNKNOWN"},
 			"parent_id":   dstDir.GetID(),
@@ -254,11 +251,11 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		params.Endpoint = "mypikpak.net"
 	}
 
-	if stream.GetSize() <= 10*utils.MB { // 文件大小 小于10MB，改用普通模式上传
-		return d.UploadByOSS(ctx, &params, stream, up)
+	if file.GetSize() <= 10*utils.MB { // 文件大小 小于10MB，改用普通模式上传
+		return d.UploadByOSS(ctx, &params, file, up)
 	}
 	// 分片上传
-	return d.UploadByMultipart(ctx, &params, stream.GetSize(), stream, up)
+	return d.UploadByMultipart(ctx, &params, file.GetSize(), file, up)
 }
 
 // 离线下载文件

--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	hash_extend "github.com/alist-org/alist/v3/pkg/utils/hash"
 	"github.com/aws/aws-sdk-go/aws"
@@ -333,22 +334,17 @@ func (xc *XunLeiCommon) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (xc *XunLeiCommon) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
-	hi := file.GetHash()
-	gcid := hi.GetHash(hash_extend.GCID)
-	if len(gcid) < hash_extend.GCID.Width {
-		tFile, err := file.CacheFullInTempFile()
-		if err != nil {
-			return err
-		}
-
-		gcid, err = utils.HashFile(hash_extend.GCID, tFile, file.GetSize())
+	gcid := file.GetHash().GetHash(hash_extend.GCID)
+	var err error
+	if len(gcid) != hash_extend.GCID.Width {
+		_, gcid, err = stream.CacheFullInTempFileAndHash(file, hash_extend.GCID, file.GetSize())
 		if err != nil {
 			return err
 		}
 	}
 
 	var resp UploadTaskResponse
-	_, err := xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
+	_, err = xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
 		r.SetContext(ctx)
 		r.SetBody(&base.Json{
 			"kind":        FILE,

--- a/drivers/thunder_browser/driver.go
+++ b/drivers/thunder_browser/driver.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	hash_extend "github.com/alist-org/alist/v3/pkg/utils/hash"
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,9 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-resty/resty/v2"
-	"io"
-	"net/http"
-	"strings"
 )
 
 type ThunderBrowser struct {
@@ -455,16 +457,11 @@ func (xc *XunLeiBrowserCommon) Remove(ctx context.Context, obj model.Obj) error 
 	}
 }
 
-func (xc *XunLeiBrowserCommon) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
-	hi := stream.GetHash()
-	gcid := hi.GetHash(hash_extend.GCID)
-	if len(gcid) < hash_extend.GCID.Width {
-		tFile, err := stream.CacheFullInTempFile()
-		if err != nil {
-			return err
-		}
-
-		gcid, err = utils.HashFile(hash_extend.GCID, tFile, stream.GetSize())
+func (xc *XunLeiBrowserCommon) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
+	gcid := file.GetHash().GetHash(hash_extend.GCID)
+	var err error
+	if len(gcid) != hash_extend.GCID.Width {
+		_, gcid, err = stream.CacheFullInTempFileAndHash(file, hash_extend.GCID, file.GetSize())
 		if err != nil {
 			return err
 		}
@@ -473,15 +470,15 @@ func (xc *XunLeiBrowserCommon) Put(ctx context.Context, dstDir model.Obj, stream
 	js := base.Json{
 		"kind":        FILE,
 		"parent_id":   dstDir.GetID(),
-		"name":        stream.GetName(),
-		"size":        stream.GetSize(),
+		"name":        file.GetName(),
+		"size":        file.GetSize(),
 		"hash":        gcid,
 		"upload_type": UPLOAD_TYPE_RESUMABLE,
 		"space":       dstDir.(*Files).GetSpace(),
 	}
 
 	var resp UploadTaskResponse
-	_, err := xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
+	_, err = xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
 		r.SetContext(ctx)
 		r.SetBody(&js)
 	}, &resp)
@@ -501,14 +498,14 @@ func (xc *XunLeiBrowserCommon) Put(ctx context.Context, dstDir model.Obj, stream
 			return err
 		}
 		uploader := s3manager.NewUploader(s)
-		if stream.GetSize() > s3manager.MaxUploadParts*s3manager.DefaultUploadPartSize {
-			uploader.PartSize = stream.GetSize() / (s3manager.MaxUploadParts - 1)
+		if file.GetSize() > s3manager.MaxUploadParts*s3manager.DefaultUploadPartSize {
+			uploader.PartSize = file.GetSize() / (s3manager.MaxUploadParts - 1)
 		}
 		_, err = uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 			Bucket:  aws.String(param.Bucket),
 			Key:     aws.String(param.Key),
 			Expires: aws.Time(param.Expiration),
-			Body:    driver.NewLimitedUploadStream(ctx, io.TeeReader(stream, driver.NewProgress(stream.GetSize(), up))),
+			Body:    driver.NewLimitedUploadStream(ctx, io.TeeReader(file, driver.NewProgress(file.GetSize(), up))),
 		})
 		return err
 	}

--- a/drivers/thunderx/driver.go
+++ b/drivers/thunderx/driver.go
@@ -3,11 +3,15 @@ package thunderx
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	hash_extend "github.com/alist-org/alist/v3/pkg/utils/hash"
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,8 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-resty/resty/v2"
-	"net/http"
-	"strings"
 )
 
 type ThunderX struct {
@@ -364,22 +366,17 @@ func (xc *XunLeiXCommon) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (xc *XunLeiXCommon) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
-	hi := file.GetHash()
-	gcid := hi.GetHash(hash_extend.GCID)
-	if len(gcid) < hash_extend.GCID.Width {
-		tFile, err := file.CacheFullInTempFile()
-		if err != nil {
-			return err
-		}
-
-		gcid, err = utils.HashFile(hash_extend.GCID, tFile, file.GetSize())
+	gcid := file.GetHash().GetHash(hash_extend.GCID)
+	var err error
+	if len(gcid) != hash_extend.GCID.Width {
+		_, gcid, err = stream.CacheFullInTempFileAndHash(file, hash_extend.GCID, file.GetSize())
 		if err != nil {
 			return err
 		}
 	}
 
 	var resp UploadTaskResponse
-	_, err := xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
+	_, err = xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
 		r.SetContext(ctx)
 		r.SetBody(&base.Json{
 			"kind":        FILE,

--- a/internal/archive/archives/utils.go
+++ b/internal/archive/archives/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/mholt/archives"
 )
 
@@ -73,7 +74,7 @@ func decompress(fsys fs2.FS, filePath, targetPath string, up model.UpdateProgres
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(f, &stream.ReaderUpdatingProgress{
+	_, err = utils.CopyWithBuffer(f, &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: rc,
 			Size:   stat.Size(),

--- a/internal/archive/iso9660/utils.go
+++ b/internal/archive/iso9660/utils.go
@@ -1,14 +1,15 @@
 package iso9660
 
 import (
-	"github.com/alist-org/alist/v3/internal/errs"
-	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/stream"
-	"github.com/kdomanski/iso9660"
-	"io"
 	"os"
 	stdpath "path"
 	"strings"
+
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/kdomanski/iso9660"
 )
 
 func getImage(ss *stream.SeekableStream) (*iso9660.Image, error) {
@@ -66,7 +67,7 @@ func decompress(f *iso9660.File, path string, up model.UpdateProgress) error {
 		return err
 	}
 	defer file.Close()
-	_, err = io.Copy(file, &stream.ReaderUpdatingProgress{
+	_, err = utils.CopyWithBuffer(file, &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: f.Reader(),
 			Size:   f.Size(),

--- a/internal/archive/zip/utils.go
+++ b/internal/archive/zip/utils.go
@@ -2,9 +2,15 @@ package zip
 
 import (
 	"bytes"
+	"io"
+	"os"
+	stdpath "path"
+	"strings"
+
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/saintfish/chardet"
 	"github.com/yeka/zip"
 	"golang.org/x/text/encoding"
@@ -16,10 +22,6 @@ import (
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/encoding/unicode/utf32"
 	"golang.org/x/text/transform"
-	"io"
-	"os"
-	stdpath "path"
-	"strings"
 )
 
 func toModelObj(file os.FileInfo) *model.Object {
@@ -64,7 +66,7 @@ func _decompress(file *zip.File, targetPath, password string, up model.UpdatePro
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(f, &stream.ReaderUpdatingProgress{
+	_, err = utils.CopyWithBuffer(f, &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: rc,
 			Size:   file.FileInfo().Size(),

--- a/internal/fs/archive.go
+++ b/internal/fs/archive.go
@@ -4,6 +4,17 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
+	"math/rand"
+	"mime"
+	"net/http"
+	"os"
+	stdpath "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/alist-org/alist/v3/internal/archive/tool"
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -15,16 +26,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/xhofe/tache"
-	"io"
-	"math/rand"
-	"mime"
-	"net/http"
-	"os"
-	stdpath "path"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type ArchiveDownloadTask struct {
@@ -90,7 +91,7 @@ func (t *ArchiveDownloadTask) RunWithoutPushUploadTask() (*ArchiveContentUploadT
 	if t.CacheFull {
 		t.SetTotalBytes(srcObj.GetSize())
 		t.status = "getting src object"
-		_, err = ss.CacheFullInTempFileAndUpdateProgress(t.SetProgress)
+		_, err = stream.CacheFullInTempFileAndUpdateProgress(ss, t.SetProgress)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/fs/archive.go
+++ b/internal/fs/archive.go
@@ -88,7 +88,7 @@ func (t *ArchiveDownloadTask) RunWithoutPushUploadTask() (*ArchiveContentUploadT
 		}
 	}()
 	var decompressUp model.UpdateProgress
-	if t.CacheFull {
+	if t.CacheFull && ss.GetFile() == nil {
 		t.SetTotalBytes(srcObj.GetSize())
 		t.status = "getting src object"
 		_, err = stream.CacheFullInTempFileAndUpdateProgress(ss, t.SetProgress)

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -49,8 +49,8 @@ type FileStreamer interface {
 	RangeRead(http_range.Range) (io.Reader, error)
 	//for a non-seekable Stream, if Read is called, this function won't work
 	CacheFullInTempFile() (File, error)
-	GetCache() File
 	SetTmpFile(r *os.File)
+	GetFile() File
 }
 
 type UpdateProgress func(percentage float64)

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -48,7 +49,8 @@ type FileStreamer interface {
 	RangeRead(http_range.Range) (io.Reader, error)
 	//for a non-seekable Stream, if Read is called, this function won't work
 	CacheFullInTempFile() (File, error)
-	CacheFullInTempFileAndUpdateProgress(up UpdateProgress) (File, error)
+	GetCache() File
+	SetTmpFile(r *os.File)
 }
 
 type UpdateProgress func(percentage float64)

--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -248,8 +248,9 @@ func (d *downloader) sendChunkTask(newConcurrency bool) error {
 			size:  finalSize,
 			id:    d.nextChunk,
 			buf:   buf,
+
+			newConcurrency: newConcurrency,
 		}
-		ch.newConcurrency = newConcurrency
 		d.pos += finalSize
 		d.nextChunk++
 		d.chunkChannel <- ch

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -93,27 +93,23 @@ func (f *FileStream) CacheFullInTempFile() (model.File, error) {
 	f.Add(tmpF)
 	f.tmpFile = tmpF
 	f.Reader = tmpF
-	return f.tmpFile, nil
+	return tmpF, nil
 }
 
-func (f *FileStream) CacheFullInTempFileAndUpdateProgress(up model.UpdateProgress) (model.File, error) {
+func (f *FileStream) SetTmpFile(r *os.File) {
+	f.Add(r)
+	f.tmpFile = r
+	f.Reader = r
+}
+
+func (f *FileStream) GetCache() model.File {
 	if f.tmpFile != nil {
-		return f.tmpFile, nil
+		return f.tmpFile
 	}
 	if file, ok := f.Reader.(model.File); ok {
-		return file, nil
+		return file
 	}
-	tmpF, err := utils.CreateTempFile(&ReaderUpdatingProgress{
-		Reader:         f,
-		UpdateProgress: up,
-	}, f.GetSize())
-	if err != nil {
-		return nil, err
-	}
-	f.Add(tmpF)
-	f.tmpFile = tmpF
-	f.Reader = tmpF
-	return f.tmpFile, nil
+	return nil
 }
 
 const InMemoryBufMaxSize = 10 // Megabytes
@@ -273,7 +269,7 @@ func (ss *SeekableStream) CacheFullInTempFile() (model.File, error) {
 	if ss.tmpFile != nil {
 		return ss.tmpFile, nil
 	}
-	if _, ok := ss.mFile.(*os.File); ok {
+	if ss.mFile != nil {
 		return ss.mFile, nil
 	}
 	tmpF, err := utils.CreateTempFile(ss, ss.GetSize())
@@ -283,33 +279,17 @@ func (ss *SeekableStream) CacheFullInTempFile() (model.File, error) {
 	ss.Add(tmpF)
 	ss.tmpFile = tmpF
 	ss.Reader = tmpF
-	return ss.tmpFile, nil
+	return tmpF, nil
 }
 
-func (ss *SeekableStream) CacheFullInTempFileAndUpdateProgress(up model.UpdateProgress) (model.File, error) {
+func (ss *SeekableStream) GetCache() model.File {
 	if ss.tmpFile != nil {
-		return ss.tmpFile, nil
+		return ss.tmpFile
 	}
-	if _, ok := ss.mFile.(*os.File); ok {
-		return ss.mFile, nil
+	if ss.mFile != nil {
+		return ss.mFile
 	}
-	tmpF, err := utils.CreateTempFile(&ReaderUpdatingProgress{
-		Reader:         ss,
-		UpdateProgress: up,
-	}, ss.GetSize())
-	if err != nil {
-		return nil, err
-	}
-	ss.Add(tmpF)
-	ss.tmpFile = tmpF
-	ss.Reader = tmpF
-	return ss.tmpFile, nil
-}
-
-func (f *FileStream) SetTmpFile(r *os.File) {
-	f.Add(r)
-	f.tmpFile = r
-	f.Reader = r
+	return nil
 }
 
 type ReaderWithSize interface {

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -102,7 +102,7 @@ func (f *FileStream) SetTmpFile(r *os.File) {
 	f.Reader = r
 }
 
-func (f *FileStream) GetCache() model.File {
+func (f *FileStream) GetFile() model.File {
 	if f.tmpFile != nil {
 		return f.tmpFile
 	}
@@ -282,7 +282,7 @@ func (ss *SeekableStream) CacheFullInTempFile() (model.File, error) {
 	return tmpF, nil
 }
 
-func (ss *SeekableStream) GetCache() model.File {
+func (ss *SeekableStream) GetFile() model.File {
 	if ss.tmpFile != nil {
 		return ss.tmpFile
 	}

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -107,7 +107,8 @@ func (r *ReaderWithCtx) Close() error {
 }
 
 func CacheFullInTempFileAndUpdateProgress(stream model.FileStreamer, up model.UpdateProgress) (model.File, error) {
-	if cache := stream.GetCache(); cache != nil {
+	if cache := stream.GetFile(); cache != nil {
+		up(100)
 		return cache, nil
 	}
 	tmpF, err := utils.CreateTempFile(&ReaderUpdatingProgress{
@@ -121,7 +122,7 @@ func CacheFullInTempFileAndUpdateProgress(stream model.FileStreamer, up model.Up
 }
 
 func CacheFullInTempFileAndWriter(stream model.FileStreamer, w io.Writer) (model.File, error) {
-	if cache := stream.GetCache(); cache != nil {
+	if cache := stream.GetFile(); cache != nil {
 		_, err := cache.Seek(0, io.SeekStart)
 		if err == nil {
 			_, err = utils.CopyWithBuffer(w, cache)
@@ -140,7 +141,7 @@ func CacheFullInTempFileAndWriter(stream model.FileStreamer, w io.Writer) (model
 
 func CacheFullInTempFileAndHash(stream model.FileStreamer, hashType *utils.HashType, params ...any) (model.File, string, error) {
 	h := hashType.NewFunc(params...)
-	if cache := stream.GetCache(); cache != nil {
+	if cache := stream.GetFile(); cache != nil {
 		_, err := cache.Seek(0, io.SeekStart)
 		if err == nil {
 			_, err = utils.CopyWithBuffer(h, cache)

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,4 +104,58 @@ func (r *ReaderWithCtx) Close() error {
 		return c.Close()
 	}
 	return nil
+}
+
+func CacheFullInTempFileAndUpdateProgress(stream model.FileStreamer, up model.UpdateProgress) (model.File, error) {
+	if cache := stream.GetCache(); cache != nil {
+		return cache, nil
+	}
+	tmpF, err := utils.CreateTempFile(&ReaderUpdatingProgress{
+		Reader:         stream,
+		UpdateProgress: up,
+	}, stream.GetSize())
+	if err == nil {
+		stream.SetTmpFile(tmpF)
+	}
+	return tmpF, err
+}
+
+func CacheFullInTempFileAndWriter(stream model.FileStreamer, w io.Writer) (model.File, error) {
+	if cache := stream.GetCache(); cache != nil {
+		_, err := cache.Seek(0, io.SeekStart)
+		if err == nil {
+			_, err = utils.CopyWithBuffer(w, cache)
+			if err == nil {
+				_, err = cache.Seek(0, io.SeekStart)
+			}
+		}
+		return cache, err
+	}
+	tmpF, err := utils.CreateTempFile(io.TeeReader(stream, w), stream.GetSize())
+	if err == nil {
+		stream.SetTmpFile(tmpF)
+	}
+	return tmpF, err
+}
+
+func CacheFullInTempFileAndHash(stream model.FileStreamer, hashType *utils.HashType, params ...any) (model.File, string, error) {
+	h := hashType.NewFunc(params...)
+	if cache := stream.GetCache(); cache != nil {
+		_, err := cache.Seek(0, io.SeekStart)
+		if err == nil {
+			_, err = utils.CopyWithBuffer(h, cache)
+			if err == nil {
+				_, err = cache.Seek(0, io.SeekStart)
+			}
+			return cache, hex.EncodeToString(h.Sum(nil)), err
+		}
+		return nil, "", err
+	}
+
+	tmpF, err := utils.CreateTempFile(io.TeeReader(stream, h), stream.GetSize())
+	if err == nil {
+		stream.SetTmpFile(tmpF)
+		return tmpF, hex.EncodeToString(h.Sum(nil)), nil
+	}
+	return nil, "", err
 }

--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -1,13 +1,14 @@
 package handles
 
 import (
-	"github.com/alist-org/alist/v3/internal/task"
-	"github.com/alist-org/alist/v3/pkg/utils"
 	"io"
 	"net/url"
 	stdpath "path"
 	"strconv"
 	"time"
+
+	"github.com/alist-org/alist/v3/internal/task"
+	"github.com/alist-org/alist/v3/pkg/utils"
 
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -44,7 +45,7 @@ func FsStream(c *gin.Context) {
 	}
 	if !overwrite {
 		if res, _ := fs.Get(c, path, &fs.GetArgs{NoLog: true}); res != nil {
-			_, _ = io.Copy(io.Discard, c.Request.Body)
+			_, _ = utils.CopyWithBuffer(io.Discard, c.Request.Body)
 			common.ErrorStrResp(c, "file exists", 403)
 			return
 		}
@@ -89,6 +90,9 @@ func FsStream(c *gin.Context) {
 		return
 	}
 	if t == nil {
+		if n, _ := c.Request.Body.Read([]byte{0}); n == 1 {
+			_, _ = utils.CopyWithBuffer(io.Discard, c.Request.Body)
+		}
 		common.SuccessResp(c)
 		return
 	}
@@ -114,7 +118,7 @@ func FsForm(c *gin.Context) {
 	}
 	if !overwrite {
 		if res, _ := fs.Get(c, path, &fs.GetArgs{NoLog: true}); res != nil {
-			_, _ = io.Copy(io.Discard, c.Request.Body)
+			_, _ = utils.CopyWithBuffer(io.Discard, c.Request.Body)
 			common.ErrorStrResp(c, "file exists", 403)
 			return
 		}


### PR DESCRIPTION
我只测试了第一个提交被修改的驱动，其他没测试
* 更多驱动支持这个PR的功能(尝试秒传) #7851
* 当提供了上传所需的哈希值时(#7851)，则不会缓存到临时文件(流上传)。例如移动云盘的新个人云
* Close #8170 
## 开发笔记
使用bytes.Buffer作为io.CopyBuffer的写入对象，CopyBuffer会调用Buffer.ReadFrom
即使被写入的数据量与Buffer.Cap一致，Buffer也会扩大