### PR TITLE
fix(ipfs): fix problems

### DIFF
--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -81,9 +81,6 @@ func (d *IPFS) Get(ctx context.Context, path string) (model.Obj, error) {
 	if err != nil {
 		return nil, err
 	}
-	if file.Type == "directory" {
-		return nil, fmt.Errorf("not a file")
-	}
 	return &model.Object{ID: file.Hash, Name: filepath.Base(path), Path: path, Size: int64(file.Size), IsFolder: file.Type == "directory"}, nil
 }
 

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -111,8 +111,8 @@ func (d *IPFS) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 	if d.Mode != "mfs" {
 		return fmt.Errorf("only write in mfs mode")
 	}
-	newFileName := filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
-	return d.sh.FilesCp(ctx, srcObj.GetPath(), newFileName)
+	dstPath := filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	return d.sh.FilesCp(ctx, srcObj.GetPath(), dstPath)
 }
 
 func (d *IPFS) Remove(ctx context.Context, obj model.Obj) error {

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -104,6 +104,7 @@ func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
+	d.sh.FilesRm(ctx, dstDir.GetPath(), true)
 	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstDir.GetPath(), Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
 		d.sh.FilesMv(ctx, srcObj.GetPath(), dstDir.GetPath())
 }
@@ -113,6 +114,7 @@ func (d *IPFS) Rename(ctx context.Context, srcObj model.Obj, newName string) (mo
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
 	dstPath := filepath.Join(filepath.Dir(srcObj.GetPath()), newName)
+	d.sh.FilesRm(ctx, dstPath, true)
 	return &model.Object{ID: srcObj.GetID(), Name: newName, Path: dstPath, Size: int64(srcObj.GetSize()),
 		IsFolder: srcObj.IsDir()}, d.sh.FilesMv(ctx, srcObj.GetPath(), dstPath)
 }
@@ -122,8 +124,9 @@ func (d *IPFS) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
 	dstPath := filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	d.sh.FilesRm(ctx, dstPath, true)
 	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstPath, Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
-		d.sh.FilesCp(ctx, srcObj.GetPath(), dstPath, shell.FilesCp.Parents(true))
+		d.sh.FilesCp(ctx, filepath.Join("/ipfs/", srcObj.GetID()), dstPath, shell.FilesCp.Parents(true))
 }
 
 func (d *IPFS) Remove(ctx context.Context, obj model.Obj) error {

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"path/filepath"
 
 	shell "github.com/ipfs/go-ipfs-api"
 
@@ -105,7 +104,7 @@ func (d *IPFS) Get(ctx context.Context, rawPath string) (model.Obj, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &model.Object{ID: file.Hash, Name: filepath.Base(rawPath), Path: rawPath, Size: int64(file.Size), IsFolder: file.Type == "directory"}, nil
+	return &model.Object{ID: file.Hash, Name: path.Base(rawPath), Path: rawPath, Size: int64(file.Size), IsFolder: file.Type == "directory"}, nil
 }
 
 func (d *IPFS) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
@@ -128,7 +127,7 @@ func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
-	dstPath := path.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	dstPath := path.Join(dstDir.GetPath(), path.Base(srcObj.GetPath()))
 	d.sh.FilesRm(ctx, dstPath, true)
 	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstPath, Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
 		d.sh.FilesMv(ctx, srcObj.GetPath(), dstDir.GetPath())
@@ -138,7 +137,7 @@ func (d *IPFS) Rename(ctx context.Context, srcObj model.Obj, newName string) (mo
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
-	dstPath := path.Join(filepath.Dir(srcObj.GetPath()), newName)
+	dstPath := path.Join(path.Dir(srcObj.GetPath()), newName)
 	d.sh.FilesRm(ctx, dstPath, true)
 	return &model.Object{ID: srcObj.GetID(), Name: newName, Path: dstPath, Size: int64(srcObj.GetSize()),
 		IsFolder: srcObj.IsDir()}, d.sh.FilesMv(ctx, srcObj.GetPath(), dstPath)
@@ -148,7 +147,7 @@ func (d *IPFS) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
-	dstPath := path.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	dstPath := path.Join(dstDir.GetPath(), path.Base(srcObj.GetPath()))
 	d.sh.FilesRm(ctx, dstPath, true)
 	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstPath, Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
 		d.sh.FilesCp(ctx, path.Join("/ipfs/", srcObj.GetID()), dstPath, shell.FilesCp.Parents(true))

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -104,7 +104,7 @@ func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
-	d.sh.FilesRm(ctx, dstDir.GetPath(), true)
+	d.sh.FilesRm(ctx, filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath())), true)
 	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstDir.GetPath(), Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
 		d.sh.FilesMv(ctx, srcObj.GetPath(), dstDir.GetPath())
 }

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"strings"
 
 	shell "github.com/ipfs/go-ipfs-api"
 
