### PR TITLE
docs: add 20 language links of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="right">
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=en">English</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=zh-CN">简体中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=zh-TW">繁體中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=ja">日本語</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=ko">한국어</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=hi">हिन्दी</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=th">ไทย</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=fr">Français</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=de">Deutsch</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=es">Español</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=it">Itapano</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=ru">Русский</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=pt">Português</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=nl">Nederlands</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=pl">Polski</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=ar">العربية</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=fa">فارسی</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=tr">Türkçe</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=vi">Tiếng Việt</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=id">Bahasa Indonesia</a></p>
+      </div>
+    </div>
+  </details>
+</div>
+
 <div align="center">
   <a href="https://alistgo.com"><img width="100px" alt="logo" src="https://cdn.jsdelivr.net/gh/alist-org/logo@main/logo.svg"/></a>
   <p><em>🗂️A file list program that supports multiple storages, powered by Gin and Solidjs.</em></p>


### PR DESCRIPTION
PR adds 20 languages link to the README and user can easily access translated README, supports google/bing multiple languages SEO search.

Page demo: https://openaitx.github.io/view.html?user=alistgo&project=alist&lang=ja

> OpenAiTx is free and open-source:  https://github.com/OpenAiTx/OpenAiTx 

 ![Image](https://github.com/user-attachments/assets/1a95bf8c-ab15-4a32-a6fa-0acfdb8ff26f)