### PR TITLE
feat(azure_blob): Update content-type and MD5 handling for Azure Blob uploads

### DIFF
--- a/drivers/azure_blob/driver.go
+++ b/drivers/azure_blob/driver.go
@@ -296,7 +296,7 @@ func (d *AzureBlob) Put(ctx context.Context, dstDir model.Obj, stream model.File
 	// Set content MD5 hash if available
 	base64MD5 := stream.GetHash().GetHash(utils.MD5)
 	if base64MD5 != "" {
-		// covert base64 to hex byte
+		// convert base64 to hex byte
 		md5, err := base64.StdEncoding.DecodeString(base64MD5)
 		if err == nil && len(md5) == 16 {
 			options.HTTPHeaders.BlobContentMD5 = md5


### PR DESCRIPTION
## Enhance the upload process and download file with Azure Blob driver
* Set the `content-type` and for files being uploaded to Azure Blob Storage. Default content type is applied when none is provided, 
* Set `content-md5` hash when provided and warnings are logged for invalid MD5 hashes.

![image](https://github.com/user-attachments/assets/2cea74ca-d2e8-41e2-8f82-a7aa2488f8df)

