### PR TITLE
fix(azure_blob): implement GetRootId interface in Addition struct

### DIFF
--- a/drivers/azure_blob/meta.go
+++ b/drivers/azure_blob/meta.go
@@ -12,6 +12,11 @@ type Addition struct {
 	SignURLExpire int    `json:"sign_url_expire" type:"number" default:"4" help:"The expiration time for SAS URLs, in hours."`
 }
 
+// implement GetRootId interface
+func (r Addition) GetRootId() string {
+	return r.ContainerName
+}
+
 var config = driver.Config{
 	Name:        "Azure Blob Storage",
 	LocalSort:   true,


### PR DESCRIPTION
implement GetRootId interface in Addition struct to fix failed get dir:

![image](https://github.com/user-attachments/assets/5796473c-71cb-4cf7-b1d2-b8b0f1fdb93c)

now
![image](https://github.com/user-attachments/assets/4307c6f8-f53f-4678-a406-41be00216952)
