### PR TITLE
fix(authn): remove auth middleware for webauthn login api

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -77,10 +77,10 @@ func Init(e *gin.Engine) {
 	api.GET("/auth/sso_get_token", handles.SSOLoginCallback)
 
 	// webauthn
+	api.GET("/authn/webauthn_begin_login", handles.BeginAuthnLogin)
+	api.POST("/authn/webauthn_finish_login", handles.FinishAuthnLogin)
 	webauthn.GET("/webauthn_begin_registration", handles.BeginAuthnRegistration)
 	webauthn.POST("/webauthn_finish_registration", handles.FinishAuthnRegistration)
-	webauthn.GET("/webauthn_begin_login", handles.BeginAuthnLogin)
-	webauthn.POST("/webauthn_finish_login", handles.FinishAuthnLogin)
 	webauthn.POST("/delete_authn", handles.DeleteAuthnLogin)
 	webauthn.GET("/getcredentials", handles.GetAuthnCredentials)
 


### PR DESCRIPTION
API router of authn login should not contain auth middleware. Currently, the API will throw an error only when there is an invalid token during login; If the token is empty, the request will succeed and the request will be granted a Guest identity, regardless of whether the Guest is disabled or not.

This PR is prerequisite for https://github.com/AlistGo/alist-web/pull/274

![image](https://github.com/user-attachments/assets/d013a3f2-f5b4-4d49-be2f-30a81574a2b0)

![image](https://github.com/user-attachments/assets/f0729bbe-f880-4b76-bd94-5568b17cf1de)

Image for test: `mmx233/alist:frontend-20250420`

To meet testing requirements, this image includes changes from both https://github.com/AlistGo/alist-web/pull/274 and https://github.com/AlistGo/alist-web/pull/273.