### PR TITLE
feat(smb-server): smb server support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/KirCute/ftpserverlib-pasvportmap v1.25.0
+	github.com/KirCute/go-smb2-alist v0.0.3
 	github.com/KirCute/sftpd-alist v0.0.12
 	github.com/ProtonMail/go-crypto v1.0.0
 	github.com/SheltonZhu/115driver v1.0.34

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/KirCute/ftpserverlib-pasvportmap v1.25.0 h1:ikwCzeqoqN6wvBHOB9OI6dde/jbV7EoTMpUcxtYl5Po=
 github.com/KirCute/ftpserverlib-pasvportmap v1.25.0/go.mod h1:v0NgMtKDDi/6CM6r4P+daCljCW3eO9yS+Z+pZDTKo1E=
+github.com/KirCute/go-smb2-alist v0.0.3 h1:NgL2F6cb0iW4GWa+rR75Bh8Z4TjDoDnt4mBCnhiSqck=
+github.com/KirCute/go-smb2-alist v0.0.3/go.mod h1:BzUuyzAaJbS4Eb733i9SBxIllZQYDZe5UBsGpkoP6U4=
 github.com/KirCute/sftpd-alist v0.0.12 h1:GNVM5QLbQLAfXP4wGUlXFA2IO6fVek0n0IsGnOuISdg=
 github.com/KirCute/sftpd-alist v0.0.12/go.mod h1:2wNK7yyW2XfjyJq10OY6xB4COLac64hOwfV6clDJn6s=
 github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd h1:nzE1YQBdx1bq9IlZinHa+HVffy+NmVRoKr+wHN8fpLE=

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -92,6 +92,19 @@ type SFTP struct {
 	Listen string `json:"listen" env:"LISTEN"`
 }
 
