### PR TITLE
feat(log): enhance log formatter to respect NO_COLOR env variable

### DIFF
--- a/internal/bootstrap/log.go
+++ b/internal/bootstrap/log.go
@@ -14,10 +14,14 @@ import (
 
 func init() {
 	formatter := logrus.TextFormatter{
-		ForceColors:               true,
-		EnvironmentOverrideColors: true,
-		TimestampFormat:           "2006-01-02 15:04:05",
-		FullTimestamp:             true,
+		TimestampFormat: "2006-01-02 15:04:05",
+		FullTimestamp:   true,
+	}
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("ALIST_NO_COLOR") == "1" {
+		formatter.DisableColors = true
+	} else {
+		formatter.ForceColors = true
+		formatter.EnvironmentOverrideColors = true
 	}
 	logrus.SetFormatter(&formatter)
 	utils.Log.SetFormatter(&formatter)


### PR DESCRIPTION
fix: #9237 
- Adjust log formatter to disable colors when NO_COLOR or ALIST_NO_COLOR environment variables are set.
- Reorganize formatter settings for better readability.