### PR TITLE
fix(thunder): fix login issue

### DIFF
--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -44,26 +44,29 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 			Common: &Common{
 				client: base.NewRestyClient(),
 				Algorithms: []string{
-					"HPxr4BVygTQVtQkIMwQH33ywbgYG5l4JoR",
-					"GzhNkZ8pOBsCY+7",
-					"v+l0ImTpG7c7/",
-					"e5ztohgVXNP",
-					"t",
-					"EbXUWyVVqQbQX39Mbjn2geok3/0WEkAVxeqhtx857++kjJiRheP8l77gO",
-					"o7dvYgbRMOpHXxCs",
-					"6MW8TD8DphmakaxCqVrfv7NReRRN7ck3KLnXBculD58MvxjFRqT+",
-					"kmo0HxCKVfmxoZswLB4bVA/dwqbVAYghSb",
-					"j",
-					"4scKJNdd7F27Hv7tbt",
+					"9uJNVj/wLmdwKrJaVj/omlQ",
+					"Oz64Lp0GigmChHMf/6TNfxx7O9PyopcczMsnf",
+					"Eb+L7Ce+Ej48u",
+					"jKY0",
+					"ASr0zCl6v8W4aidjPK5KHd1Lq3t+vBFf41dqv5+fnOd",
+					"wQlozdg6r1qxh0eRmt3QgNXOvSZO6q/GXK",
+					"gmirk+ciAvIgA/cxUUCema47jr/YToixTT+Q6O",
+					"5IiCoM9B1/788ntB",
+					"P07JH0h6qoM6TSUAK2aL9T5s2QBVeY9JWvalf",
+					"+oK0AN",
 				},
-				DeviceID:          utils.GetMD5EncodeStr(x.Username + x.Password),
+				DeviceID: func() string {
+					if len(x.DeviceID) != 32 {
+						return utils.GetMD5EncodeStr(x.DeviceID)
+					}
+					return x.DeviceID
+				}(),
 				ClientID:          "Xp6vsxz_7IYVw2BB",
 				ClientSecret:      "Xp6vsy4tN9toTVdMSpomVdXpRmES",
-				ClientVersion:     "7.51.0.8196",
+				ClientVersion:     "8.31.0.9726",
 				PackageName:       "com.xunlei.downloadprovider",
-				UserAgent:         "ANDROID-com.xunlei.downloadprovider/7.51.0.8196 netWorkType/5G appid/40 deviceName/Xiaomi_M2004j7ac deviceModel/M2004J7AC OSVersion/12 protocolVersion/301 platformVersion/10 sdkVersion/220200 Oauth2Client/0.9 (Linux 4_14_186-perf-gddfs8vbb238b) (JAVA 0)",
+				UserAgent:         "ANDROID-com.xunlei.downloadprovider/8.31.0.9726 netWorkType/5G appid/40 deviceName/Xiaomi_M2004j7ac deviceModel/M2004J7AC OSVersion/12 protocolVersion/301 platformVersion/10 sdkVersion/512000 Oauth2Client/0.9 (Linux 4_14_186-perf-gddfs8vbb238b) (JAVA 0)",
 				DownloadUserAgent: "Dalvik/2.1.0 (Linux; U; Android 12; M2004J7AC Build/SP1A.210812.016)",
-
 				refreshCTokenCk: func(token string) {
 					x.CaptchaToken = token
 					op.MustSaveDriverStorage(x)
@@ -79,6 +82,8 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 						x.GetStorage().SetStatus(fmt.Sprintf("%+v", err.Error()))
 						op.MustSaveDriverStorage(x)
 					}
+					// 清空 信任密钥
+					x.Addition.CreditKey = ""
 				}
 				x.SetTokenResp(token)
 				return err
@@ -92,6 +97,17 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 		x.SetCaptchaToken(ctoekn)
 	}
 
+	if x.Addition.CreditKey != "" {
+		x.SetCreditKey(x.Addition.CreditKey)
+	}
+
+	if x.Addition.DeviceID != "" {
+		x.Common.DeviceID = x.Addition.DeviceID
+	} else {
+		x.Addition.DeviceID = x.Common.DeviceID
+		op.MustSaveDriverStorage(x)
+	}
+
 	// 防止重复登录
 	identity := x.GetIdentity()
 	if x.identity != identity || !x.IsLogin() {
@@ -101,6 +117,8 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+		// 清空 信任密钥
+		x.Addition.CreditKey = ""
 		x.SetTokenResp(token)
 	}
 	return nil