+type SMB struct {
+	Enable      bool   `json:"enable" env:"ENABLE"`
+	Listen      string `json:"listen" env:"LISTEN"`
+	MaxIOReads  int    `json:"max_io_reads" env:"MAX_IO_READS"`
+	MaxIOWrites int    `json:"max_io_writes" env:"MAX_IO_WRITES"`
+	TargetSPN   string `json:"target_spn" env:"TARGET_SPN"`
+	NbDomain    string `json:"nb_domain" env:"NB_DOMAIN"`
+	NbName      string `json:"nb_name" env:"NB_NAME"`
+	DnsName     string `json:"dns_name" env:"DNS_NAME"`
+	DnsDomain   string `json:"dns_domain" env:"DNS_DOMAIN"`
+	ShareName   string `json:"share_name" env:"SHARE_NAME"`
+}
+
 type Config struct {
 	Force                 bool        `json:"force" env:"FORCE"`
 	SiteURL               string      `json:"site_url" env:"SITE_URL"`
@@ -114,6 +127,7 @@ type Config struct {
 	S3                    S3          `json:"s3" envPrefix:"S3_"`
 	FTP                   FTP         `json:"ftp" envPrefix:"FTP_"`
 	SFTP                  SFTP        `json:"sftp" envPrefix:"SFTP_"`
+	SMB                   SMB         `json:"smb" envPrefix:"SMB_"`
 	LastLaunchedVersion   string      `json:"last_launched_version"`
 }
 
@@ -210,6 +224,18 @@ func DefaultConfig() *Config {
 		SFTP: SFTP{
 			Enable: false,
 			Listen: ":5222",
+		},
+		SMB: SMB{
+			Enable:      false,
+			Listen:      ":5445",
+			MaxIOReads:  4,
+			MaxIOWrites: 4,
+			TargetSPN:   "",
+			NbDomain:    "",
+			NbName:      "",
+			DnsName:     "",
+			DnsDomain:   "",
+			ShareName:   "AList",
 		},
 		LastLaunchedVersion: "",
 	}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -46,6 +46,8 @@ type User struct {
 	//   11: ftp/sftp write
 	//   12: can read archives
 	//   13: can decompress archives
+	//   14: smb read
+	//   15: smb write
 	Permission int32  `json:"permission"`
 	OtpSecret  string `json:"-"`
 	SsoID      string `json:"sso_id"` // unique by sso platform
@@ -135,6 +137,14 @@ func (u *User) CanReadArchives() bool {
 
 func (u *User) CanDecompress() bool {
 	return (u.Permission>>13)&1 == 1
+}
+
+func (u *User) CanSMBAccess() bool {
+	return (u.Permission>>14)&1 == 1
+}
+
+func (u *User) CanSMBManage() bool {
+	return (u.Permission>>15)&1 == 1
 }
 
 func (u *User) JoinPath(reqPath string) (string, error) {

--- a/server/smb.go
+++ b/server/smb.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"github.com/alist-org/alist/v3/internal/errs"
 
 	smb2 "github.com/KirCute/go-smb2-alist/server"
 	"github.com/KirCute/go-smb2-alist/vfs"
@@ -60,11 +61,15 @@ func GetUserFileSystem(user string) (map[string]vfs.VFSFileSystem, error) {
 		return nil, err
 	}
 	if !userObj.CanSMBAccess() { // For allow guest case
-		return nil, err
+		return nil, errs.PermissionDenied
 	}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "user", userObj)
+	fs, err := smb.NewVFS(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return map[string]vfs.VFSFileSystem{
-		conf.Conf.SMB.ShareName: smb.NewVFS(ctx),
+		conf.Conf.SMB.ShareName: fs,
 	}, nil
 }

--- a/server/smb.go
+++ b/server/smb.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+
+	smb2 "github.com/KirCute/go-smb2-alist/server"
+	"github.com/KirCute/go-smb2-alist/vfs"
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/server/smb"
+)
+
+func NewSmbServer() (*smb2.Server, error) {
+	srv := smb2.NewServer(
+		&smb2.ServerConfig{
+			MaxIOReads:  conf.Conf.SMB.MaxIOReads,
+			MaxIOWrites: conf.Conf.SMB.MaxIOWrites,
+			Xatrrs:      false,
+		},
+		&smb2.NTLMAuthenticator{
+			TargetSPN:    conf.Conf.SMB.TargetSPN,
+			NbDomain:     conf.Conf.SMB.NbDomain,
+			NbName:       conf.Conf.SMB.NbName,
+			DnsName:      conf.Conf.SMB.DnsName,
+			DnsDomain:    conf.Conf.SMB.DnsDomain,
+			UserPassword: GetUserPassword,
+			AllowGuest:   AllowGuest,
+		},
+		GetUserFileSystem,
+	)
+	return srv, nil
+}
+
+func AllowGuest() bool {
+	guest, err := op.GetGuest()
+	return err == nil && !guest.Disabled
+}
+
+func GetUserPassword(user string) (string, bool) {
+	u, err := op.GetUserByName(user)
+	if err != nil {
+		return "", false
+	}
+	if u.IsGuest() || !u.CanSMBAccess() {
+		return "", false
+	}
+	return u.PwdHash[:16], true
+}
+
+func GetUserFileSystem(user string) (map[string]vfs.VFSFileSystem, error) {
+	var userObj *model.User
+	var err error
+	if user == "" {
+		userObj, err = op.GetGuest()
+	} else {
+		userObj, err = op.GetUserByName(user)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !userObj.CanSMBAccess() { // For allow guest case
+		return nil, err
+	}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "user", userObj)
+	return map[string]vfs.VFSFileSystem{
+		conf.Conf.SMB.ShareName: smb.NewVFS(ctx),
+	}, nil
+}

--- a/server/smb/const.go
+++ b/server/smb/const.go
@@ -1,0 +1,5 @@
+package smb
+
+import "github.com/pkg/errors"
+
+var ErrBadHandle = errors.New("bad handle")

--- a/server/smb/fsmanage.go
+++ b/server/smb/fsmanage.go
@@ -32,7 +32,7 @@ func Mkdir(ctx context.Context, path string) (model.Obj, error) {
 	if err = fs.MakeDir(ctx, reqPath); err != nil {
 		return nil, err
 	}
-	return fs.Get(ctx, path, &fs.GetArgs{})
+	return fs.Get(ctx, reqPath, &fs.GetArgs{})
 }
 
 func Remove(ctx context.Context, path string) error {

--- a/server/smb/fsmanage.go
+++ b/server/smb/fsmanage.go
@@ -1,0 +1,79 @@
+package smb
+
+import (
+	"context"
+	stdpath "path"
+
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/fs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/server/common"
+	"github.com/pkg/errors"
+)
+
+func Mkdir(ctx context.Context, path string) (model.Obj, error) {
+	user := ctx.Value("user").(*model.User)
+	reqPath, err := user.JoinPath(path)
+	if err != nil {
+		return nil, err
+	}
+	if !user.CanWrite() || !user.CanSMBManage() {
+		meta, err := op.GetNearestMeta(stdpath.Dir(reqPath))
+		if err != nil {
+			if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+				return nil, err
+			}
+		}
+		if !common.CanWrite(meta, reqPath) {
+			return nil, errs.PermissionDenied
+		}
+	}
+	if err = fs.MakeDir(ctx, reqPath); err != nil {
+		return nil, err
+	}
+	return fs.Get(ctx, path, &fs.GetArgs{})
+}
+
+func Remove(ctx context.Context, path string) error {
+	user := ctx.Value("user").(*model.User)
+	if !user.CanRemove() || !user.CanSMBManage() {
+		return errs.PermissionDenied
+	}
+	reqPath, err := user.JoinPath(path)
+	if err != nil {
+		return err
+	}
+	return fs.Remove(ctx, reqPath)
+}
+
+func Rename(ctx context.Context, oldPath, newPath string) error {
+	user := ctx.Value("user").(*model.User)
+	srcPath, err := user.JoinPath(oldPath)
+	if err != nil {
+		return err
+	}
+	dstPath, err := user.JoinPath(newPath)
+	if err != nil {
+		return err
+	}
+	srcDir, srcBase := stdpath.Split(srcPath)
+	dstDir, dstBase := stdpath.Split(dstPath)
+	if srcDir == dstDir {
+		if !user.CanRename() || !user.CanSMBManage() {
+			return errs.PermissionDenied
+		}
+		return fs.Rename(ctx, srcPath, dstBase)
+	} else {
+		if !user.CanSMBManage() || !user.CanMove() || (srcBase != dstBase && !user.CanRename()) {
+			return errs.PermissionDenied
+		}
+		if err = fs.Move(ctx, srcPath, dstDir); err != nil {
+			return err
+		}
+		if srcBase != dstBase {
+			return fs.Rename(ctx, stdpath.Join(dstDir, srcBase), dstBase)
+		}
+		return nil
+	}
+}

--- a/server/smb/fsread.go
+++ b/server/smb/fsread.go
@@ -1,0 +1,179 @@
+package smb
+
+import (
+	"context"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"hash/fnv"
+	"os"
+
+	"github.com/KirCute/go-smb2-alist/vfs"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/fs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/server/common"
+	"github.com/pkg/errors"
+)
+
+type readingFile struct {
+	path    string
+	obj     model.Obj
+	s       stream.SStreamReadAtSeeker
+	dirRead bool
+}
+
+func newRead(path string, obj model.Obj) *readingFile {
+	return &readingFile{path: path, obj: obj, s: nil}
+}
+
+func (f *readingFile) initDownload(ctx context.Context) error {
+	if f.s != nil {
+		return nil
+	}
+	if f.obj.IsDir() {
+		return errs.NotFile
+	}
+	user := ctx.Value("user").(*model.User)
+	meta, err := op.GetNearestMeta(f.path)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+			return err
+		}
+	}
+	ctx = context.WithValue(ctx, "meta", meta)
+	if !common.CanAccess(user, meta, f.path, "") {
+		return errs.PermissionDenied
+	}
+
+	link, obj, err := fs.Link(ctx, f.path, model.LinkArgs{})
+	if err != nil {
+		return err
+	}
+	f.obj = obj
+	fileStream := stream.FileStream{
+		Obj: obj,
+		Ctx: ctx,
+	}
+	ss, err := stream.NewSeekableStream(fileStream, link)
+	if err != nil {
+		return err
+	}
+	reader, err := stream.NewReadAtSeeker(ss, 0)
+	if err != nil {
+		_ = ss.Close()
+		return err
+	}
+	f.s = reader
+	return nil
+}
+
+func (f *readingFile) Close() error {
+	if f.s == nil {
+		return nil
+	}
+	return f.s.Close()
+}
+
+func FsGet(ctx context.Context, path string) (model.Obj, error) {
+	user := ctx.Value("user").(*model.User)
+	reqPath, err := user.JoinPath(path)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := op.GetNearestMeta(reqPath)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+			return nil, err
+		}
+	}
+	ctx = context.WithValue(ctx, "meta", meta)
+	if !common.CanAccess(user, meta, reqPath, "") {
+		return nil, errs.PermissionDenied
+	}
+	return fs.Get(ctx, reqPath, &fs.GetArgs{})
+}
+
+func List(ctx context.Context, path string) ([]vfs.DirInfo, error) {
+	user := ctx.Value("user").(*model.User)
+	reqPath, err := user.JoinPath(path)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := op.GetNearestMeta(reqPath)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+			return nil, err
+		}
+	}
+	ctx = context.WithValue(ctx, "meta", meta)
+	if !common.CanAccess(user, meta, reqPath, "") {
+		return nil, errs.PermissionDenied
+	}
+	self, err := fs.Get(ctx, reqPath, &fs.GetArgs{})
+	if err != nil {
+		return nil, err
+	}
+	attr, err := MakeObjAttribute(self)
+	if err != nil {
+		return nil, err
+	}
+	objs, err := fs.List(ctx, reqPath, &fs.ListArgs{})
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]vfs.DirInfo, 0, len(objs)+2)
+	ret = append(ret, vfs.DirInfo{Name: ".", Attributes: *attr})
+	if utils.FixAndCleanPath(user.BasePath) != reqPath {
+		ret = append(ret, vfs.DirInfo{Name: "..", Attributes: *attr})
+	}
+	for _, obj := range objs {
+		a, e := MakeObjAttribute(obj)
+		if e != nil {
+			continue
+		}
+		ret = append(ret, vfs.DirInfo{Name: obj.GetName(), Attributes: *a})
+	}
+	return ret, nil
+}
+
+func MakeFileAttribute(file *os.File) (*vfs.Attributes, error) {
+	a := &vfs.Attributes{}
+	a.SetInodeNumber(uint64(file.Fd())) // 用fd没什么依据，纯随便给了个不会冲突的整数
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	a.SetSizeBytes(uint64(stat.Size()))
+	a.SetUnixMode(uint32(stat.Mode()))
+	a.SetPermissions(vfs.NewPermissionsFromMode(uint32(stat.Mode().Perm())))
+	a.SetLastDataModificationTime(stat.ModTime())
+	if stat.IsDir() {
+		a.SetFileType(vfs.FileTypeDirectory)
+	} else {
+		a.SetFileType(vfs.FileTypeRegularFile)
+	}
+	return a, nil
+}
+
+func MakeObjAttribute(obj model.Obj) (*vfs.Attributes, error) {
+	a := &vfs.Attributes{}
+	h := fnv.New64()
+	_, err := h.Write([]byte(obj.GetPath()))
+	if err != nil {
+		return nil, err
+	}
+	a.SetInodeNumber(h.Sum64())
+	a.SetSizeBytes(uint64(obj.GetSize()))
+	a.SetLastDataModificationTime(obj.ModTime())
+	if obj.IsDir() {
+		a.SetFileType(vfs.FileTypeDirectory)
+		a.SetUnixMode(0755)
+		a.SetPermissions(vfs.NewPermissionsFromMode(0755))
+	} else {
+		a.SetFileType(vfs.FileTypeRegularFile)
+		a.SetUnixMode(0644)
+		a.SetPermissions(vfs.NewPermissionsFromMode(0644))
+	}
+	return a, nil
+}

