### PR TITLE
feat(doubao): add get_download_info API and download_api option

### DIFF
--- a/drivers/doubao/meta.go
+++ b/drivers/doubao/meta.go
@@ -12,6 +12,7 @@ type Addition struct {
 	// define other
 	Cookie       string `json:"cookie" type:"text"`
 	UploadThread string `json:"upload_thread" default:"3"`
+	DownloadApi  string `json:"download_api" type:"select" options:"get_file_url,get_download_info" default:"get_file_url"`
 }
 
 var config = driver.Config{

--- a/drivers/doubao/types.go
+++ b/drivers/doubao/types.go
@@ -3,8 +3,9 @@ package doubao
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alist-org/alist/v3/internal/model"
 	"time"
+
+	"github.com/alist-org/alist/v3/internal/model"
 )
 
 type BaseResp struct {
@@ -36,6 +37,17 @@ type File struct {
 	ParentID            string `json:"parent_id"`
 	CreateTime          int64  `json:"create_time"`
 	UpdateTime          int64  `json:"update_time"`
+}
+
+type GetDownloadInfoResp struct {
+	BaseResp
+	Data struct {
+		DownloadInfos []struct {
+			NodeID    string `json:"node_id"`
+			MainURL   string `json:"main_url"`
+			BackupURL string `json:"backup_url"`
+		} `json:"download_infos"`
+	} `json:"data"`
 }
 
 type GetFileUrlResp struct {


### PR DESCRIPTION
增加 `get_download_info` 这个 API，目前网页端默认使用，返回的链接带有文件名参数，不会出现文件名被编码的问题，支持获取视频文件的下载链接，获取到图片的下载地址也不会被压缩（不包括 PNG）。

Note: 文件名参数：`?attname=`
