### PR TITLE
fix(baidu_netdisk): add another video crack api

### DIFF
--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -78,6 +78,8 @@ func (d *BaiduNetdisk) List(ctx context.Context, dir model.Obj, args model.ListA
 func (d *BaiduNetdisk) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if d.DownloadAPI == "crack" {
 		return d.linkCrack(file, args)
+	} else if d.DownloadAPI == "crack_video" {
+		return d.linkCrackVideo(file, args)
 	}
 	return d.linkOfficial(file, args)
 }

--- a/drivers/baidu_netdisk/meta.go
+++ b/drivers/baidu_netdisk/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	driver.RootPath
 	OrderBy               string `json:"order_by" type:"select" options:"name,time,size" default:"name"`
 	OrderDirection        string `json:"order_direction" type:"select" options:"asc,desc" default:"asc"`
-	DownloadAPI           string `json:"download_api" type:"select" options:"official,crack" default:"official"`
+	DownloadAPI           string `json:"download_api" type:"select" options:"official,crack,crack_video" default:"official"`
 	ClientID              string `json:"client_id" required:"true" default:"iYCeC9g08h5vuP9UqvPHKKSVrKFXGa1v"`
 	ClientSecret          string `json:"client_secret" required:"true" default:"jXiFMOPVPCWlO2M5CwWQzffpNPaGTRBG"`
 	CustomCrackUA         string `json:"custom_crack_ua" required:"true" default:"netdisk"`
@@ -19,6 +19,7 @@ type Addition struct {
 	UploadAPI             string `json:"upload_api" default:"https://d.pcs.baidu.com"`
 	CustomUploadPartSize  int64  `json:"custom_upload_part_size" type:"number" default:"0" help:"0 for auto"`
 	LowBandwithUploadMode bool   `json:"low_bandwith_upload_mode" default:"false"`
+	OnlyListVideoFile     bool   `json:"only_list_video_file" default:"false"`
 }
 
 var config = driver.Config{

--- a/drivers/baidu_netdisk/types.go
+++ b/drivers/baidu_netdisk/types.go
@@ -17,7 +17,7 @@ type TokenErrResp struct {
 type File struct {
 	//TkbindId     int    `json:"tkbind_id"`
 	//OwnerType    int    `json:"owner_type"`
-	//Category     int    `json:"category"`
+	Category int `json:"category"`
 	//RealCategory string `json:"real_category"`
 	FsId int64 `json:"fs_id"`
 	//OperId      int   `json:"oper_id"`


### PR DESCRIPTION
为 百度网盘驱动添加了新的下载接口 `crack_video` ，仅能获取视频文件的地址，目前测试下来，无vip可原画满速下载，仍需要ua

同时还增加了 `OnlyListVideoFile` 选项，是否仅展示视频文件(包括文件夹)