### PR TITLE
fix(lanzou): remove JavaScript comments from response data

### DIFF
--- a/drivers/lanzou/help.go
+++ b/drivers/lanzou/help.go
@@ -78,6 +78,45 @@ func RemoveNotes(html string) string {
 	})
 }
 
+// 清理JS注释
+func RemoveJSComment(data string) string {
+	var result strings.Builder
+	inComment := false
+	inSingleLineComment := false
+
+	for i := 0; i < len(data); i++ {
+		v := data[i]
+
+		if inSingleLineComment && (v == '\n' || v == '\r') {
+			inSingleLineComment = false
+			result.WriteByte(v)
+			continue
+		}
+		if inComment {
+			if v == '*' && i+1 < len(data) && data[i+1] == '/' {
+				inComment = false
+				i++
+			}
+			continue
+		}
+		if v == '/' && i+1 < len(data) {
+			nextChar := data[i+1]
+			if nextChar == '*' {
+				inComment = true
+				i++
+				continue
+			} else if nextChar == '/' {
+				inSingleLineComment = true
+				i++
+				continue
+			}
+		}
+		result.WriteByte(v)
+	}
+
+	return result.String()
+}
+
 var findAcwScV2Reg = regexp.MustCompile(`arg1='([0-9A-Z]+)'`)
 
 // 在页面被过多访问或其他情况下，有时候会先返回一个加密的页面，其执行计算出一个acw_sc__v2后放入页面后再重新访问页面才能获得正常页面

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -348,6 +348,10 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 		file        FileOrFolderByShareUrl
 	)
 
+	// 删除注释
+	sharePageData = RemoveNotes(sharePageData)
+	sharePageData = RemoveJSComment(sharePageData)
+
 	// 需要密码
 	if strings.Contains(sharePageData, "pwdload") || strings.Contains(sharePageData, "passwddiv") {
 		sharePageData, err := getJSFunctionByName(sharePageData, "down_p")


### PR DESCRIPTION
Close: #8286
Close: #8351

- 在 `getFilesByShareUrl()` 中增强对 HTML 内容注释的清洗
- 增加 `RemoveJSComment()` 方法，尝试对 JavaScript 注释进行解析并清理
- 避免因 JavaScript 各种注释，造成：
  -  `findJSFunctionIndex()` 方法找到 `down_p` 函数后无法正确解析反括号，导致无法读取参数，报错 `failed link: failed get link: not find down_p function`
  - `getJSFunctionByName()` 方法获取到被注释的错误信息，被误导使用错误的参数请求，从而返回 405 “文件不存在，或者已被删除”页面