### PR TITLE
fix: prevent guest user from updating profile

### DIFF
--- a/server/handles/auth.go
+++ b/server/handles/auth.go
@@ -113,6 +113,10 @@ func UpdateCurrent(c *gin.Context) {
 		return
 	}
 	user := c.MustGet("user").(*model.User)
+	if user.IsGuest() {
+		common.ErrorStrResp(c, "Guest user can not update profile", 403)
+		return
+	}
 	user.Username = req.Username
 	if req.Password != "" {
 		user.SetPassword(req.Password)


### PR DESCRIPTION
## Problem Description
Currently, if the guest account is enabled, anyone can modify the guest user's username and password through the `/api/me/update` API endpoint without any authentication (something that even admins cannot do through the user management interface). While testing has not revealed any severe security issues, I believe no one wants to see the GUEST username changed to "You are cute"  (⁄ ⁄•⁄ω⁄•⁄ ⁄) .

![postman post1](https://github.com/user-attachments/assets/844fc6de-1c1d-47cc-876c-4e74eff71056)


![admin user1](https://github.com/user-attachments/assets/816f2332-1686-4a48-9e38-f07fd6995226)


## Changes Made
Added a check for Guest users in the `UpdateCurrent` function. When a Guest user attempts to modify their profile information, the system now returns a 403 error and blocks the operation. This is consistent with restrictions applied to Guest users in other functions (such as `Generate2FA`).

This small change ensures your GUEST user won't suddenly become unexpectedly charming without your permission.