--- a/server/smb/fsup.go
+++ b/server/smb/fsup.go
@@ -1,0 +1,83 @@
+package smb
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	stdpath "path"
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/fs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/server/common"
+	"github.com/pkg/errors"
+)
+
+type writingFile struct {
+	path string
+	f    *os.File
+}
+
+func newUpload(ctx context.Context, path string) (*writingFile, error) {
+	err := uploadAuth(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	tmpFile, err := os.CreateTemp(conf.Conf.TempDir, "file-*")
+	if err != nil {
+		return nil, err
+	}
+	return &writingFile{f: tmpFile, path: path}, nil
+}
+
+func uploadAuth(ctx context.Context, path string) error {
+	user := ctx.Value("user").(*model.User)
+	meta, err := op.GetNearestMeta(stdpath.Dir(path))
+	if err != nil {
+		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+			return err
+		}
+	}
+	if !(common.CanAccess(user, meta, path, "") &&
+		((user.CanSMBManage() && user.CanWrite()) || common.CanWrite(meta, stdpath.Dir(path)))) {
+		return errs.PermissionDenied
+	}
+	return nil
+}
+
+func (f *writingFile) close(ctx context.Context) error {
+	dir, name := stdpath.Split(f.path)
+	size, err := f.f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	if _, err := f.f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	arr := make([]byte, 512)
+	if _, err := f.f.Read(arr); err != nil {
+		return err
+	}
+	contentType := http.DetectContentType(arr)
+	if _, err := f.f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	_ = fs.Remove(ctx, f.path)
+	s := &stream.FileStream{
+		Obj: &model.Object{
+			Name:     name,
+			Size:     size,
+			Modified: time.Now(),
+		},
+		Mimetype:     contentType,
+		WebPutAsTask: true,
+	}
+	s.SetTmpFile(f.f)
+	_, err = fs.PutAsTask(ctx, dir, s)
+	return err
+}