@@ -160,6 +178,17 @@ func (x *ThunderExpert) Init(ctx context.Context) (err error) {
 			x.SetCaptchaToken(x.CaptchaToken)
 		}
 
+		if x.ExpertAddition.CreditKey != "" {
+			x.SetCreditKey(x.ExpertAddition.CreditKey)
+		}
+
+		if x.ExpertAddition.DeviceID != "" {
+			x.Common.DeviceID = x.ExpertAddition.DeviceID
+		} else {
+			x.ExpertAddition.DeviceID = x.Common.DeviceID
+			op.MustSaveDriverStorage(x)
+		}
+
 		// 签名方法
 		if x.SignType == "captcha_sign" {
 			x.Common.Timestamp = x.Timestamp
@@ -193,6 +222,8 @@ func (x *ThunderExpert) Init(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			}
+			// 清空 信任密钥
+			x.ExpertAddition.CreditKey = ""
 			x.SetTokenResp(token)
 			x.SetRefreshTokenFunc(func() error {
 				token, err := x.XunLeiCommon.RefreshToken(x.TokenResp.RefreshToken)
@@ -201,6 +232,8 @@ func (x *ThunderExpert) Init(ctx context.Context) (err error) {
 					if err != nil {
 						x.GetStorage().SetStatus(fmt.Sprintf("%+v", err.Error()))
 					}
+					// 清空 信任密钥
+					x.ExpertAddition.CreditKey = ""
 				}
 				x.SetTokenResp(token)
 				op.MustSaveDriverStorage(x)
@@ -232,7 +265,8 @@ func (x *ThunderExpert) SetTokenResp(token *TokenResp) {
 
 type XunLeiCommon struct {
 	*Common
-	*TokenResp // 登录信息
+	*TokenResp     // 登录信息
+	*CoreLoginResp // core登录信息
 
 	refreshTokenFunc func() error
 }
@@ -437,6 +471,10 @@ func (xc *XunLeiCommon) SetTokenResp(tr *TokenResp) {
 	xc.TokenResp = tr
 }
 
+func (xc *XunLeiCommon) SetCoreTokenResp(tr *CoreLoginResp) {
+	xc.CoreLoginResp = tr
+}
+
 // 携带Authorization和CaptchaToken的请求
 func (xc *XunLeiCommon) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
 	data, err := xc.Common.Request(url, method, func(req *resty.Request) {
@@ -465,7 +503,7 @@ func (xc *XunLeiCommon) Request(url string, method string, callback base.ReqCall
 		}
 		return nil, err
 	case 9: // 验证码token过期
-		if err = xc.RefreshCaptchaTokenAtLogin(GetAction(method, url), xc.UserID); err != nil {
+		if err = xc.RefreshCaptchaTokenAtLogin(GetAction(method, url), xc.TokenResp.UserID); err != nil {
 			return nil, err
 		}
 	default:
@@ -497,20 +535,25 @@ func (xc *XunLeiCommon) RefreshToken(refreshToken string) (*TokenResp, error) {
 
 // 登录
 func (xc *XunLeiCommon) Login(username, password string) (*TokenResp, error) {
-	url := XLUSER_API_URL + "/auth/signin"
-	err := xc.RefreshCaptchaTokenInLogin(GetAction(http.MethodPost, url), username)
+	//v3 login拿到 sessionID
+	sessionID, err := xc.CoreLogin(username, password)
 	if err != nil {
+		return nil, err
+	}
+	//v1 login拿到令牌
+	url := XLUSER_API_URL + "/auth/signin/token"
+	if err = xc.RefreshCaptchaTokenInLogin(GetAction(http.MethodPost, url), username); err != nil {
 		return nil, err
 	}
 
 	var resp TokenResp
 	_, err = xc.Common.Request(url, http.MethodPost, func(req *resty.Request) {
+		req.SetPathParam("client_id", xc.ClientID)
 		req.SetBody(&SignInRequest{
-			CaptchaToken: xc.GetCaptchaToken(),
 			ClientID:     xc.ClientID,
 			ClientSecret: xc.ClientSecret,
-			Username:     username,
-			Password:     password,
+			Provider:     SignProvider,
+			SigninToken:  sessionID,
 		})
 	}, &resp)
 	if err != nil {
@@ -585,4 +628,49 @@ func (xc *XunLeiCommon) DeleteOfflineTasks(ctx context.Context, taskIDs []string
 		return fmt.Errorf("failed to delete tasks %v: %w", taskIDs, err)
 	}
 	return nil
+}
+
+func (xc *XunLeiCommon) CoreLogin(username string, password string) (sessionID string, err error) {
+	url := XLUSER_API_BASE_URL + "/xluser.core.login/v3/login"
+	var resp CoreLoginResp
+	res, err := xc.Common.Request(url, http.MethodPost, func(req *resty.Request) {
+		req.SetHeader("User-Agent", "android-ok-http-client/xl-acc-sdk/version-5.0.12.512000")
+		req.SetBody(&CoreLoginRequest{
+			ProtocolVersion: "301",
+			SequenceNo:      "1000012",
+			PlatformVersion: "10",
+			IsCompressed:    "0",
+			Appid:           APPID,
+			ClientVersion:   "8.31.0.9726",
+			PeerID:          "00000000000000000000000000000000",
+			AppName:         "ANDROID-com.xunlei.downloadprovider",
+			SdkVersion:      "512000",
+			Devicesign:      generateDeviceSign(xc.DeviceID, xc.PackageName),
+			NetWorkType:     "WIFI",
+			ProviderName:    "NONE",
+			DeviceModel:     "M2004J7AC",
+			DeviceName:      "Xiaomi_M2004j7ac",
+			OSVersion:       "12",
+			Creditkey:       xc.GetCreditKey(),
+			Hl:              "zh-CN",
+			UserName:        username,
+			PassWord:        password,
+			VerifyKey:       "",
+			VerifyCode:      "",
+			IsMd5Pwd:        "0",
+		})
+	}, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if err = utils.Json.Unmarshal(res, &resp); err != nil {
+		return "", err
+	}
+
+	xc.SetCoreTokenResp(&resp)
+
+	sessionID = resp.SessionID
+
+	return sessionID, nil
 }

--- a/drivers/thunder/meta.go
+++ b/drivers/thunder/meta.go
@@ -23,23 +23,25 @@ type ExpertAddition struct {
 	RefreshToken string `json:"refresh_token" required:"true" help:"login type is refresh_token,this is required"`
 
 	// 签名方法1
-	Algorithms string `json:"algorithms" required:"true" help:"sign type is algorithms,this is required" default:"HPxr4BVygTQVtQkIMwQH33ywbgYG5l4JoR,GzhNkZ8pOBsCY+7,v+l0ImTpG7c7/,e5ztohgVXNP,t,EbXUWyVVqQbQX39Mbjn2geok3/0WEkAVxeqhtx857++kjJiRheP8l77gO,o7dvYgbRMOpHXxCs,6MW8TD8DphmakaxCqVrfv7NReRRN7ck3KLnXBculD58MvxjFRqT+,kmo0HxCKVfmxoZswLB4bVA/dwqbVAYghSb,j,4scKJNdd7F27Hv7tbt"`
+	Algorithms string `json:"algorithms" required:"true" help:"sign type is algorithms,this is required" default:"9uJNVj/wLmdwKrJaVj/omlQ,Oz64Lp0GigmChHMf/6TNfxx7O9PyopcczMsnf,Eb+L7Ce+Ej48u,jKY0,ASr0zCl6v8W4aidjPK5KHd1Lq3t+vBFf41dqv5+fnOd,wQlozdg6r1qxh0eRmt3QgNXOvSZO6q/GXK,gmirk+ciAvIgA/cxUUCema47jr/YToixTT+Q6O,5IiCoM9B1/788ntB,P07JH0h6qoM6TSUAK2aL9T5s2QBVeY9JWvalf,+oK0AN"`
 	// 签名方法2
 	CaptchaSign string `json:"captcha_sign" required:"true" help:"sign type is captcha_sign,this is required"`
 	Timestamp   string `json:"timestamp" required:"true" help:"sign type is captcha_sign,this is required"`
 
 	// 验证码
 	CaptchaToken string `json:"captcha_token"`
+	// 信任密钥
+	CreditKey string `json:"credit_key" help:"credit key,used for login"`
 
 	// 必要且影响登录,由签名决定
-	DeviceID      string `json:"device_id"  required:"true" default:"9aa5c268e7bcfc197a9ad88e2fb330e5"`
+	DeviceID      string `json:"device_id" default:""`
 	ClientID      string `json:"client_id"  required:"true" default:"Xp6vsxz_7IYVw2BB"`
 	ClientSecret  string `json:"client_secret"  required:"true" default:"Xp6vsy4tN9toTVdMSpomVdXpRmES"`
-	ClientVersion string `json:"client_version"  required:"true" default:"7.51.0.8196"`
+	ClientVersion string `json:"client_version"  required:"true" default:"8.31.0.9726"`
 	PackageName   string `json:"package_name"  required:"true" default:"com.xunlei.downloadprovider"`
 
 	//不影响登录,影响下载速度
-	UserAgent         string `json:"user_agent"  required:"true" default:"ANDROID-com.xunlei.downloadprovider/7.51.0.8196 netWorkType/4G appid/40 deviceName/Xiaomi_M2004j7ac deviceModel/M2004J7AC OSVersion/12 protocolVersion/301 platformVersion/10 sdkVersion/220200 Oauth2Client/0.9 (Linux 4_14_186-perf-gdcf98eab238b) (JAVA 0)"`
+	UserAgent         string `json:"user_agent"  required:"true" default:"ANDROID-com.xunlei.downloadprovider/8.31.0.9726 netWorkType/5G appid/40 deviceName/Xiaomi_M2004j7ac deviceModel/M2004J7AC OSVersion/12 protocolVersion/301 platformVersion/10 sdkVersion/512000 Oauth2Client/0.9 (Linux 4_14_186-perf-gddfs8vbb238b) (JAVA 0)"`
 	DownloadUserAgent string `json:"download_user_agent"  required:"true" default:"Dalvik/2.1.0 (Linux; U; Android 12; M2004J7AC Build/SP1A.210812.016)"`
 
 	//优先使用视频链接代替下载链接
@@ -74,6 +76,10 @@ type Addition struct {
 	Username     string `json:"username" required:"true"`
 	Password     string `json:"password" required:"true"`
 	CaptchaToken string `json:"captcha_token"`
+	// 信任密钥
+	CreditKey string `json:"credit_key" help:"credit key,used for login"`
+	// 登录设备ID
+	DeviceID string `json:"device_id" default:""`
 }
 
 // 登录特征,用于判断是否重新登录

--- a/drivers/thunder/types.go
+++ b/drivers/thunder/types.go
@@ -18,6 +18,10 @@ type ErrResp struct {
 }
 
 func (e *ErrResp) IsError() bool {
+	if e.ErrorMsg == "success" {
+		return false
+	}
+
 	return e.ErrorCode != 0 || e.ErrorMsg != "" || e.ErrorDescription != ""
 }
 
@@ -61,13 +65,79 @@ func (t *TokenResp) Token() string {
 }
 
 type SignInRequest struct {
-	CaptchaToken string `json:"captcha_token"`
-
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Provider    string `json:"provider"`
+	SigninToken string `json:"signin_token"`
+}
+
+type CoreLoginRequest struct {
+	ProtocolVersion string `json:"protocolVersion"`
+	SequenceNo      string `json:"sequenceNo"`
+	PlatformVersion string `json:"platformVersion"`
+	IsCompressed    string `json:"isCompressed"`
+	Appid           string `json:"appid"`
+	ClientVersion   string `json:"clientVersion"`
+	PeerID          string `json:"peerID"`
+	AppName         string `json:"appName"`
+	SdkVersion      string `json:"sdkVersion"`
+	Devicesign      string `json:"devicesign"`
+	NetWorkType     string `json:"netWorkType"`
+	ProviderName    string `json:"providerName"`
+	DeviceModel     string `json:"deviceModel"`
+	DeviceName      string `json:"deviceName"`
+	OSVersion       string `json:"OSVersion"`
+	Creditkey       string `json:"creditkey"`
+	Hl              string `json:"hl"`
+	UserName        string `json:"userName"`
+	PassWord        string `json:"passWord"`
+	VerifyKey       string `json:"verifyKey"`
+	VerifyCode      string `json:"verifyCode"`
+	IsMd5Pwd        string `json:"isMd5Pwd"`
+}
+
+type CoreLoginResp struct {
+	Account   string `json:"account"`
+	Creditkey string `json:"creditkey"`
+	/*	Error              string `json:"error"`
+		ErrorCode          string `json:"errorCode"`
+		ErrorDescription   string `json:"error_description"`*/
+	ExpiresIn          int    `json:"expires_in"`
+	IsCompressed       string `json:"isCompressed"`
+	IsSetPassWord      string `json:"isSetPassWord"`
+	KeepAliveMinPeriod string `json:"keepAliveMinPeriod"`
+	KeepAlivePeriod    string `json:"keepAlivePeriod"`
+	LoginKey           string `json:"loginKey"`
+	NickName           string `json:"nickName"`
+	PlatformVersion    string `json:"platformVersion"`
+	ProtocolVersion    string `json:"protocolVersion"`
+	SecureKey          string `json:"secureKey"`
+	SequenceNo         string `json:"sequenceNo"`
+	SessionID          string `json:"sessionID"`
+	Timestamp          string `json:"timestamp"`
+	UserID             string `json:"userID"`
+	UserName           string `json:"userName"`
+	UserNewNo          string `json:"userNewNo"`
+	Version            string `json:"version"`
+	/*	VipList []struct {
+		ExpireDate string `json:"expireDate"`
+		IsAutoDeduct string `json:"isAutoDeduct"`
+		IsVip string `json:"isVip"`
+		IsYear string `json:"isYear"`
+		PayID string `json:"payId"`
+		PayName string `json:"payName"`
+		Register string `json:"register"`
+		Vasid string `json:"vasid"`
+		VasType string `json:"vasType"`
+		VipDayGrow string `json:"vipDayGrow"`
+		VipGrow string `json:"vipGrow"`
+		VipLevel string `json:"vipLevel"`
+		Icon struct {
+			General string `json:"general"`
+			Small string `json:"small"`
+		} `json:"icon"`
+	} `json:"vipList"`*/
 }
 
 /*
@@ -250,4 +320,30 @@ type Params struct {
 	FolderType   string `json:"folder_type"`
 	PredictSpeed string `json:"predict_speed"`
 	PredictType  string `json:"predict_type"`
+}
+
+// LoginReviewResp 登录验证响应
+type LoginReviewResp struct {
+	Creditkey        string `json:"creditkey"`
+	Error            string `json:"error"`
+	ErrorCode        string `json:"errorCode"`
+	ErrorDesc        string `json:"errorDesc"`
+	ErrorDescURL     string `json:"errorDescUrl"`
+	ErrorIsRetry     int    `json:"errorIsRetry"`
+	ErrorDescription string `json:"error_description"`
+	IsCompressed     string `json:"isCompressed"`
+	PlatformVersion  string `json:"platformVersion"`
+	ProtocolVersion  string `json:"protocolVersion"`
+	Reviewurl        string `json:"reviewurl"`
+	SequenceNo       string `json:"sequenceNo"`
+	UserID           string `json:"userID"`
+	VerifyType       string `json:"verifyType"`
+}
+
+// ReviewData 验证数据
+type ReviewData struct {
+	Creditkey  string `json:"creditkey"`
+	Reviewurl  string `json:"reviewurl"`
+	Deviceid   string `json:"deviceid"`
+	Devicesign string `json:"devicesign"`
 }


### PR DESCRIPTION
## 修复 `迅雷云盘、迅雷云盘专业版` 使用账号密码登录异常问题

---

### 改动点
- 更新登录参数
- 修改了账号密码登录所使用的接口
- 增加了 `信任密钥（CreditKey）`  字段，用于应对登录验证的情况，具体内容见下文
- `迅雷云盘` 驱动，也可自定义 `DeviceID`

---

### 注意

**如果在添加驱动时出现下图所示的情况，就是触发了登录验证**

> 
![image](https://github.com/user-attachments/assets/ae2af540-0a8f-4318-a61e-ece71b414dee)

> 
![image](https://github.com/user-attachments/assets/3a86d7ba-d61b-4e61-9ee0-98f860853860)

---

#### 登录验证的解决办法
- 尽量使用电脑方便操作

- **完整复制**方框中的数据，从第一个 `{`  开始到 最后一个 `}` 结束，例如： `{
  "creditkey": "",
  "reviewurl": "",
  "deviceid": "",
  "devicesign": ""
}`

- 打开下面的网站：`https://i.xunlei.com/xlcaptcha/android.html`
![image](https://github.com/user-attachments/assets/2a925f9d-d849-46b4-876a-c470c9fd76ba)
上面为刚打开的样子，注意⚠️这个验证码与挂载所需的验证并无关系

- 打开浏览器的控制台（F12），输入 `reviewCb(中间的参数为之前复制的数据)` 后回车，即可看到页面变成短信验证或智能检测
示例：
![image](https://github.com/user-attachments/assets/acff6009-fb3a-493a-ab11-720935aa203d)
![image](https://github.com/user-attachments/assets/abbddcc2-4b71-4eae-909c-125920328bb2)
![image](https://github.com/user-attachments/assets/6701a6fd-ddbe-44e1-8dba-eafca4d728e4)

- 完成短信验证，~智能检测页面无需完成~，**注意这里并不能转跳回Alist, 且点击确定按钮后并无任何提示**

- 复制控制台中的 `creditkey` ，并将其填回驱动配置的 `信任密钥（CreditKey）`字段中，~似乎不填写也可以~，如下图
![image](https://github.com/user-attachments/assets/0db2f2fb-987e-4ff2-a096-e224e4de5ff5)

- 此时，保存驱动配置，应该正常工作了

