### PR TITLE
perf(alias): add timeout when List and Link

### DIFF
--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -14,6 +14,7 @@ type Addition struct {
 	DownloadConcurrency int    `json:"download_concurrency" default:"0" required:"false" type:"number" help:"Need to enable proxy"`
 	DownloadPartSize    int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	Writable            bool   `json:"writable" type:"bool" default:"false"`
+	Timeout             int    `json:"timeout" default:"10" required:"true" type:"number"`
 }
 
 var config = driver.Config{

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -14,7 +14,7 @@ type Addition struct {
 	DownloadConcurrency int    `json:"download_concurrency" default:"0" required:"false" type:"number" help:"Need to enable proxy"`
 	DownloadPartSize    int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	Writable            bool   `json:"writable" type:"bool" default:"false"`
-	Timeout             int    `json:"timeout" default:"10" required:"true" type:"number"`
+	Timeout             int    `json:"timeout" default:"0" required:"false" type:"number" help:"0 for no timeout"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
为别名驱动的 List 和 Link 操作新增超时自动切换选项，当某个存储出现故障或性能下降时，能够自动切换到下一个存储，避免长时间卡住而影响体验。