@@ -43,33 +42,32 @@ func (d *IPFS) Drop(ctx context.Context) error {
 }
 
 func (d *IPFS) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
-	path := dir.GetPath()
+	ipfsPath := dir.GetPath()
 	switch d.Mode {
 	case "ipfs":
-		path, _ = url.JoinPath("/ipfs", path)
+		ipfsPath = filepath.Join("/ipfs", ipfsPath)
 	case "ipns":
-		path, _ = url.JoinPath("/ipns", path)
+		ipfsPath = filepath.Join("/ipns", ipfsPath)
 	case "mfs":
-		fileStat, err := d.sh.FilesStat(ctx, path)
+		fileStat, err := d.sh.FilesStat(ctx, ipfsPath)
 		if err != nil {
 			return nil, err
 		}
-		path, _ = url.JoinPath("/ipfs", fileStat.Hash)
+		ipfsPath = filepath.Join("/ipfs", fileStat.Hash)
 	default:
 		return nil, fmt.Errorf("mode error")
 	}
-
-	dirs, err := d.sh.List(path)
+	dirs, err := d.sh.List(ipfsPath)
 	if err != nil {
 		return nil, err
 	}
 
 	objlist := []model.Obj{}
 	for _, file := range dirs {
-		gateurl := *d.gateURL.JoinPath("/ipfs/" + file.Hash)
-		gateurl.RawQuery = "filename=" + url.PathEscape(file.Name)
+		gateurl := *d.gateURL.JoinPath("/ipfs/", file.Hash)
+		gateurl.RawQuery = "filename=" + url.QueryEscape(file.Name)
 		objlist = append(objlist, &model.ObjectURL{
-			Object: model.Object{ID: "/ipfs/" + file.Hash, Name: file.Name, Size: int64(file.Size), IsFolder: file.Type == 1},
+			Object: model.Object{ID: file.Hash, Name: file.Name, Size: int64(file.Size), IsFolder: file.Type == 1},
 			Url:    model.Url{Url: gateurl.String()},
 		})
 	}
@@ -78,8 +76,8 @@ func (d *IPFS) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]
 }
 
 func (d *IPFS) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
-	gateurl := d.gateURL.JoinPath(file.GetID())
-	gateurl.RawQuery = "filename=" + url.PathEscape(file.GetName())
+	gateurl := d.gateURL.JoinPath("/ipfs/", file.GetID())
+	gateurl.RawQuery = "filename=" + url.QueryEscape(file.GetName())
 	return &model.Link{URL: gateurl.String()}, nil
 }
 
@@ -91,7 +89,7 @@ func (d *IPFS) MakeDir(ctx context.Context, parentDir model.Obj, dirName string)
 	if path[len(path):] != "/" {
 		path += "/"
 	}
-	return d.sh.FilesMkdir(ctx, path+dirName)
+	return d.sh.FilesMkdir(ctx, filepath.Join(path, dirName))
 }
 
 func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
@@ -105,16 +103,16 @@ func (d *IPFS) Rename(ctx context.Context, srcObj model.Obj, newName string) err
 	if d.Mode != "mfs" {
 		return fmt.Errorf("only write in mfs mode")
 	}
-	newFileName := filepath.Dir(srcObj.GetPath()) + "/" + newName
-	return d.sh.FilesMv(ctx, srcObj.GetPath(), strings.ReplaceAll(newFileName, "\\", "/"))
+	dstPath := filepath.Join(filepath.Dir(srcObj.GetPath()), newName)
+	return d.sh.FilesMv(ctx, srcObj.GetPath(), dstPath)
 }
 
 func (d *IPFS) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 	if d.Mode != "mfs" {
 		return fmt.Errorf("only write in mfs mode")
 	}
