### PR TITLE
fix(ssologin): missing role in SSO auto-registration and minor callback issue

### DIFF
--- a/server/handles/ssologin.go
+++ b/server/handles/ssologin.go
@@ -256,6 +256,7 @@ func OIDCLoginCallback(c *gin.Context) {
 			user, err = autoRegister(userID, userID, err)
 			if err != nil {
 				common.ErrorResp(c, err, 400)
+				return
 			}
 		}
 		token, err := common.GenerateToken(user)

--- a/server/handles/ssologin.go
+++ b/server/handles/ssologin.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/alist-org/alist/v3/internal/op"
 	"net/http"
 	"net/url"
 	"path"
@@ -154,7 +155,7 @@ func autoRegister(username, userID string, err error) (*model.User, error) {
 		Password:   random.String(16),
 		Permission: int32(setting.GetInt(conf.SSODefaultPermission, 0)),
 		BasePath:   setting.GetStr(conf.SSODefaultDir),
-		Role:       nil,
+		Role:       model.Roles{op.GetDefaultRoleID()},
 		Disabled:   false,
 		SsoID:      userID,
 	}


### PR DESCRIPTION
# Description
Fixes an issue where users created through SSO auto-registration cannot access the system properly.

# Problem
A After a user is auto-registered, the `role` field is set to `null`, which prevents the user from accessing the system:

```
{
    "code": 200,
    "message": "success",
    "data": {
        ...
        "role": null,
        ...
    }
}
```

Additionally, administrators are unable to modify the affected user unless they delete the account first.

# Solution
- Assign default roles to auto-registered users following the same logic as normal registration.
- Fixed a minor issue in the `OIDCLoginCallback` where `return` was missing after an error response.