### PR TITLE
fix(fs): remove old target object from cache before updating

### DIFF
--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -3,6 +3,7 @@ package op
 import (
 	"context"
 	stdpath "path"
+	"slices"
 	"time"
 
 	"github.com/Xhofe/go-cache"
@@ -25,6 +26,12 @@ func updateCacheObj(storage driver.Driver, path string, oldObj model.Obj, newObj
 	key := Key(storage, path)
 	objs, ok := listCache.Get(key)
 	if ok {
+		for i, obj := range objs {
+			if obj.GetName() == newObj.GetName() {
+				objs = slices.Delete(objs, i, i+1)
+				break
+			}
+		}
 		for i, obj := range objs {
 			if obj.GetName() == oldObj.GetName() {
 				objs[i] = newObj


### PR DESCRIPTION
当执行 Rename 时，并启用 Overwrite existing files 选项时，由于重命名的目标没有从缓存中被删除，导致目录缓存中存在两个同名文件，因此列目录时(可能)看到的依然是旧文件。

本 PR 在更新缓存前从缓存中删除了旧的目标文件，以确保缓存正确性。

BTW，对于未勾选 Overwrite existing files 选项的情形，由于目标文件不存在，因而不会触发删除操作。