### PR TITLE
refactor(alias): return URL when root has .proxy suffix

### DIFF
--- a/internal/net/request_test.go
+++ b/internal/net/request_test.go
@@ -70,7 +70,7 @@ func TestDownloadOrder(t *testing.T) {
 		t.Errorf("expect %v API calls, got %v", e, a)
 	}
 
-	expectRngs := []string{"2-3", "5-3", "8-3", "11-1"}
+	expectRngs := []string{"2-1", "3-3", "6-3", "9-3"}
 	for _, rng := range expectRngs {
 		if !slices.Contains(*ranges, rng) {
 			t.Errorf("expect range %v, but absent in return", rng)

--- a/internal/stream/util.go
+++ b/internal/stream/util.go
@@ -19,7 +19,7 @@ func GetRangeReadCloserFromLink(size int64, link *model.Link) (model.RangeReadCl
 		return nil, fmt.Errorf("can't create RangeReadCloser since URL is empty in link")
 	}
 	rangeReaderFunc := func(ctx context.Context, r http_range.Range) (io.ReadCloser, error) {
-		if link.Concurrency != 0 || link.PartSize != 0 {
+		if link.Concurrency > 0 || link.PartSize > 0 {
 			header := net.ProcessHeader(nil, link.Header)
 			down := net.NewDownloader(func(d *net.Downloader) {
 				d.Concurrency = link.Concurrency

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.Obj) error {
@@ -43,7 +42,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 			RangeReadCloserIF: link.RangeReadCloser,
 			Limiter:           stream.ServerDownloadLimit,
 		})
-	} else if link.Concurrency != 0 || link.PartSize != 0 {
+	} else if link.Concurrency > 0 || link.PartSize > 0 {
 		attachHeader(w, file)
 		size := file.GetSize()
 		rangeReader := func(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error) {
@@ -111,22 +110,13 @@ func GetEtag(file model.Obj) string {
 	return fmt.Sprintf(`"%x-%x"`, file.ModTime().Unix(), file.GetSize())
 }
 
-var NoProxyRange = &model.RangeReadCloser{}
+const NoProxyRangeMark int = -1
 
 func ProxyRange(link *model.Link, size int64) {
-	if link.MFile != nil {
+	if link.RangeReadCloser != nil || len(link.URL) == 0 || link.Concurrency == NoProxyRangeMark {
 		return
 	}
-	if link.RangeReadCloser == nil {
-		var rrc, err = stream.GetRangeReadCloserFromLink(size, link)
-		if err != nil {
-			log.Warnf("ProxyRange error: %s", err)
-			return
-		}
-		link.RangeReadCloser = rrc
-	} else if link.RangeReadCloser == NoProxyRange {
-		link.RangeReadCloser = nil
-	}
+	link.RangeReadCloser, _ = stream.GetRangeReadCloserFromLink(size, link)
 }
 
 type InterceptResponseWriter struct {


### PR DESCRIPTION
根目录以`.proxy`结尾时返回代理链接
可以让crypt、mega等驱动(不返回URL的) 更好的支持并发
路径设置示例：
crypt.proxy:/crypt
mega.proxy:/mega