### PR TITLE
fix(netease_music): change ListResp size fields from string to int64

### DIFF
--- a/drivers/netease_music/types.go
+++ b/drivers/netease_music/types.go
@@ -2,13 +2,13 @@ package netease_music
 
 import (
 	"context"
-	"github.com/alist-org/alist/v3/internal/driver"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/sign"
 	"github.com/alist-org/alist/v3/pkg/http_range"
@@ -28,8 +28,8 @@ type SongResp struct {
 }
 
 type ListResp struct {
-	Size    string `json:"size"`
-	MaxSize string `json:"maxSize"`
+	Size    int64 `json:"size"`
+	MaxSize int64 `json:"maxSize"`
 	Data    []struct {
 		AddTime    int64  `json:"addTime"`
 		FileName   string `json:"fileName"`


### PR DESCRIPTION
更改 `ListResp.Size`、`ListResp.MaxSize` 的类型为 `int64`，避免 JSON 反序列化错误。

Close: https://github.com/AlistGo/alist/issues/8406