### PR TITLE
revert "refactor(net): pass request header"

### DIFF
--- a/internal/net/serve.go
+++ b/internal/net/serve.go
@@ -114,7 +114,7 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request, name string, modTime time
 
 	// 使用请求的Context
 	// 不然从sendContent读不到数据，即使请求断开CopyBuffer也会一直堵塞
-	ctx := context.WithValue(r.Context(), "request_header", &r.Header)
+	ctx := context.WithValue(r.Context(), "request_header", r.Header)
 	switch {
 	case len(ranges) == 0:
 		reader, err := RangeReadCloser.RangeRead(ctx, http_range.Range{Length: -1})

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -19,11 +19,7 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 	}
 	rangeReaderFunc := func(ctx context.Context, r http_range.Range) (io.ReadCloser, error) {
 		if link.Concurrency != 0 || link.PartSize != 0 {
-			requestHeader := ctx.Value("request_header")
-			if requestHeader == nil {
-				requestHeader = &http.Header{}
-			}
-			header := net.ProcessHeader(*(requestHeader.(*http.Header)), link.Header)
+			header := net.ProcessHeader(nil, link.Header)
 			down := net.NewDownloader(func(d *net.Downloader) {
 				d.Concurrency = link.Concurrency
 				d.PartSize = link.PartSize
@@ -64,11 +60,7 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 }
 
 func RequestRangedHttp(ctx context.Context, link *model.Link, offset, length int64) (*http.Response, error) {
-	requestHeader := ctx.Value("request_header")
-	if requestHeader == nil {
-		requestHeader = &http.Header{}
-	}
-	header := net.ProcessHeader(*(requestHeader.(*http.Header)), link.Header)
+	header := net.ProcessHeader(nil, link.Header)
 	header = http_range.ApplyRangeToHttpHeader(http_range.Range{Start: offset, Length: length}, header)
 
 	return net.RequestHttp(ctx, "GET", header, link.URL)

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -50,9 +50,9 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		rangeReader := func(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
 			requestHeader := ctx.Value("request_header")
 			if requestHeader == nil {
-				requestHeader = &http.Header{}
+				requestHeader = http.Header{}
 			}
-			header := net.ProcessHeader(*(requestHeader.(*http.Header)), link.Header)
+			header := net.ProcessHeader(requestHeader.(http.Header), link.Header)
 			down := net.NewDownloader(func(d *net.Downloader) {
 				d.Concurrency = link.Concurrency
 				d.PartSize = link.PartSize


### PR DESCRIPTION
* 恢复部分修改 https://github.com/AlistGo/alist/pull/8031/commits/5be50e77d9ad8d67e343aa7e9380bcdd2506ae8f

stream.GetRangeReadCloserFromLink只在内部使用，传递请求头好像不是个好选择😢
* https://github.com/AlistGo/alist/issues/8119#issuecomment-2765817711