-	newFileName := dstDir.GetPath() + "/" + filepath.Base(srcObj.GetPath())
-	return d.sh.FilesCp(ctx, srcObj.GetPath(), strings.ReplaceAll(newFileName, "\\", "/"))
+	newFileName := filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	return d.sh.FilesCp(ctx, srcObj.GetPath(), newFileName)
 }
 
 func (d *IPFS) Remove(ctx context.Context, obj model.Obj) error {
@@ -135,7 +133,7 @@ func (d *IPFS) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, 
 	if err != nil {
 		return err
 	}
-	err = d.sh.FilesCp(ctx, "/ipfs/"+outHash, dstDir.GetPath()+"/"+strings.ReplaceAll(s.GetName(), "\\", "/"))
+	err = d.sh.FilesCp(ctx, filepath.Join("/ipfs/", outHash), filepath.Join(dstDir.GetPath(), s.GetName()))
 	return err
 }
 

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -104,8 +104,9 @@ func (d *IPFS) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, e
 	if d.Mode != "mfs" {
 		return nil, fmt.Errorf("only write in mfs mode")
 	}
-	d.sh.FilesRm(ctx, filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath())), true)
-	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstDir.GetPath(), Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
+	dstPath := filepath.Join(dstDir.GetPath(), filepath.Base(srcObj.GetPath()))
+	d.sh.FilesRm(ctx, dstPath, true)
+	return &model.Object{ID: srcObj.GetID(), Name: srcObj.GetName(), Path: dstPath, Size: int64(srcObj.GetSize()), IsFolder: srcObj.IsDir()},
 		d.sh.FilesMv(ctx, srcObj.GetPath(), dstDir.GetPath())
 }
 
@@ -147,13 +148,14 @@ func (d *IPFS) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, 
 	if err != nil {
 		return nil, err
 	}
+	dstPath := filepath.Join(dstDir.GetPath(), s.GetName())
 	if s.GetExist() != nil {
-		d.sh.FilesRm(ctx, filepath.Join(dstDir.GetPath(), s.GetName()), true)
+		d.sh.FilesRm(ctx, dstPath, true)
 	}
-	err = d.sh.FilesCp(ctx, filepath.Join("/ipfs/", outHash), filepath.Join(dstDir.GetPath(), s.GetName()), shell.FilesCp.Parents(true))
+	err = d.sh.FilesCp(ctx, filepath.Join("/ipfs/", outHash), dstPath, shell.FilesCp.Parents(true))
 	gateurl := d.gateURL.JoinPath("/ipfs/", outHash)
 	gateurl.RawQuery = "filename=" + url.QueryEscape(s.GetName())
-	return &model.Object{ID: outHash, Name: s.GetName(), Path: filepath.Join(dstDir.GetPath(), s.GetName()), Size: int64(s.GetSize()), IsFolder: s.IsDir()}, err
+	return &model.Object{ID: outHash, Name: s.GetName(), Path: dstPath, Size: int64(s.GetSize()), IsFolder: s.IsDir()}, err
 }
 
 //func (d *Template) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -86,9 +86,6 @@ func (d *IPFS) MakeDir(ctx context.Context, parentDir model.Obj, dirName string)
 		return fmt.Errorf("only write in mfs mode")
 	}
 	path := parentDir.GetPath()
-	if path[len(path):] != "/" {
-		path += "/"
-	}
 	return d.sh.FilesMkdir(ctx, filepath.Join(path, dirName))
 }
 

--- a/drivers/ipfs_api/driver.go
+++ b/drivers/ipfs_api/driver.go
@@ -77,6 +77,9 @@ func (d *IPFS) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*
 }
 
 func (d *IPFS) Get(ctx context.Context, path string) (model.Obj, error) {
+	if d.Mode != "mfs" {
+		return nil, fmt.Errorf("only get path for mfs")
+	}
 	file, err := d.sh.FilesStat(ctx, path)
 	if err != nil {
 		return nil, err

--- a/drivers/ipfs_api/meta.go
+++ b/drivers/ipfs_api/meta.go
@@ -9,8 +9,8 @@ type Addition struct {
 	// Usually one of two
 	driver.RootPath
 	Mode     string `json:"mode" options:"ipfs,ipns,mfs" type:"select" required:"true"`
-	Endpoint string `json:"endpoint" default:"http://127.0.0.1:5001"`
-	Gateway  string `json:"gateway" default:"http://127.0.0.1:8080"`
+	Endpoint string `json:"endpoint" default:"http://127.0.0.1:5001" required:"true"`
+	Gateway  string `json:"gateway" default:"http://127.0.0.1:8080" required:"true"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
进行了进一步的测试
## 使用正确的路径拼接
发现了由于路径拼接导致的中文和带符号路径无法正常使用的问题
使用更加规范的路径拼接，修复了有中文或符号的路径无法正常访问的问题
## 用withresult方法重构
提高性能
## 添加get方法
提高性能
## 写方法方法进行覆写
允许覆写文件
## 允许创建parent目录
使用parent参数，例如允许直接使用/aa/bb/m.md同时创建目录和文件