### PR TITLE
feat: better ipfs support

### DIFF
--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	stdpath "path"
 	"path/filepath"
 	"strings"
 
+	shell "github.com/ipfs/go-ipfs-api"
+
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
-	shell "github.com/ipfs/go-ipfs-api"
 )
 
 type IPFS struct {
@@ -44,27 +44,32 @@ func (d *IPFS) Drop(ctx context.Context) error {
 
 func (d *IPFS) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	path := dir.GetPath()
-	if path[len(path):] != "/" {
-		path += "/"
+	switch d.Mode {
+	case "ipfs":
+		path, _ = url.JoinPath("/ipfs", path)
+	case "ipns":
+		path, _ = url.JoinPath("/ipns", path)
+	case "mfs":
+		fileStat, err := d.sh.FilesStat(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		path, _ = url.JoinPath("/ipfs", fileStat.Hash)
+	default:
+		return nil, fmt.Errorf("mode error")
 	}
 
-	path_cid, err := d.sh.FilesStat(ctx, path)
-	if err != nil {
-		return nil, err
-	}
-
-	dirs, err := d.sh.List(path_cid.Hash)
+	dirs, err := d.sh.List(path)
 	if err != nil {
 		return nil, err
 	}
 
 	objlist := []model.Obj{}
 	for _, file := range dirs {
-		gateurl := *d.gateURL
-		gateurl.Path = "ipfs/" + file.Hash
+		gateurl := *d.gateURL.JoinPath("/ipfs/" + file.Hash)
 		gateurl.RawQuery = "filename=" + url.PathEscape(file.Name)
 		objlist = append(objlist, &model.ObjectURL{
-			Object: model.Object{ID: file.Hash, Name: file.Name, Size: int64(file.Size), IsFolder: file.Type == 1},
+			Object: model.Object{ID: "/ipfs/" + file.Hash, Name: file.Name, Size: int64(file.Size), IsFolder: file.Type == 1},
 			Url:    model.Url{Url: gateurl.String()},
 		})
 	}
@@ -73,11 +78,16 @@ func (d *IPFS) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]
 }
 
 func (d *IPFS) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
-	link := d.Gateway + "/ipfs/" + file.GetID() + "/?filename=" + url.PathEscape(file.GetName())
-	return &model.Link{URL: link}, nil
+	gateurl := d.gateURL.JoinPath(file.GetID())
+	gateurl.RawQuery = "filename" + url.PathEscape(file.GetName())
+	fmt.Println(gateurl)
+	return &model.Link{URL: gateurl.String()}, nil
 }
 
 func (d *IPFS) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
 	path := parentDir.GetPath()
 	if path[len(path):] != "/" {
 		path += "/"
@@ -86,42 +96,49 @@ func (d *IPFS) MakeDir(ctx context.Context, parentDir model.Obj, dirName string)
 }
 
 func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
 	return d.sh.FilesMv(ctx, srcObj.GetPath(), dstDir.GetPath())
 }
 
 func (d *IPFS) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
 	newFileName := filepath.Dir(srcObj.GetPath()) + "/" + newName
 	return d.sh.FilesMv(ctx, srcObj.GetPath(), strings.ReplaceAll(newFileName, "\\", "/"))
 }
 
 func (d *IPFS) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
-	// TODO copy obj, optional
-	fmt.Println(srcObj.GetPath())
-	fmt.Println(dstDir.GetPath())
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
 	newFileName := dstDir.GetPath() + "/" + filepath.Base(srcObj.GetPath())
 	fmt.Println(newFileName)
 	return d.sh.FilesCp(ctx, srcObj.GetPath(), strings.ReplaceAll(newFileName, "\\", "/"))
 }
 
 func (d *IPFS) Remove(ctx context.Context, obj model.Obj) error {
-	// TODO remove obj, optional
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
 	return d.sh.FilesRm(ctx, obj.GetPath(), true)
 }
 
 func (d *IPFS) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
-	// TODO upload file, optional
-	_, err := d.sh.Add(driver.NewLimitedUploadStream(ctx, &driver.ReaderUpdatingProgress{
+	if d.Mode != "mfs" {
+		return fmt.Errorf("only write in mfs mode")
+	}
+	outHash, err := d.sh.Add(driver.NewLimitedUploadStream(ctx, &driver.ReaderUpdatingProgress{
 		Reader:         s,
 		UpdateProgress: up,
-	}), ToFiles(stdpath.Join(dstDir.GetPath(), s.GetName())))
-	return err
-}
-
-func ToFiles(dstDir string) shell.AddOpts {
-	return func(rb *shell.RequestBuilder) error {
-		rb.Option("to-files", dstDir)
-		return nil
+	}))
+	if err != nil {
+		return err
 	}
+	err = d.sh.FilesCp(ctx, "/ipfs/"+outHash, dstDir.GetPath()+"/"+strings.ReplaceAll(s.GetName(), "\\", "/"))
+	return err
 }
 
 //func (d *Template) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {

--- a/drivers/ipfs_api/meta.go
+++ b/drivers/ipfs_api/meta.go
@@ -8,14 +8,16 @@ import (
 type Addition struct {
 	// Usually one of two
 	driver.RootPath
+	Mode     string `json:"mode" options:"ipfs,ipns,mfs" type:"select" required:"true"`
 	Endpoint string `json:"endpoint" default:"http://127.0.0.1:5001"`
-	Gateway  string `json:"gateway" default:"https://ipfs.io"`
+	Gateway  string `json:"gateway" default:"http://127.0.0.1:8080"`
 }
 
 var config = driver.Config{
 	Name:        "IPFS API",
 	DefaultRoot: "/",
 	LocalSort:   true,
+	OnlyProxy:   false,
 }
 
 func init() {


### PR DESCRIPTION
## cn
更好的ipfs支持
分别提供ipfs,ipns,mfs模式. 配置中直接输入cid或者ipns的名字即可使用，mfs可以挂载本地mfs目录
ifps和ipns下只读，mfs可以通过endpoint进行读写操作

## en
Better IPFS support
Added IPFS,IPNS,MFS mode. In config, use the cid or ipns to use it, mfs can be used to mount local mfs dir 
Readonly in IPFS and IPNS mode, writeable in MFS mode through endpoint