--- a/server/smb/fsup.go
+++ b/server/smb/fsup.go
@@ -2,18 +2,22 @@ package smb
 
 import (
 	"context"
+	"hash/fnv"
 	"io"
 	"net/http"
 	"os"
 	stdpath "path"
 	"time"
 
+	"github.com/KirCute/go-smb2-alist/vfs"
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/internal/stream"
+	"github.com/alist-org/alist/v3/internal/task"
+	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/alist-org/alist/v3/server/common"
 	"github.com/pkg/errors"
 )
@@ -24,15 +28,20 @@ type writingFile struct {
 }
 
 func newUpload(ctx context.Context, path string) (*writingFile, error) {
-	err := uploadAuth(ctx, path)
+	user := ctx.Value("user").(*model.User)
+	reqPath, err := user.JoinPath(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
+	}
+	err = uploadAuth(ctx, reqPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
 	tmpFile, err := os.CreateTemp(conf.Conf.TempDir, "file-*")
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
-	return &writingFile{f: tmpFile, path: path}, nil
+	return &writingFile{f: tmpFile, path: utils.FixAndCleanPath(path)}, nil
 }
 
 func uploadAuth(ctx context.Context, path string) error {
@@ -40,34 +49,39 @@ func uploadAuth(ctx context.Context, path string) error {
 	meta, err := op.GetNearestMeta(stdpath.Dir(path))
 	if err != nil {
 		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 	if !(common.CanAccess(user, meta, path, "") &&
 		((user.CanSMBManage() && user.CanWrite()) || common.CanWrite(meta, stdpath.Dir(path)))) {
-		return errs.PermissionDenied
+		return errors.WithStack(errs.PermissionDenied)
 	}
 	return nil
 }
 
-func (f *writingFile) close(ctx context.Context) error {
-	dir, name := stdpath.Split(f.path)
+func (f *writingFile) close(ctx context.Context) (task.TaskExtensionInfo, error) {
+	user := ctx.Value("user").(*model.User)
+	reqPath, err := user.JoinPath(f.path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	dir, name := stdpath.Split(reqPath)
 	size, err := f.f.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return err
+		return nil, errors.WithStack(err)
 	}
 	if _, err := f.f.Seek(0, io.SeekStart); err != nil {
-		return err
+		return nil, errors.WithStack(err)
 	}
 	arr := make([]byte, 512)
 	if _, err := f.f.Read(arr); err != nil {
-		return err
+		return nil, errors.WithStack(err)
 	}
 	contentType := http.DetectContentType(arr)
 	if _, err := f.f.Seek(0, io.SeekStart); err != nil {
-		return err
+		return nil, errors.WithStack(err)
 	}
-	_ = fs.Remove(ctx, f.path)
+	_ = fs.Remove(ctx, reqPath)
 	s := &stream.FileStream{
 		Obj: &model.Object{
 			Name:     name,
@@ -78,6 +92,21 @@ func (f *writingFile) close(ctx context.Context) error {
 		WebPutAsTask: true,
 	}
 	s.SetTmpFile(f.f)
-	_, err = fs.PutAsTask(ctx, dir, s)
-	return err
+	return fs.PutAsTask(ctx, dir, s)
+}
+
+func MakeTaskAttribute(tsk task.TaskExtensionInfo) (*vfs.Attributes, error) {
+	a := &vfs.Attributes{}
+	h := fnv.New64()
+	_, err := h.Write([]byte(tsk.GetID()))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	a.SetInodeNumber(h.Sum64())
+	a.SetSizeBytes(uint64(tsk.GetTotalBytes()))
+	a.SetLastDataModificationTime(*tsk.GetStartTime())
+	a.SetFileType(vfs.FileTypeRegularFile)
+	a.SetUnixMode(0644)
+	a.SetPermissions(vfs.NewPermissionsFromMode(0644))
+	return a, nil
 }

--- a/server/smb/vfs.go
+++ b/server/smb/vfs.go
@@ -1,0 +1,235 @@
+package smb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	stdpath "path"
+	"sync"
+	"sync/atomic"
+
+	"github.com/KirCute/go-smb2-alist/vfs"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/stream"
+)
+
+type VFS struct {
+	ctx           context.Context
+	openedPath    sync.Map // VfsHandle: *readingFile
+	openedTmpFile sync.Map // VfsHandle: *writingFile
+	nextHandle    atomic.Uint64
+}
+
+func NewVFS(ctx context.Context) *VFS {
+	return &VFS{
+		ctx:           ctx,
+		openedPath:    sync.Map{},
+		openedTmpFile: sync.Map{},
+		nextHandle:    atomic.Uint64{},
+	}
+}
+
+func (fs *VFS) GetAttr(handle vfs.VfsHandle) (*vfs.Attributes, error) {
+	if tmp, ok := fs.openedTmpFile.Load(handle); ok {
+		return MakeFileAttribute(tmp.(*writingFile).f)
+	}
+	if r, ok := fs.openedPath.Load(handle); ok {
+		return MakeObjAttribute(r.(*readingFile).obj)
+	}
+	return nil, errors.New("bad handle")
+}
+
+func (fs *VFS) Flush(handle vfs.VfsHandle) error {
+	if tmp, ok := fs.openedTmpFile.Load(handle); ok {
+		return tmp.(*writingFile).f.Sync()
+	}
+	return nil
+}
+
+func (fs *VFS) newUpload(path string) (vfs.VfsHandle, error) {
+	f, err := newUpload(fs.ctx, path)
+	if err != nil {
+		return 0, err
+	}
+	handle := vfs.VfsHandle(fs.nextHandle.Add(1))
+	fs.openedTmpFile.Store(handle, f)
+	return handle, nil
+}
+
+func (fs *VFS) Open(path string, flags int, _ int) (vfs.VfsHandle, error) {
+	if (flags & os.O_APPEND) != 0 {
+		return 0, errs.NotSupport
+	}
+	obj, err := FsGet(fs.ctx, path)
+	if errors.Is(err, errs.ObjectNotFound) {
+		if (flags&os.O_RDWR) == 0 || (flags&os.O_CREATE) == 0 {
+			return 0, os.ErrNotExist
+		}
+		return fs.newUpload(path)
+	} else if err == nil {
+		if (flags&os.O_CREATE) != 0 && (flags&os.O_EXCL) != 0 {
+			return 0, os.ErrExist
+		}
+		if (flags & os.O_RDWR) != 0 {
+			if (flags&os.O_CREATE) != 0 && (flags&os.O_TRUNC) != 0 {
+				return fs.newUpload(path)
+			}
+			return 0, errs.NotSupport
+		}
+		handle := vfs.VfsHandle(fs.nextHandle.Add(1))
+		fs.openedPath.Store(handle, newRead(path, obj))
+		return handle, nil
+	}
+	return 0, err
+}
+
+func (fs *VFS) Close(handle vfs.VfsHandle) error {
+	if tmp, ok := fs.openedTmpFile.Load(handle); ok {
+		err := tmp.(*writingFile).close(fs.ctx)
+		fs.openedTmpFile.Delete(handle)
+		return err
+	}
+	if r, ok := fs.openedPath.Load(handle); ok {
+		err := r.(*readingFile).Close()
+		fs.openedPath.Delete(handle)
+		return err
+	}
+	return errors.New("bad handle")
+}
+
+func (fs *VFS) Lookup(handle vfs.VfsHandle, name string) (*vfs.Attributes, error) {
+	var p *readingFile
+	if r, ok := fs.openedPath.Load(handle); ok {
+		p = r.(*readingFile)
+	} else {
+		return nil, errors.New("bad handle")
+	}
+	obj, err := FsGet(fs.ctx, stdpath.Join(p.path, name))
+	if err != nil {
+		return nil, err
+	}
+	return MakeObjAttribute(obj)
+}
+
+func (fs *VFS) Mkdir(path string, _ int) (*vfs.Attributes, error) {
+	obj, err := Mkdir(fs.ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return MakeObjAttribute(obj)
+}
+
+func (fs *VFS) Read(handle vfs.VfsHandle, buf []byte, offset uint64, _ int) (n int, err error) {
+	if tmp, ok := fs.openedTmpFile.Load(handle); ok {
+		n, err = tmp.(*writingFile).f.ReadAt(buf, int64(offset))
+	} else if r, ok := fs.openedPath.Load(handle); ok {
+		rf := r.(*readingFile)
+		err = rf.initDownload(fs.ctx)
+		if err == nil {
+			n, err = rf.s.ReadAt(buf, int64(offset))
+		}
+	} else {
+		err = errors.New("bad handle")
+	}
+	_ = stream.ClientDownloadLimit.WaitN(fs.ctx, n)
+	return
+}
+
+func (fs *VFS) Write(handle vfs.VfsHandle, buf []byte, offset uint64, _ int) (n int, err error) {
+	if tmp, ok := fs.openedTmpFile.Load(handle); ok {
+		n, err = tmp.(*writingFile).f.WriteAt(buf, int64(offset))
+	} else {
+		err = errors.New("bad handle")
+	}
+	_ = stream.ClientUploadLimit.WaitN(fs.ctx, n)
+	return
+}
+
+func (fs *VFS) OpenDir(path string) (vfs.VfsHandle, error) {
+	obj, err := FsGet(fs.ctx, path)
+	if err != nil {
+		return 0, err
+	}
+	handle := vfs.VfsHandle(fs.nextHandle.Add(1))
+	fs.openedPath.Store(handle, newRead(path, obj))
+	return handle, nil
+}
+
+func (fs *VFS) ReadDir(handle vfs.VfsHandle, pos int, _ int) ([]vfs.DirInfo, error) {
+	var p *readingFile
+	if r, ok := fs.openedPath.Load(handle); ok {
+		p = r.(*readingFile)
+	} else {
+		return nil, errors.New("bad handle")
+	}
+	if pos == 0 && p.dirRead {
+		return nil, io.EOF
+	}
+	p.dirRead = true
+	return List(fs.ctx, p.path)
+}
+
+func (fs *VFS) Unlink(handle vfs.VfsHandle) error {
+	if r, ok := fs.openedPath.Load(handle); ok {
+		rf := r.(*readingFile)
+		_ = rf.Close()
+		fs.openedPath.Delete(handle)
+		return Remove(fs.ctx, rf.path)
+	}
+	return errors.New("bad handle")
+}
+
+func (fs *VFS) Rename(handle vfs.VfsHandle, to string, _ int) error {
+	if r, ok := fs.openedPath.Load(handle); ok {
+		rf := r.(*readingFile)
+		_ = rf.Close()
+		fs.openedPath.Delete(handle)
+		return Rename(fs.ctx, rf.path, to)
+	}
+	return errors.New("bad handle")
+}
+
+func (fs *VFS) StatFS(vfs.VfsHandle) (*vfs.FSAttributes, error) {
+	return &vfs.FSAttributes{}, nil
+}
+
+func (fs *VFS) SetAttr(vfs.VfsHandle, *vfs.Attributes) (*vfs.Attributes, error) {
+	return nil, errs.NotSupport
+}
+
+func (fs *VFS) FSync(vfs.VfsHandle) error {
+	return nil
+}
+
+func (fs *VFS) Readlink(vfs.VfsHandle) (string, error) {
+	return "", errs.NotSupport
+}
+
+func (fs *VFS) Truncate(vfs.VfsHandle, uint64) error {
+	return errs.NotSupport
+}
+
+func (fs *VFS) Symlink(vfs.VfsHandle, string, int) (*vfs.Attributes, error) {
+	return nil, errs.NotSupport
+}
+
+func (fs *VFS) Link(vfs.VfsNode, vfs.VfsNode, string) (*vfs.Attributes, error) {
+	return nil, nil
+}
+
+func (fs *VFS) Listxattr(vfs.VfsHandle) ([]string, error) {
+	return []string{}, nil
+}
+
+func (fs *VFS) Getxattr(vfs.VfsHandle, string, []byte) (int, error) {
+	return 0, errs.NotSupport
+}
+
+func (fs *VFS) Setxattr(vfs.VfsHandle, string, []byte) error {
+	return errs.NotSupport
+}
+
+func (fs *VFS) Removexattr(vfs.VfsHandle, string) error {
+	return errs.NotSupport
+}

--- a/server/smb/vfs_wrap.go
+++ b/server/smb/vfs_wrap.go
@@ -1,0 +1,167 @@
+package smb
+
+import (
+	"errors"
+	"io"
+
+	"github.com/KirCute/go-smb2-alist/vfs"
+	"github.com/alist-org/alist/v3/internal/errs"
+	log "github.com/sirupsen/logrus"
+)
+
+type VFSWrapper struct {
+	fs   *VFS
+	user string
+}
+
+func (v *VFSWrapper) GetAttr(handle vfs.VfsHandle) (*vfs.Attributes, error) {
+	a, e := v.fs.GetAttr(handle)
+	if e != nil {
+		log.Errorf("SMB: %s called GetAttr(%d) and got error: %+v", v.user, handle, e)
+	}
+	return a, e
+}
+
+func (v *VFSWrapper) SetAttr(handle vfs.VfsHandle, attributes *vfs.Attributes) (*vfs.Attributes, error) {
+	return v.fs.SetAttr(handle, attributes)
+}
+
+func (v *VFSWrapper) StatFS(handle vfs.VfsHandle) (*vfs.FSAttributes, error) {
+	return v.fs.StatFS(handle)
+}
+
+func (v *VFSWrapper) FSync(handle vfs.VfsHandle) error {
+	return v.fs.FSync(handle)
+}
+
+func (v *VFSWrapper) Flush(handle vfs.VfsHandle) error {
+	return v.fs.Flush(handle)
+}
+
+func (v *VFSWrapper) Open(s string, i int, i2 int) (vfs.VfsHandle, error) {
+	h, e := v.fs.Open(s, i, i2)
+	if e == nil {
+		log.Infof("SMB: %s called Open(%s, %o) and got result: %d", v.user, s, i, h)
+	} else {
+		log.Errorf("SMB: %s called Open(%s, %o) and got error: %+v", v.user, s, i, e)
+	}
+	return h, e
+}
+
+func (v *VFSWrapper) Close(handle vfs.VfsHandle) error {
+	e := v.fs.Close(handle)
+	if e == nil {
+		log.Infof("SMB: %s called Close(%d)", v.user, handle)
+	} else if errors.Is(e, ErrBadHandle) {
+		log.Warnf("SMB: %s called Close(%d) but duplicate", v.user, handle)
+	} else {
+		log.Errorf("SMB: %s called Close(%d) and got error: %+v", v.user, handle, e)
+	}
+	return e
+}
+
+func (v *VFSWrapper) Lookup(handle vfs.VfsHandle, s string) (*vfs.Attributes, error) {
+	a, e := v.fs.Lookup(handle, s)
+	if errors.Is(e, errs.ObjectNotFound) {
+		log.Warnf("SMB: %s called Lookup(%d, %s) but not found", v.user, handle, s)
+	} else if e != nil {
+		log.Errorf("SMB: %s called Lookup(%d, %s) and got error: %+v", v.user, handle, s, e)
+	}
+	return a, e
+}
+
+func (v *VFSWrapper) Mkdir(s string, i int) (*vfs.Attributes, error) {
+	a, e := v.fs.Mkdir(s, i)
+	if e == nil {
+		log.Infof("SMB: %s called Mkdir(%s, %d)", v.user, s, i)
+	} else {
+		log.Errorf("SMB: %s called Mkdir(%s, %d) and got error: %+v", v.user, s, i, e)
+	}
+	return a, e
+}
+
+func (v *VFSWrapper) Read(handle vfs.VfsHandle, bytes []byte, u uint64, i int) (int, error) {
+	n, err := v.fs.Read(handle, bytes, u, i)
+	if err != nil {
+		log.Errorf("SMB: %s called Read(%d, len=%d, offset=%d), read %d bytes and got error %+v", v.user, handle, len(bytes), u, n, err)
+	}
+	return n, err
+}
+
+func (v *VFSWrapper) Write(handle vfs.VfsHandle, bytes []byte, u uint64, i int) (int, error) {
+	n, err := v.fs.Write(handle, bytes, u, i)
+	if err != nil {
+		log.Errorf("SMB: %s called Write(%d, len=%d, offset=%d, mode=%d), write %d bytes and got error %+v", v.user, handle, len(bytes), u, i, n, err)
+	}
+	return n, err
+}
+
+func (v *VFSWrapper) OpenDir(s string) (vfs.VfsHandle, error) {
+	h, e := v.fs.OpenDir(s)
+	if e == nil {
+		log.Infof("SMB: %s called OpenDir(%s) and got result: %d", v.user, s, h)
+	} else {
+		log.Errorf("SMB: %s called OpenDir(%s) and got error: %+v", v.user, s, e)
+	}
+	return h, e
+}
+
+func (v *VFSWrapper) ReadDir(handle vfs.VfsHandle, i int, i2 int) ([]vfs.DirInfo, error) {
+	info, e := v.fs.ReadDir(handle, i, i2)
+	if e != nil && !errors.Is(e, io.EOF) {
+		log.Errorf("SMB: %s called ReadDir(%d, %d, %d) and got error: %+v", v.user, handle, i, i2, e)
+	}
+	return info, e
+}
+
+func (v *VFSWrapper) Readlink(handle vfs.VfsHandle) (string, error) {
+	return v.fs.Readlink(handle)
+}
+
+func (v *VFSWrapper) Unlink(handle vfs.VfsHandle) error {
+	e := v.fs.Unlink(handle)
+	if e == nil {
+		log.Infof("SMB: %s called Unlink(%d)", v.user, handle)
+	} else {
+		log.Errorf("SMB: %s called Unlink(%d) and got error: %+v", v.user, handle, e)
+	}
+	return e
+}
+
+func (v *VFSWrapper) Truncate(handle vfs.VfsHandle, u uint64) error {
+	return v.fs.Truncate(handle, u)
+}
+
+func (v *VFSWrapper) Rename(handle vfs.VfsHandle, s string, i int) error {
+	e := v.fs.Rename(handle, s, i)
+	if e == nil {
+		log.Infof("SMB: %s called Rename(%d, %s, %d)", v.user, handle, s, i)
+	} else {
+		log.Errorf("SMB: %s called Rename(%d, %s, %d) and got error: %+v", v.user, handle, s, i, e)
+	}
+	return e
+}
+
+func (v *VFSWrapper) Symlink(handle vfs.VfsHandle, s string, i int) (*vfs.Attributes, error) {
+	return v.fs.Symlink(handle, s, i)
+}
+
+func (v *VFSWrapper) Link(node vfs.VfsNode, node2 vfs.VfsNode, s string) (*vfs.Attributes, error) {
+	return v.fs.Link(node, node2, s)
+}
+
+func (v *VFSWrapper) Listxattr(handle vfs.VfsHandle) ([]string, error) {
+	return v.fs.Listxattr(handle)
+}
+
+func (v *VFSWrapper) Getxattr(handle vfs.VfsHandle, s string, bytes []byte) (int, error) {
+	return v.fs.Getxattr(handle, s, bytes)
+}
+
+func (v *VFSWrapper) Setxattr(handle vfs.VfsHandle, s string, bytes []byte) error {
+	return v.fs.Setxattr(handle, s, bytes)
+}
+
+func (v *VFSWrapper) Removexattr(handle vfs.VfsHandle, s string) error {
+	return v.fs.Removexattr(handle, s)
+}


### PR DESCRIPTION
在`macos-fuse-t/go-smb2`的基础上改了一些实现的 SMB 挂载。

已使用以下客户端进行测试，由于 SMB 协议非常贴近底层，适配起来问题比较多，希望有意者可以再多用几种客户端进行测试，分享一下测试结果。
- AList SMB 驱动：通过。
- smbclient：删除文件失败，文件表现为循环以 O_RDONLY 方式打开（`Open`）和关闭（`Close`）待删除的文件，删除文件夹通过，客户端不支持复制，其它通过。
- mount.cifs：偶遇`Unable to apply new capability set.`，拼尽全力无法战胜。
- Windows 添加网络位置：
   使用命令：
   ```cmd
   net use A: \\127.0.0.1\AList <16位密码> /USER:admin /TCPPORT:5445
   ```
   上传、复制、下载可能会报“0x8007003A: 指定的服务器无法运行请求的操作”错误，但如果操作的是小文件一般实际上会成功，如果操作大文件，上传、复制的结果可能会被截断，下载的结果一般与源文件等大小（应该只是预分配了这么大）但也无法正常读取，其它操作通过。
   这是最主要的使用场景但效果不尽人意，后面再优化一下吧。

暂时没有测试游客访问。

除此之外登录验证部分还存在一些问题，SMB 比较基础的验证方式 NTLMv2 大概是这么一个原理：

1. 服务器生成一个随机数字发送给客户端
2. 客户端使用这个数字、密码、全大写用户名和域名进行一些不可逆计算得到一个哈希值，把这个哈希值发送给服务器
3. 服务器进行同样的运算，如果运算结果相同，则验证成功

显然这样的验证方式需要服务器知道密码的原文（退而求其次也必须知道密码的 MD4 哈希），然而服务器中只有用户的加盐 SHA256 哈希，所以验证这一块我暂时不知道怎么搞，想听听大伙怎么想。

目前访问 SMB 服务使用的密码是用户密码的加盐 SHA256 哈希的前 16 位。

Front-end part: AlistGo/alist-web#266