### PR TITLE
fix(docker_release): shebang of entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 umask ${UMASK}
 


### PR DESCRIPTION
Change from `#!/bin/bash` to `#!/bin/sh`. A wrong shebang may cause images built on some platforms, such as Docker Desktop, to throw an error: `exec /entrypoint.sh: no such file or directory`.

Example image: `mmx233/alist:joint-20250420`

The `/entrypoint.sh` file does exist, but the error will occurs because of the shebang.