### PR TITLE
fix(handles): fix that when not a README file, markdown file being automatically parsed into html in proxy mode

### DIFF
--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -131,7 +131,7 @@ func localProxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange boo
 	Writer := &common.WrittenResponseWriter{ResponseWriter: c.Writer}
 
 	//优先处理md文件
-	if utils.Ext(file.GetName()) == "md" && setting.GetBool(conf.FilterReadMeScripts) {
+	if file.GetName() == "README.md" && setting.GetBool(conf.FilterReadMeScripts) {
 		buf := bytes.NewBuffer(make([]byte, 0, file.GetSize()))
 		w := &common.InterceptResponseWriter{ResponseWriter: Writer, Writer: buf}
 		err = common.Proxy(w, c.Request, link, file)

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -130,7 +130,8 @@ func localProxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange boo
 	}
 	Writer := &common.WrittenResponseWriter{ResponseWriter: c.Writer}
 
-	if strings.EqualFold(file.GetName(), "README.md") && setting.GetBool(conf.FilterReadMeScripts) {
+	absPath := c.Request.URL.String()
+	if absPath[1] == 'p' && utils.Ext(file.GetName()) == "md" && setting.GetBool(conf.FilterReadMeScripts) {
 		buf := bytes.NewBuffer(make([]byte, 0, file.GetSize()))
 		w := &common.InterceptResponseWriter{ResponseWriter: Writer, Writer: buf}
 		err = common.Proxy(w, c.Request, link, file)

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -130,8 +130,7 @@ func localProxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange boo
 	}
 	Writer := &common.WrittenResponseWriter{ResponseWriter: c.Writer}
 
-	//优先处理md文件
-	if file.GetName() == "README.md" && setting.GetBool(conf.FilterReadMeScripts) {
+	if strings.EqualFold(file.GetName(), "README.md") && setting.GetBool(conf.FilterReadMeScripts) {
 		buf := bytes.NewBuffer(make([]byte, 0, file.GetSize()))
 		w := &common.InterceptResponseWriter{ResponseWriter: Writer, Writer: buf}
 		err = common.Proxy(w, c.Request, link, file)


### PR DESCRIPTION
修复了在代理模式下（比如本地），非README的markdown文档被自动parse成html的问题，这会导致预览和下载的markdown文件都是parse过的，如截图所示。
Fixed the problem that markdown documents are automatically parsed into html in proxy mode (such as local), which will cause the preview and downloaded markdown files to be parsed, as shown in the screenshot.

![image](https://github.com/user-attachments/assets/1165f1ac-e4e6-42b4-9f18-6659dde13238)
![image](https://github.com/user-attachments/assets/813b3476-502e-4722-9923-e7efc7e5cb6c)

如果是其他类型的文件（如txt）就没有这个问题。
If it is other types of files (such as txt), there is no problem.

![image](https://github.com/user-attachments/assets/b7c27388-e443-4d5b-9993-6618c895112f)
![image](https://github.com/user-attachments/assets/86405fe3-088c-4485-9cf6-086bb2150632)
