### PR TITLE
feat(cloudreve_v4): add Cloudreve V4 driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/baidu_share"
 	_ "github.com/alist-org/alist/v3/drivers/chaoxing"
 	_ "github.com/alist-org/alist/v3/drivers/cloudreve"
+	_ "github.com/alist-org/alist/v3/drivers/cloudreve_v4"
 	_ "github.com/alist-org/alist/v3/drivers/crypt"
 	_ "github.com/alist-org/alist/v3/drivers/doubao"
 	_ "github.com/alist-org/alist/v3/drivers/doubao_share"

--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -18,6 +18,7 @@ import (
 type Cloudreve struct {
 	model.Storage
 	Addition
+	ref *Cloudreve
 }
 
 func (d *Cloudreve) Config() driver.Config {
@@ -37,8 +38,18 @@ func (d *Cloudreve) Init(ctx context.Context) error {
 	return d.login()
 }
 
+func (d *Cloudreve) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*Cloudreve)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return errs.NotSupport
+}
+
 func (d *Cloudreve) Drop(ctx context.Context) error {
 	d.Cookie = ""
+	d.ref = nil
 	return nil
 }
 

--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -36,6 +36,9 @@ func (d *Cloudreve) getUA() string {
 }
 
 func (d *Cloudreve) request(method string, path string, callback base.ReqCallback, out interface{}) error {
+	if d.ref != nil {
+		return d.ref.request(method, path, callback, out)
+	}
 	u := d.Address + "/api/v3" + path
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -147,7 +147,7 @@ func (d *CloudreveV4) Link(ctx context.Context, file model.Obj, args model.LinkA
 	}
 	exp := time.Until(url.Expires)
 	return &model.Link{
-		URL:        url.Urls[0],
+		URL:        url.Urls[0].URL,
 		Expiration: &exp,
 	}, nil
 }

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -20,6 +20,7 @@ import (
 type CloudreveV4 struct {
 	model.Storage
 	Addition
+	ref *CloudreveV4
 }
 
 func (d *CloudreveV4) Config() driver.Config {
@@ -34,6 +35,9 @@ func (d *CloudreveV4) Init(ctx context.Context) error {
 	// removing trailing slash
 	d.Address = strings.TrimSuffix(d.Address, "/")
 	op.MustSaveDriverStorage(d)
+	if d.ref != nil {
+		return nil
+	}
 	if d.AccessToken == "" && d.RefreshToken != "" {
 		return d.refreshToken()
 	}
@@ -43,7 +47,17 @@ func (d *CloudreveV4) Init(ctx context.Context) error {
 	return nil
 }
 
+func (d *CloudreveV4) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*CloudreveV4)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return errs.NotSupport
+}
+
 func (d *CloudreveV4) Drop(ctx context.Context) error {
+	d.ref = nil
 	return nil
 }
 

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -31,12 +31,15 @@ func (d *CloudreveV4) GetAddition() driver.Additional {
 }
 
 func (d *CloudreveV4) Init(ctx context.Context) error {
-	if d.AccessToken != "" {
-		return nil
-	}
 	// removing trailing slash
 	d.Address = strings.TrimSuffix(d.Address, "/")
 	op.MustSaveDriverStorage(d)
+	if d.AccessToken != "" || d.RefreshToken != "" {
+		return nil
+	}
+	if d.AccessToken == "" || d.RefreshToken != "" {
+		return d.refreshToken()
+	}
 	return d.login()
 }
 

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -34,13 +34,13 @@ func (d *CloudreveV4) Init(ctx context.Context) error {
 	// removing trailing slash
 	d.Address = strings.TrimSuffix(d.Address, "/")
 	op.MustSaveDriverStorage(d)
-	if d.AccessToken != "" || d.RefreshToken != "" {
-		return nil
-	}
-	if d.AccessToken == "" || d.RefreshToken != "" {
+	if d.AccessToken == "" && d.RefreshToken != "" {
 		return d.refreshToken()
 	}
-	return d.login()
+	if d.Username != "" {
+		return d.login()
+	}
+	return nil
 }
 
 func (d *CloudreveV4) Drop(ctx context.Context) error {

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -1,0 +1,278 @@
+package cloudreve_v4
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/go-resty/resty/v2"
+)
+
+type CloudreveV4 struct {
+	model.Storage
+	Addition
+}
+
+func (d *CloudreveV4) Config() driver.Config {
+	return config
+}
+
+func (d *CloudreveV4) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *CloudreveV4) Init(ctx context.Context) error {
+	if d.AccessToken != "" {
+		return nil
+	}
+	// removing trailing slash
+	d.Address = strings.TrimSuffix(d.Address, "/")
+	op.MustSaveDriverStorage(d)
+	return d.login()
+}
+
+func (d *CloudreveV4) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *CloudreveV4) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	const pageSize int = 100
+	var f []File
+	var r FileResp
+	params := map[string]string{
+		"page_size":       strconv.Itoa(pageSize),
+		"uri":             dir.GetPath(),
+		"order_by":        "created_at",
+		"order_direction": "asc",
+		"page":            "0",
+	}
+
+	for {
+		err := d.request(http.MethodGet, "/file", func(req *resty.Request) {
+			req.SetQueryParams(params)
+		}, &r)
+		if err != nil {
+			return nil, err
+		}
+		f = append(f, r.Files...)
+		if r.Pagination.NextToken == "" || len(r.Files) < pageSize {
+			break
+		}
+		params["next_page_token"] = r.Pagination.NextToken
+	}
+
+	return utils.SliceConvert(f, func(src File) (model.Obj, error) {
+		if d.EnableFolderSize && src.Type == 1 {
+			var ds FolderSummaryResp
+			err := d.request(http.MethodGet, "/file/info", func(req *resty.Request) {
+				req.SetQueryParam("uri", src.Path)
+				req.SetQueryParam("folder_summary", "true")
+			}, &r)
+			if err == nil && ds.FolderSummary.Size > 0 {
+				src.Size = ds.FolderSummary.Size
+			}
+		}
+		var thumb model.Thumbnail
+		if d.EnableThumb && src.Type == 0 {
+			var t FileThumbResp
+			err := d.request(http.MethodGet, "/file/thumb", func(req *resty.Request) {
+				req.SetQueryParam("uri", src.Path)
+			}, &t)
+			if err == nil && t.URL != "" {
+				thumb = model.Thumbnail{
+					Thumbnail: t.URL,
+				}
+			}
+		}
+		return &model.ObjThumb{
+			Object: model.Object{
+				ID:       src.ID,
+				Path:     src.Path,
+				Name:     src.Name,
+				Size:     src.Size,
+				Modified: src.UpdatedAt,
+				Ctime:    src.CreatedAt,
+				IsFolder: src.Type == 1,
+			},
+			Thumbnail: thumb,
+		}, nil
+	})
+}
+
+func (d *CloudreveV4) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	var url FileUrlResp
+	err := d.request(http.MethodPost, "/file/url", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"uris":     []string{file.GetPath()},
+			"download": true,
+		})
+	}, &url)
+	if err != nil {
+		return nil, err
+	}
+	if len(url.Urls) == 0 {
+		return nil, errors.New("server returns no url")
+	}
+	exp := time.Until(url.Expires)
+	return &model.Link{
+		URL:        url.Urls[0],
+		Expiration: &exp,
+	}, nil
+}
+
+func (d *CloudreveV4) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	return d.request(http.MethodPost, "/file/create", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"type":              "folder",
+			"uri":               parentDir.GetPath() + "/" + dirName,
+			"error_on_conflict": true,
+		})
+	}, nil)
+}
+
+func (d *CloudreveV4) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
+	return d.request(http.MethodPost, "/file/move", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"uris": []string{srcObj.GetPath()},
+			"dst":  dstDir.GetPath(),
+			"copy": false,
+		})
+	}, nil)
+}
+
+func (d *CloudreveV4) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	return d.request(http.MethodPost, "/file/create", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"new_name": newName,
+			"uri":      srcObj.GetPath(),
+		})
+	}, nil)
+
+}
+
+func (d *CloudreveV4) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	return d.request(http.MethodPost, "/file/move", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"uris": []string{srcObj.GetPath()},
+			"dst":  dstDir.GetPath(),
+			"copy": true,
+		})
+	}, nil)
+}
+
+func (d *CloudreveV4) Remove(ctx context.Context, obj model.Obj) error {
+	return d.request(http.MethodDelete, "/file", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"uris":             []string{obj.GetPath()},
+			"unlink":           false,
+			"skip_soft_delete": true,
+		})
+	}, nil)
+}
+
+func (d *CloudreveV4) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
+	if dstDir.GetSize() == 0 {
+		// 空文件使用新建文件方法，避免上传卡锁
+		return d.request(http.MethodPost, "/file/create", func(req *resty.Request) {
+			req.SetBody(base.Json{
+				"type":              "file",
+				"uri":               dstDir.GetPath() + "/" + file.GetName(),
+				"error_on_conflict": true,
+			})
+		}, nil)
+	}
+	var p StoragePolicy
+	var r FileResp
+	var u FileUploadResp
+	var err error
+	params := map[string]string{
+		"page_size":       "10",
+		"uri":             dstDir.GetPath(),
+		"order_by":        "created_at",
+		"order_direction": "asc",
+		"page":            "0",
+	}
+	err = d.request(http.MethodGet, "/file", func(req *resty.Request) {
+		req.SetQueryParams(params)
+	}, &r)
+	if err != nil {
+		return err
+	}
+	p = r.StoragePolicy
+	err = d.request(http.MethodPut, "/file/upload", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"uri":           dstDir.GetPath() + "/" + file.GetName(),
+			"size":          file.GetSize(),
+			"policy_id":     p.ID,
+			"last_modified": file.ModTime().UnixMilli(),
+			"mime_type":     "",
+		})
+	}, &u)
+	if err != nil {
+		return err
+	}
+	if u.StoragePolicy.Relay {
+		err = d.upLocal(ctx, file, u, up)
+	} else {
+		switch u.StoragePolicy.Type {
+		case "local":
+			err = d.upLocal(ctx, file, u, up)
+		case "remote":
+			err = d.upRemote(ctx, file, u, up)
+		case "onedrive":
+			err = d.upOneDrive(ctx, file, u, up)
+		case "s3":
+			err = d.upS3(ctx, file, u, up)
+		default:
+			return errs.NotImplement
+		}
+	}
+	if err != nil {
+		// 删除失败的会话
+		_ = d.request(http.MethodDelete, "/file/upload", func(req *resty.Request) {
+			req.SetBody(base.Json{
+				"id":  u.SessionID,
+				"uri": u.URI,
+			})
+		}, nil)
+		return err
+	}
+	return nil
+}
+
+func (d *CloudreveV4) GetArchiveMeta(ctx context.Context, obj model.Obj, args model.ArchiveArgs) (model.ArchiveMeta, error) {
+	// TODO get archive file meta-info, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CloudreveV4) ListArchive(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) ([]model.Obj, error) {
+	// TODO list args.InnerPath in the archive obj, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CloudreveV4) Extract(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) (*model.Link, error) {
+	// TODO return link of file args.InnerPath in the archive obj, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CloudreveV4) ArchiveDecompress(ctx context.Context, srcObj, dstDir model.Obj, args model.ArchiveDecompressArgs) ([]model.Obj, error) {
+	// TODO extract args.InnerPath path in the archive srcObj to the dstDir location, optional
+	// a folder with the same name as the archive file needs to be created to store the extracted results if args.PutIntoNewDir
+	// return errs.NotImplement to use an internal archive tool
+	return nil, errs.NotImplement
+}
+
+//func (d *CloudreveV4) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {
+//	return nil, errs.NotSupport
+//}
+
+var _ driver.Driver = (*CloudreveV4)(nil)

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -76,7 +76,7 @@ func (d *CloudreveV4) List(ctx context.Context, dir model.Obj, args model.ListAr
 			err := d.request(http.MethodGet, "/file/info", func(req *resty.Request) {
 				req.SetQueryParam("uri", src.Path)
 				req.SetQueryParam("folder_summary", "true")
-			}, &r)
+			}, &ds)
 			if err == nil && ds.FolderSummary.Size > 0 {
 				src.Size = ds.FolderSummary.Size
 			}

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -51,8 +51,8 @@ func (d *CloudreveV4) List(ctx context.Context, dir model.Obj, args model.ListAr
 	params := map[string]string{
 		"page_size":       strconv.Itoa(pageSize),
 		"uri":             dir.GetPath(),
-		"order_by":        "created_at",
-		"order_direction": "asc",
+		"order_by":        d.OrderBy,
+		"order_direction": d.OrderDirection,
 		"page":            "0",
 	}
 
@@ -180,7 +180,7 @@ func (d *CloudreveV4) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (d *CloudreveV4) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
-	if dstDir.GetSize() == 0 {
+	if file.GetSize() == 0 {
 		// 空文件使用新建文件方法，避免上传卡锁
 		return d.request(http.MethodPost, "/file/create", func(req *resty.Request) {
 			req.SetBody(base.Json{

--- a/drivers/cloudreve_v4/meta.go
+++ b/drivers/cloudreve_v4/meta.go
@@ -10,16 +10,17 @@ type Addition struct {
 	driver.RootPath
 	// driver.RootID
 	// define other
-	Address          string `json:"address" required:"true"`
-	Username         string `json:"username"`
-	Password         string `json:"password"`
-	AccessToken      string `json:"access_token"`
-	RefreshToken     string `json:"refresh_token"`
-	CustomUA         string `json:"custom_ua"`
-	EnableFolderSize bool   `json:"enable_folder_size"`
-	EnableThumb      bool   `json:"enable_thumb"`
-	OrderBy          string `json:"order_by" type:"select" options:"name,size,updated_at,created_at" default:"name" required:"true"`
-	OrderDirection   string `json:"order_direction" type:"select" options:"asc,desc" default:"asc" required:"true"`
+	Address             string `json:"address" required:"true"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	AccessToken         string `json:"access_token"`
+	RefreshToken        string `json:"refresh_token"`
+	CustomUA            string `json:"custom_ua"`
+	EnableFolderSize    bool   `json:"enable_folder_size"`
+	EnableThumb         bool   `json:"enable_thumb"`
+	EnableVersionUpload bool   `json:"enable_version_upload"`
+	OrderBy             string `json:"order_by" type:"select" options:"name,size,updated_at,created_at" default:"name" required:"true"`
+	OrderDirection      string `json:"order_direction" type:"select" options:"asc,desc" default:"asc" required:"true"`
 }
 
 var config = driver.Config{
@@ -33,7 +34,7 @@ var config = driver.Config{
 	DefaultRoot:       "cloudreve://my",
 	CheckStatus:       true,
 	Alert:             "",
-	NoOverwriteUpload: false,
+	NoOverwriteUpload: true,
 }
 
 func init() {

--- a/drivers/cloudreve_v4/meta.go
+++ b/drivers/cloudreve_v4/meta.go
@@ -18,11 +18,13 @@ type Addition struct {
 	CustomUA         string `json:"custom_ua"`
 	EnableFolderSize bool   `json:"enable_folder_size"`
 	EnableThumb      bool   `json:"enable_thumb"`
+	OrderBy          string `json:"order_by" type:"select" options:"name,size,updated_at,created_at" default:"name" required:"true"`
+	OrderDirection   string `json:"order_direction" type:"select" options:"asc,desc" default:"asc" required:"true"`
 }
 
 var config = driver.Config{
 	Name:              "Cloudreve V4",
-	LocalSort:         true,
+	LocalSort:         false,
 	OnlyLocal:         false,
 	OnlyProxy:         false,
 	NoCache:           false,

--- a/drivers/cloudreve_v4/meta.go
+++ b/drivers/cloudreve_v4/meta.go
@@ -1,0 +1,41 @@
+package cloudreve_v4
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	// Usually one of two
+	driver.RootPath
+	// driver.RootID
+	// define other
+	Address          string `json:"address" required:"true"`
+	Username         string `json:"username"`
+	Password         string `json:"password"`
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	CustomUA         string `json:"custom_ua"`
+	EnableFolderSize bool   `json:"enable_folder_size"`
+	EnableThumb      bool   `json:"enable_thumb"`
+}
+
+var config = driver.Config{
+	Name:              "Cloudreve V4",
+	LocalSort:         true,
+	OnlyLocal:         false,
+	OnlyProxy:         false,
+	NoCache:           false,
+	NoUpload:          false,
+	NeedMs:            false,
+	DefaultRoot:       "cloudreve://my",
+	CheckStatus:       true,
+	Alert:             "",
+	NoOverwriteUpload: false,
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &CloudreveV4{}
+	})
+}

--- a/drivers/cloudreve_v4/types.go
+++ b/drivers/cloudreve_v4/types.go
@@ -128,7 +128,9 @@ type FileResp struct {
 }
 
 type FileUrlResp struct {
-	Urls    []string  `json:"urls"`
+	Urls []struct {
+		URL string `json:"url"`
+	} `json:"urls"`
 	Expires time.Time `json:"expires"`
 }
 

--- a/drivers/cloudreve_v4/types.go
+++ b/drivers/cloudreve_v4/types.go
@@ -1,0 +1,162 @@
+package cloudreve_v4
+
+import (
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+type Object struct {
+	model.Object
+	StoragePolicy StoragePolicy
+}
+
+type Resp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data any    `json:"data"`
+}
+
+type BasicConfigResp struct {
+	InstanceID string `json:"instance_id"`
+	// Title        string `json:"title"`
+	// Themes       string `json:"themes"`
+	// DefaultTheme string `json:"default_theme"`
+	User struct {
+		ID string `json:"id"`
+		// Nickname  string    `json:"nickname"`
+		// CreatedAt time.Time `json:"created_at"`
+		// Anonymous bool      `json:"anonymous"`
+		Group struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			Permission string `json:"permission"`
+		} `json:"group"`
+	} `json:"user"`
+	// Logo                string `json:"logo"`
+	// LogoLight           string `json:"logo_light"`
+	// CaptchaReCaptchaKey string `json:"captcha_ReCaptchaKey"`
+	CaptchaType string `json:"captcha_type"` // support 'normal' only
+	// AppPromotion        bool   `json:"app_promotion"`
+}
+
+type SiteLoginConfigResp struct {
+	LoginCaptcha bool `json:"login_captcha"`
+	Authn        bool `json:"authn"`
+}
+
+type PrepareLoginResp struct {
+	WebauthnEnabled bool `json:"webauthn_enabled"`
+	PasswordEnabled bool `json:"password_enabled"`
+}
+
+type CaptchaResp struct {
+	Image  string `json:"image"`
+	Ticket string `json:"ticket"`
+}
+
+type Token struct {
+	AccessToken    string    `json:"access_token"`
+	RefreshToken   string    `json:"refresh_token"`
+	AccessExpires  time.Time `json:"access_expires"`
+	RefreshExpires time.Time `json:"refresh_expires"`
+}
+
+type TokenResponse struct {
+	User struct {
+		ID string `json:"id"`
+		// Email     string    `json:"email"`
+		// Nickname  string    `json:"nickname"`
+		Status string `json:"status"`
+		// CreatedAt time.Time `json:"created_at"`
+		Group struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			Permission string `json:"permission"`
+			// DirectLinkBatchSize int    `json:"direct_link_batch_size"`
+			// TrashRetention      int    `json:"trash_retention"`
+		} `json:"group"`
+		// Language string `json:"language"`
+	} `json:"user"`
+	Token Token `json:"token"`
+}
+
+type File struct {
+	Type          int         `json:"type"` // 0: file, 1: folder
+	ID            string      `json:"id"`
+	Name          string      `json:"name"`
+	CreatedAt     time.Time   `json:"created_at"`
+	UpdatedAt     time.Time   `json:"updated_at"`
+	Size          int64       `json:"size"`
+	Metadata      interface{} `json:"metadata"`
+	Path          string      `json:"path"`
+	Capability    string      `json:"capability"`
+	Owned         bool        `json:"owned"`
+	PrimaryEntity string      `json:"primary_entity"`
+}
+
+type StoragePolicy struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	MaxSize int64  `json:"max_size"`
+	Relay   bool   `json:"relay,omitempty"`
+}
+
+type Pagination struct {
+	Page      int    `json:"page"`
+	PageSize  int    `json:"page_size"`
+	IsCursor  bool   `json:"is_cursor"`
+	NextToken string `json:"next_token,omitempty"`
+}
+
+type Props struct {
+	Capability            string   `json:"capability"`
+	MaxPageSize           int      `json:"max_page_size"`
+	OrderByOptions        []string `json:"order_by_options"`
+	OrderDirectionOptions []string `json:"order_direction_options"`
+}
+
+type FileResp struct {
+	Files         []File        `json:"files"`
+	Parent        File          `json:"parent"`
+	Pagination    Pagination    `json:"pagination"`
+	Props         Props         `json:"props"`
+	ContextHint   string        `json:"context_hint"`
+	MixedType     bool          `json:"mixed_type"`
+	StoragePolicy StoragePolicy `json:"storage_policy"`
+}
+
+type FileUrlResp struct {
+	Urls    []string  `json:"urls"`
+	Expires time.Time `json:"expires"`
+}
+
+type FileUploadResp struct {
+	// UploadID       string        `json:"upload_id"`
+	SessionID      string        `json:"session_id"`
+	ChunkSize      int64         `json:"chunk_size"`
+	Expires        int64         `json:"expires"`
+	StoragePolicy  StoragePolicy `json:"storage_policy"`
+	URI            string        `json:"uri"`
+	CompleteURL    string        `json:"completeURL,omitempty"`     // for S3-like
+	CallbackSecret string        `json:"callback_secret,omitempty"` // for S3-like, OneDrive
+	UploadUrls     []string      `json:"upload_urls,omitempty"`     // for not-local
+	Credential     string        `json:"credential,omitempty"`      // for local
+}
+
+type FileThumbResp struct {
+	URL     string    `json:"url"`
+	Expires time.Time `json:"expires"`
+}
+
+type FolderSummaryResp struct {
+	File
+	FolderSummary struct {
+		Size         int64     `json:"size"`
+		Files        int64     `json:"files"`
+		Folders      int64     `json:"folders"`
+		Completed    bool      `json:"completed"`
+		CalculatedAt time.Time `json:"calculated_at"`
+	} `json:"folder_summary"`
+}

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -34,6 +34,9 @@ func (d *CloudreveV4) getUA() string {
 }
 
 func (d *CloudreveV4) request(method string, path string, callback base.ReqCallback, out any) error {
+	if d.ref != nil {
+		return d.ref.request(method, path, callback, out)
+	}
 	u := d.Address + "/api/v4" + path
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -223,6 +223,7 @@ func (d *CloudreveV4) upLocal(ctx context.Context, file model.FileStreamer, u Fi
 			req.SetHeader("Content-Type", "application/octet-stream")
 			req.SetContentLength(true)
 			req.SetHeader("Content-Length", strconv.FormatInt(byteSize, 10))
+			req.SetBody(driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
 			req.AddRetryCondition(func(r *resty.Response, err error) bool {
 				if err != nil {
 					return true

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -1,0 +1,399 @@
+package cloudreve_v4
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/setting"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/go-resty/resty/v2"
+	jsoniter "github.com/json-iterator/go"
+)
+
+// do others that not defined in Driver interface
+
+func (d *CloudreveV4) getUA() string {
+	if d.CustomUA != "" {
+		return d.CustomUA
+	}
+	return base.UserAgent
+}
+
+func (d *CloudreveV4) request(method string, path string, callback base.ReqCallback, out any) error {
+	u := d.Address + "/api/v4" + path
+	req := base.RestyClient.R()
+	req.SetHeaders(map[string]string{
+		"Accept":     "application/json, text/plain, */*",
+		"User-Agent": d.getUA(),
+	})
+	if d.AccessToken != "" {
+		req.SetHeader("Authorization", "Bearer "+d.AccessToken)
+	}
+
+	var r Resp
+	req.SetResult(&r)
+
+	if callback != nil {
+		callback(req)
+	}
+
+	resp, err := req.Execute(method, u)
+	if err != nil {
+		return err
+	}
+	if !resp.IsSuccess() {
+		return errors.New(resp.String())
+	}
+
+	if r.Code != 0 {
+		if r.Code == 401 && d.RefreshToken != "" {
+			// try to refresh token
+			err = d.refreshToken()
+			if err != nil {
+				return err
+			}
+			return d.request(method, path, callback, out)
+		}
+		return errors.New(r.Msg)
+	}
+
+	if out != nil && r.Data != nil {
+		var marshal []byte
+		marshal, err = json.Marshal(r.Data)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(marshal, out)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *CloudreveV4) login() error {
+	var siteConfig SiteLoginConfigResp
+	err := d.request(http.MethodGet, "/site/config/login", nil, &siteConfig)
+	if err != nil {
+		return err
+	}
+	if !siteConfig.Authn {
+		return errors.New("authn not support")
+	}
+	var prepareLogin PrepareLoginResp
+	err = d.request(http.MethodGet, "/session/prepare?email="+d.Addition.Username, nil, &prepareLogin)
+	if err != nil {
+		return err
+	}
+	if !prepareLogin.PasswordEnabled {
+		return errors.New("password not enabled")
+	}
+	if prepareLogin.WebauthnEnabled {
+		return errors.New("webauthn not support")
+	}
+	for range 5 {
+		err = d.doLogin(siteConfig.LoginCaptcha)
+		if err == nil {
+			break
+		}
+		if err.Error() != "CAPTCHA not match." {
+			break
+		}
+	}
+	return err
+}
+
+func (d *CloudreveV4) doLogin(needCaptcha bool) error {
+	var err error
+	loginBody := base.Json{
+		"email":    d.Username,
+		"password": d.Password,
+	}
+	if needCaptcha {
+		var config BasicConfigResp
+		err = d.request(http.MethodGet, "/site/config/basic", nil, &config)
+		if err != nil {
+			return err
+		}
+		if config.CaptchaType != "normal" {
+			return fmt.Errorf("captcha type %s not support", config.CaptchaType)
+		}
+		var captcha CaptchaResp
+		err = d.request(http.MethodGet, "/site/captcha", nil, &captcha)
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(captcha.Image, "data:image/png;base64,") {
+			return errors.New("can not get captcha")
+		}
+		loginBody["ticket"] = captcha.Ticket
+		i := strings.Index(captcha.Image, ",")
+		dec := base64.NewDecoder(base64.StdEncoding, strings.NewReader(captcha.Image[i+1:]))
+		vRes, err := base.RestyClient.R().SetMultipartField(
+			"image", "validateCode.png", "image/png", dec).
+			Post(setting.GetStr(conf.OcrApi))
+		if err != nil {
+			return err
+		}
+		if jsoniter.Get(vRes.Body(), "status").ToInt() != 200 {
+			return errors.New("ocr error:" + jsoniter.Get(vRes.Body(), "msg").ToString())
+		}
+		captchaCode := jsoniter.Get(vRes.Body(), "result").ToString()
+		if captchaCode == "" {
+			return errors.New("ocr error: empty result")
+		}
+		loginBody["captcha"] = captchaCode
+	}
+	var token TokenResponse
+	err = d.request(http.MethodPost, "/session/token", func(req *resty.Request) {
+		req.SetBody(loginBody)
+	}, &token)
+	if err != nil {
+		return err
+	}
+	d.AccessToken, d.RefreshToken = token.Token.AccessToken, token.Token.RefreshToken
+	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+func (d *CloudreveV4) refreshToken() error {
+	var token Token
+	err := d.request(http.MethodPost, "/session/token/refresh", func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"refresh_token": d.RefreshToken,
+		})
+	}, &token)
+	if err != nil || token.AccessToken == "" {
+		err = d.login()
+		if err != nil {
+			return err
+		}
+	}
+	d.AccessToken, d.RefreshToken = token.AccessToken, token.RefreshToken
+	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+func (d *CloudreveV4) upLocal(ctx context.Context, file model.FileStreamer, u FileUploadResp, up driver.UpdateProgress) error {
+	var finish int64 = 0
+	var chunk int = 0
+	DEFAULT := int64(u.ChunkSize)
+	if DEFAULT == 0 {
+		// support relay
+		DEFAULT = file.GetSize()
+	}
+	for finish < file.GetSize() {
+		if utils.IsCanceled(ctx) {
+			return ctx.Err()
+		}
+		utils.Log.Debugf("[CloudreveV4-Local] upload: %d", finish)
+		var byteSize = DEFAULT
+		left := file.GetSize() - finish
+		if left < DEFAULT {
+			byteSize = left
+		}
+		byteData := make([]byte, byteSize)
+		n, err := io.ReadFull(file, byteData)
+		utils.Log.Debug(err, n)
+		if err != nil {
+			return err
+		}
+		err = d.request(http.MethodPost, "/file/upload/"+u.SessionID+"/"+strconv.Itoa(chunk), func(req *resty.Request) {
+			req.SetHeader("Content-Type", "application/octet-stream")
+			req.SetContentLength(true)
+			req.SetHeader("Content-Length", strconv.FormatInt(byteSize, 10))
+			req.SetBody(driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		}, nil)
+		if err != nil {
+			break
+		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(file.GetSize()))
+		chunk++
+	}
+	return nil
+}
+
+func (d *CloudreveV4) upRemote(ctx context.Context, file model.FileStreamer, u FileUploadResp, up driver.UpdateProgress) error {
+	uploadUrl := u.UploadUrls[0]
+	credential := u.Credential
+	var finish int64 = 0
+	var chunk int = 0
+	DEFAULT := int64(u.ChunkSize)
+	for finish < file.GetSize() {
+		if utils.IsCanceled(ctx) {
+			return ctx.Err()
+		}
+		utils.Log.Debugf("[CloudreveV4-Remote] upload: %d", finish)
+		var byteSize = DEFAULT
+		left := file.GetSize() - finish
+		if left < DEFAULT {
+			byteSize = left
+		}
+		byteData := make([]byte, byteSize)
+		n, err := io.ReadFull(file, byteData)
+		utils.Log.Debug(err, n)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequest(http.MethodPost, uploadUrl+"?chunk="+strconv.Itoa(chunk),
+			driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		if err != nil {
+			return err
+		}
+		req = req.WithContext(ctx)
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.Header.Set("Authorization", fmt.Sprint(credential))
+		req.Header.Set("User-Agent", d.getUA())
+		finish += byteSize
+		res, err := base.HttpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		_ = res.Body.Close()
+		up(float64(finish) * 100 / float64(file.GetSize()))
+		chunk++
+	}
+	return nil
+}
+
+func (d *CloudreveV4) upOneDrive(ctx context.Context, file model.FileStreamer, u FileUploadResp, up driver.UpdateProgress) error {
+	uploadUrl := u.UploadUrls[0]
+	var finish int64 = 0
+	DEFAULT := int64(u.ChunkSize)
+	for finish < file.GetSize() {
+		if utils.IsCanceled(ctx) {
+			return ctx.Err()
+		}
+		utils.Log.Debugf("[CloudreveV4-OneDrive] upload: %d", finish)
+		var byteSize = DEFAULT
+		left := file.GetSize() - finish
+		if left < DEFAULT {
+			byteSize = left
+		}
+		byteData := make([]byte, byteSize)
+		n, err := io.ReadFull(file, byteData)
+		utils.Log.Debug(err, n)
+		if err != nil {
+			return err
+		}
+		req, err := http.NewRequest(http.MethodPut, uploadUrl, driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		if err != nil {
+			return err
+		}
+		req = req.WithContext(ctx)
+		req.ContentLength = byteSize
+		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
+		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, file.GetSize()))
+		req.Header.Set("User-Agent", d.getUA())
+		finish += byteSize
+		res, err := base.HttpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
+		if res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200 {
+			data, _ := io.ReadAll(res.Body)
+			_ = res.Body.Close()
+			return errors.New(string(data))
+		}
+		_ = res.Body.Close()
+		up(float64(finish) * 100 / float64(file.GetSize()))
+	}
+	// 上传成功发送回调请求
+	return d.request(http.MethodPost, "/callback/onedrive/"+u.SessionID+"/"+u.CallbackSecret, func(req *resty.Request) {
+		req.SetBody("{}")
+	}, nil)
+}
+
+func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileUploadResp, up driver.UpdateProgress) error {
+	var finish int64 = 0
+	var chunk int = 0
+	var etags []string
+	DEFAULT := int64(u.ChunkSize)
+	for finish < file.GetSize() {
+		if utils.IsCanceled(ctx) {
+			return ctx.Err()
+		}
+		utils.Log.Debugf("[CloudreveV4-S3] upload: %d", finish)
+		var byteSize = DEFAULT
+		left := file.GetSize() - finish
+		if left < DEFAULT {
+			byteSize = left
+		}
+		byteData := make([]byte, byteSize)
+		n, err := io.ReadFull(file, byteData)
+		utils.Log.Debug(err, n)
+		if err != nil {
+			return err
+		}
+		req, err := http.NewRequest(http.MethodPut, u.UploadUrls[chunk],
+			driver.NewLimitedUploadStream(ctx, bytes.NewBuffer(byteData)))
+		if err != nil {
+			return err
+		}
+		req = req.WithContext(ctx)
+		req.ContentLength = byteSize
+		finish += byteSize
+		res, err := base.HttpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		_ = res.Body.Close()
+		etags = append(etags, res.Header.Get("ETag"))
+		up(float64(finish) * 100 / float64(file.GetSize()))
+		chunk++
+	}
+
+	// s3LikeFinishUpload
+	bodyBuilder := &strings.Builder{}
+	bodyBuilder.WriteString("<CompleteMultipartUpload>")
+	for i, etag := range etags {
+		bodyBuilder.WriteString(fmt.Sprintf(
+			`<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>`,
+			i+1, // PartNumber 从 1 开始
+			etag,
+		))
+	}
+	bodyBuilder.WriteString("</CompleteMultipartUpload>")
+	req, err := http.NewRequest(
+		"POST",
+		u.CompleteURL,
+		strings.NewReader(bodyBuilder.String()),
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/xml")
+	req.Header.Set("User-Agent", d.getUA())
+	res, err := base.HttpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("up status: %d, error: %s", res.StatusCode, string(body))
+	}
+
+	// 上传成功发送回调请求
+	return d.request(http.MethodPost, "/callback/s3/"+u.SessionID+"/"+u.CallbackSecret, func(req *resty.Request) {
+		req.SetBody("{}")
+	}, nil)
+}

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -59,7 +59,7 @@ func (d *CloudreveV4) request(method string, path string, callback base.ReqCallb
 	}
 
 	if r.Code != 0 {
-		if r.Code == 401 && d.RefreshToken != "" {
+		if r.Code == 401 && d.RefreshToken != "" && path != "/session/token/refresh" {
 			// try to refresh token
 			err = d.refreshToken()
 			if err != nil {

--- a/drivers/onedrive/util.go
+++ b/drivers/onedrive/util.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	stdpath "path"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -17,7 +18,6 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
-	log "github.com/sirupsen/logrus"
 )
 
 var onedriveHostMap = map[string]Host{
@@ -204,19 +204,18 @@ func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.Fil
 	uploadUrl := jsoniter.Get(res, "uploadUrl").ToString()
 	var finish int64 = 0
 	DEFAULT := d.ChunkSize * 1024 * 1024
+	retryCount := 0
+	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
 		}
-		log.Debugf("upload: %d", finish)
-		var byteSize int64 = DEFAULT
 		left := stream.GetSize() - finish
-		if left < DEFAULT {
-			byteSize = left
-		}
+		byteSize := min(left, DEFAULT)
+		utils.Log.Debugf("[Onedrive] upload range: %d-%d/%d", finish, finish+byteSize-1, stream.GetSize())
 		byteData := make([]byte, byteSize)
 		n, err := io.ReadFull(stream, byteData)
-		log.Debug(err, n)
+		utils.Log.Debug(err, n)
 		if err != nil {
 			return err
 		}
@@ -228,19 +227,31 @@ func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.Fil
 		req.ContentLength = byteSize
 		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
-		finish += byteSize
 		res, err := base.HttpClient.Do(req)
 		if err != nil {
 			return err
 		}
 		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
-		if res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200 {
+		switch {
+		case res.StatusCode >= 500 && res.StatusCode <= 504:
+			retryCount++
+			if retryCount > maxRetries {
+				res.Body.Close()
+				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
+			}
+			backoff := time.Duration(1<<retryCount) * time.Second
+			utils.Log.Warnf("[Onedrive] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
+			time.Sleep(backoff)
+		case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
 			data, _ := io.ReadAll(res.Body)
 			res.Body.Close()
 			return errors.New(string(data))
+		default:
+			res.Body.Close()
+			retryCount = 0
+			finish += byteSize
+			up(float64(finish) * 100 / float64(stream.GetSize()))
 		}
-		res.Body.Close()
-		up(float64(finish) * 100 / float64(stream.GetSize()))
 	}
 	return nil
 }

--- a/drivers/onedrive_app/util.go
+++ b/drivers/onedrive_app/util.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	stdpath "path"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -17,7 +18,6 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
-	log "github.com/sirupsen/logrus"
 )
 
 var onedriveHostMap = map[string]Host{
@@ -154,19 +154,18 @@ func (d *OnedriveAPP) upBig(ctx context.Context, dstDir model.Obj, stream model.
 	uploadUrl := jsoniter.Get(res, "uploadUrl").ToString()
 	var finish int64 = 0
 	DEFAULT := d.ChunkSize * 1024 * 1024
+	retryCount := 0
+	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
 		}
-		log.Debugf("upload: %d", finish)
-		var byteSize int64 = DEFAULT
 		left := stream.GetSize() - finish
-		if left < DEFAULT {
-			byteSize = left
-		}
+		byteSize := min(left, DEFAULT)
+		utils.Log.Debugf("[OnedriveAPP] upload range: %d-%d/%d", finish, finish+byteSize-1, stream.GetSize())
 		byteData := make([]byte, byteSize)
 		n, err := io.ReadFull(stream, byteData)
-		log.Debug(err, n)
+		utils.Log.Debug(err, n)
 		if err != nil {
 			return err
 		}
@@ -178,19 +177,31 @@ func (d *OnedriveAPP) upBig(ctx context.Context, dstDir model.Obj, stream model.
 		req.ContentLength = byteSize
 		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
-		finish += byteSize
 		res, err := base.HttpClient.Do(req)
 		if err != nil {
 			return err
 		}
 		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
-		if res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200 {
+		switch {
+		case res.StatusCode >= 500 && res.StatusCode <= 504:
+			retryCount++
+			if retryCount > maxRetries {
+				res.Body.Close()
+				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
+			}
+			backoff := time.Duration(1<<retryCount) * time.Second
+			utils.Log.Warnf("[OnedriveAPP] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
+			time.Sleep(backoff)
+		case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
 			data, _ := io.ReadAll(res.Body)
 			res.Body.Close()
 			return errors.New(string(data))
+		default:
+			res.Body.Close()
+			retryCount = 0
+			finish += byteSize
+			up(float64(finish) * 100 / float64(stream.GetSize()))
 		}
-		res.Body.Close()
-		up(float64(finish) * 100 / float64(stream.GetSize()))
 	}
 	return nil
 }


### PR DESCRIPTION
适配 Cloudreve V4，其API部分发生改动较大，特独立成一个存储。

Close: https://github.com/AlistGo/alist/issues/8328
Close: https://github.com/AlistGo/alist/issues/8467

此外，本 PR 还进行了：

- 对之前的 Cloudreve、OneDrive、OneDrive APP 驱动（使用类似的上传方法）加入了分片上传失败自动重试机制，提高上传成功率。
- 对 Cloudreve 增加了 https://github.com/AlistGo/alist/pull/7805 引入的 ref 支持。

文档：https://github.com/AlistGo/docs/pull/433

## 参数说明

### 鉴权

Cloudreve V4 支持使用 Access Token 和 Refresh Token 进行鉴权，这意味着挂载鉴权方式分为：

1. 账号+密码：会自动使用登录接口获取 Access Token 和 Refresh Token，存在验证码问题
2. 仅 Refresh Token：会自动使用刷新接口续期 Access Token 和 Refresh Token，参数可从浏览器请求或者 Local Storage 中找到
3. 仅 Access Token：能够临时使用，但会过期，且无法续期
4. 无：匿名用户，适用于公开分享
5. 备注填写 `ref:/{挂载路径}`：从 `已挂载的存储` 中引用认证、令牌等，同一个 Token 多个网盘使用

### 根文件夹路径

Cloudreve V4 采用自定义 URI 作为路径。可从网页链接的 `?path=` 中获取。

#### 挂载「我的文件」

默认为 `cloudreve://my/`，列出用户文件。

#### 挂载「分享」

支持挂载文件夹类型的分享，路径填写为：`cloudreve://{分享ID}@share/`。

- 分享ID为分享链接 `/s/` 后面的参数。

- 目前 Cloudreve V4 不支持「创建带密码的分享」。

### 启用文件夹大小

Cloudreve V4 服务端统计每个文件夹的大小，启用可能会造成服务端报错，默认禁用。

### 启用缩略图

Cloudreve V4 服务端为每个文件生成略缩图，启用可能会造成服务端报错，默认禁用。

### 启用版本上传

启用覆盖上传并保留之前的版本，需要消耗额外的空间。默认禁用，为覆盖上传前删除已有的文件。

### 自定义 UA

用于自定义请求使用的 `User-Agent` 头部信息。留空为 Alist 默认。

### 排序

支持更改请求列表时排序的参数。

## 上传策略

支持上传到的存储策略如下：

- 本机存储
- 从机存储
- OneDrive
- S3

上传的存储策略请在 Cloudreve V4 网页端进入相应文件夹中进行设置（需要服务端为 Cloudreve Pro）。

如果分享开启了上传权限，支持上传。需要服务端为用户组勾选「提升匿名用户权限」（需要服务端为 Cloudreve Pro）。