### PR TITLE
Fix Dockerfile: FromAsCasing Warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge as builder
+FROM alpine:edge AS builder
 LABEL stage=go-builder
 WORKDIR /app/
 RUN apk add --no-cache bash curl gcc git go musl-dev


### PR DESCRIPTION
Fix Dockerfile: FromAsCasing: 'as' and 'FROM' keywords' casing do not match warning