### PR TITLE
fix(mega): use newest file for same filename

### DIFF
--- a/drivers/mega/driver.go
+++ b/drivers/mega/driver.go
@@ -56,12 +56,21 @@ func (d *Mega) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]
 		if err != nil {
 			return nil, err
 		}
-		res := make([]model.Obj, 0)
+		fn := make(map[string]model.Obj)
 		for i := range nodes {
 			n := nodes[i]
-			if n.GetType() == mega.FILE || n.GetType() == mega.FOLDER {
-				res = append(res, &MegaNode{n})
+			if n.GetType() != mega.FILE && n.GetType() != mega.FOLDER {
+				continue
 			}
+			if _, ok := fn[n.GetName()]; !ok {
+				fn[n.GetName()] = &MegaNode{n}
+			} else if sameNameObj := fn[n.GetName()]; (&MegaNode{n}).ModTime().After(sameNameObj.ModTime()) {
+				fn[n.GetName()] = &MegaNode{n}
+			}
+		}
+		res := make([]model.Obj, 0)
+		for _, v := range fn {
+			res = append(res, v)
 		}
 		return res, nil
 	}


### PR DESCRIPTION
Close: #8344

Mega 支持一个文件夹下有多个同名文件（duplicate names），不同版本以日期区分。

AList mega driver 的 `Link()` 方法会返回多个「同名」文件，但最终 AList 只会响应第一个版本（最旧的）进行列出/下载。这就导致无论你上传了多少遍，读取到的永远是最旧的版本。

PR 是对 `Link()` 里的同名文件进行了过滤，只保留最新版本，这样 CRUD 都能保持一致

上图，首先是 Mega 官方
![image](https://github.com/user-attachments/assets/e11a6cf8-e404-486e-a421-14b758844435)

修复前（Test in v3.42）
![image](https://github.com/user-attachments/assets/a507c3df-4f01-4f29-ba8b-6019f04ec521)

修复后（PR）
![image](https://github.com/user-attachments/assets/50e074bb-ec4e-4a48-8cfd-d6d3c4c3b9f1)
