### PR TITLE
fix(aliyundrive_open): resolve file duplication issues and improve path handling

### DIFF
--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/Xhofe/rateg"
@@ -14,6 +15,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
+	log "github.com/sirupsen/logrus"
 )
 
 type AliyundriveOpen struct {
@@ -72,6 +74,18 @@ func (d *AliyundriveOpen) Drop(ctx context.Context) error {
 	return nil
 }
 
+// GetRoot implements the driver.GetRooter interface to properly set up the root object
+func (d *AliyundriveOpen) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		ID:       d.RootFolderID,
+		Path:     "/",
+		Name:     "root",
+		Size:     0,
+		Modified: d.Modified,
+		IsFolder: true,
+	}, nil
+}
+
 func (d *AliyundriveOpen) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	if d.limitList == nil {
 		return nil, fmt.Errorf("driver not init")
@@ -80,9 +94,17 @@ func (d *AliyundriveOpen) List(ctx context.Context, dir model.Obj, args model.Li
 	if err != nil {
 		return nil, err
 	}
-	return utils.SliceConvert(files, func(src File) (model.Obj, error) {
-		return fileToObj(src), nil
+
+	objs, err := utils.SliceConvert(files, func(src File) (model.Obj, error) {
+		obj := fileToObj(src)
+		// Set the correct path for the object
+		if dir.GetPath() != "" {
+			obj.Path = filepath.Join(dir.GetPath(), obj.GetName())
+		}
+		return obj, nil
 	})
+
+	return objs, err
 }
 
 func (d *AliyundriveOpen) link(ctx context.Context, file model.Obj) (*model.Link, error) {
@@ -132,7 +154,16 @@ func (d *AliyundriveOpen) MakeDir(ctx context.Context, parentDir model.Obj, dirN
 	if err != nil {
 		return nil, err
 	}
-	return fileToObj(newDir), nil
+	obj := fileToObj(newDir)
+
+	// Set the correct Path for the returned directory object
+	if parentDir.GetPath() != "" {
+		obj.Path = filepath.Join(parentDir.GetPath(), dirName)
+	} else {
+		obj.Path = "/" + dirName
+	}
+
+	return obj, nil
 }
 
 func (d *AliyundriveOpen) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
@@ -142,20 +173,23 @@ func (d *AliyundriveOpen) Move(ctx context.Context, srcObj, dstDir model.Obj) (m
 			"drive_id":          d.DriveId,
 			"file_id":           srcObj.GetID(),
 			"to_parent_file_id": dstDir.GetID(),
-			"check_name_mode":   "refuse", // optional:ignore,auto_rename,refuse
+			"check_name_mode":   "ignore", // optional:ignore,auto_rename,refuse
 			//"new_name":          "newName", // The new name to use when a file of the same name exists
 		}).SetResult(&resp)
 	})
 	if err != nil {
 		return nil, err
 	}
-	if resp.Exist {
-		return nil, errors.New("existence of files with the same name")
-	}
 
 	if srcObj, ok := srcObj.(*model.ObjThumb); ok {
 		srcObj.ID = resp.FileID
 		srcObj.Modified = time.Now()
+		srcObj.Path = filepath.Join(dstDir.GetPath(), srcObj.GetName())
+
+		// Check for duplicate files in the destination directory
+		if err := d.removeDuplicateFiles(ctx, dstDir.GetPath(), srcObj.GetName(), srcObj.GetID()); err != nil {
+			log.Errorf("Failed to remove duplicate files after move: %v", err)
+		}
 		return srcObj, nil
 	}
 	return nil, nil
@@ -173,19 +207,45 @@ func (d *AliyundriveOpen) Rename(ctx context.Context, srcObj model.Obj, newName 
 	if err != nil {
 		return nil, err
 	}
-	return fileToObj(newFile), nil
+
+	// Check for duplicate files in the parent directory
+	parentPath := filepath.Dir(srcObj.GetPath())
+	if err := d.removeDuplicateFiles(ctx, parentPath, newName, newFile.FileId); err != nil {
+		log.Errorf("Failed to remove duplicate files after rename: %v", err)
+	}
+
+	obj := fileToObj(newFile)
+
+	// Set the correct Path for the renamed object
+	if parentPath != "" && parentPath != "." {
+		obj.Path = filepath.Join(parentPath, newName)
+	} else {
+		obj.Path = "/" + newName
+	}
+
+	return obj, nil
 }
 
 func (d *AliyundriveOpen) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	var resp MoveOrCopyResp
 	_, err := d.request("/adrive/v1.0/openFile/copy", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"drive_id":          d.DriveId,
 			"file_id":           srcObj.GetID(),
 			"to_parent_file_id": dstDir.GetID(),
-			"auto_rename":       true,
-		})
+			"auto_rename":       false,
+		}).SetResult(&resp)
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Check for duplicate files in the destination directory
+	if err := d.removeDuplicateFiles(ctx, dstDir.GetPath(), srcObj.GetName(), resp.FileID); err != nil {
+		log.Errorf("Failed to remove duplicate files after copy: %v", err)
+	}
+
+	return nil
 }
 
 func (d *AliyundriveOpen) Remove(ctx context.Context, obj model.Obj) error {
@@ -203,7 +263,18 @@ func (d *AliyundriveOpen) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (d *AliyundriveOpen) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
-	return d.upload(ctx, dstDir, stream, up)
+	obj, err := d.upload(ctx, dstDir, stream, up)
+
+	// Set the correct Path for the returned file object
+	if obj != nil && obj.GetPath() == "" {
+		if dstDir.GetPath() != "" {
+			if objWithPath, ok := obj.(model.SetPath); ok {
+				objWithPath.SetPath(filepath.Join(dstDir.GetPath(), obj.GetName()))
+			}
+		}
+	}
+
+	return obj, err
 }
 
 func (d *AliyundriveOpen) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {
@@ -235,3 +306,4 @@ var _ driver.MkdirResult = (*AliyundriveOpen)(nil)
 var _ driver.MoveResult = (*AliyundriveOpen)(nil)
 var _ driver.RenameResult = (*AliyundriveOpen)(nil)
 var _ driver.PutResult = (*AliyundriveOpen)(nil)
+var _ driver.GetRooter = (*AliyundriveOpen)(nil)

--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -188,7 +188,8 @@ func (d *AliyundriveOpen) Move(ctx context.Context, srcObj, dstDir model.Obj) (m
 
 		// Check for duplicate files in the destination directory
 		if err := d.removeDuplicateFiles(ctx, dstDir.GetPath(), srcObj.GetName(), srcObj.GetID()); err != nil {
-			log.Errorf("Failed to remove duplicate files after move: %v", err)
+			// Only log a warning instead of returning an error since the move operation has already completed successfully
+			log.Warnf("Failed to remove duplicate files after move: %v", err)
 		}
 		return srcObj, nil
 	}
@@ -211,7 +212,8 @@ func (d *AliyundriveOpen) Rename(ctx context.Context, srcObj model.Obj, newName 
 	// Check for duplicate files in the parent directory
 	parentPath := filepath.Dir(srcObj.GetPath())
 	if err := d.removeDuplicateFiles(ctx, parentPath, newName, newFile.FileId); err != nil {
-		log.Errorf("Failed to remove duplicate files after rename: %v", err)
+		// Only log a warning instead of returning an error since the rename operation has already completed successfully
+		log.Warnf("Failed to remove duplicate files after rename: %v", err)
 	}
 
 	obj := fileToObj(newFile)
@@ -242,7 +244,8 @@ func (d *AliyundriveOpen) Copy(ctx context.Context, srcObj, dstDir model.Obj) er
 
 	// Check for duplicate files in the destination directory
 	if err := d.removeDuplicateFiles(ctx, dstDir.GetPath(), srcObj.GetName(), resp.FileID); err != nil {
-		log.Errorf("Failed to remove duplicate files after copy: %v", err)
+		// Only log a warning instead of returning an error since the copy operation has already completed successfully
+		log.Warnf("Failed to remove duplicate files after copy: %v", err)
 	}
 
 	return nil

--- a/drivers/aliyundrive_open/util.go
+++ b/drivers/aliyundrive_open/util.go
@@ -212,10 +212,6 @@ func (d *AliyundriveOpen) removeDuplicateFiles(ctx context.Context, parentPath s
 
 	// Remove all duplicates files, except the file with the given ID
 	for _, file := range duplicates {
-		if file.GetID() == skipID {
-			continue
-		}
-
 		err := d.Remove(ctx, file)
 		if err != nil {
 			return err

--- a/drivers/aliyundrive_open/util.go
+++ b/drivers/aliyundrive_open/util.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
@@ -185,4 +186,41 @@ func (d *AliyundriveOpen) getAccessToken() string {
 		return d.ref.getAccessToken()
 	}
 	return d.AccessToken
+}
+
+// Remove duplicate files with the same name in the given directory path,
+// preserving the file with the given skipID if provided
+func (d *AliyundriveOpen) removeDuplicateFiles(ctx context.Context, parentPath string, fileName string, skipID string) error {
+	// Handle empty path (root directory) case
+	if parentPath == "" {
+		parentPath = "/"
+	}
+
+	// List all files in the parent directory
+	files, err := op.List(ctx, d, parentPath, model.ListArgs{})
+	if err != nil {
+		return err
+	}
+
+	// Find all files with the same name
+	var duplicates []model.Obj
+	for _, file := range files {
+		if file.GetName() == fileName && file.GetID() != skipID {
+			duplicates = append(duplicates, file)
+		}
+	}
+
+	// Remove all duplicates files, except the file with the given ID
+	for _, file := range duplicates {
+		if file.GetID() == skipID {
+			continue
+		}
+
+		err := d.Remove(ctx, file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
建议来自 https://github.com/AlistGo/alist/issues/7962#issuecomment-2745873325

本次提交解决了阿里云盘开放接口驱动中的几个问题：

1. 通过实现新的removeDuplicateFiles方法清理操作后的重复文件，修复文件重复问题
2. 将移动操作的check_name_mode从"refuse"改为"ignore"，允许在目标目录存在同名文件时进行移动
3. 设置复制操作在成功复制后处理重复文件
4. 改进所有文件操作(移动、重命名、上传、创建目录)的路径处理，正确维护对象的完整路径
5. 实现GetRoot接口，使根对象能够正确初始化并设置正确路径
6. 在列表操作中添加适当的路径管理，确保对象拥有正确的路径
7. 修复错误情况下的路径处理，并改进失败日志记录

这些更改确保了在存在重名文件的情况下，文件操作能够正确工作，同时保持数据完整性并防止重复文件在阿里云盘中累积。