### PR TITLE
fix(docker release): avoid duplicate occupation in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,9 @@ RUN apk update && \
         /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
-COPY --from=builder /app/bin/alist ./
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /opt/alist/alist && \
-    chmod +x /entrypoint.sh && /entrypoint.sh version
+COPY --chmod=755 --from=builder /app/bin/alist ./
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+RUN /entrypoint.sh version
 
 ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -24,10 +24,9 @@ RUN apk update && \
         /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
 
-COPY /build/${TARGETPLATFORM}/alist ./
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /opt/alist/alist && \
-    chmod +x /entrypoint.sh && /entrypoint.sh version
+COPY --chmod=755 /build/${TARGETPLATFORM}/alist ./
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+RUN /entrypoint.sh version
 
 ENV PUID=0 PGID=0 UMASK=022 RUN_ARIA2=${INSTALL_ARIA2}
 VOLUME /opt/alist/data/


### PR DESCRIPTION
Using `COPY --chmod=755` instead of `chmod +x` prevents Docker from creating duplicate layers for the binary file, which will resolve the abnormal increase in image space usage since v3.42.0.  

Although the issue only occurs in CI, I also update the local Dockerfile for consistency.

Close: #8388