### PR TITLE
Fix stale missing meta cache

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -169,6 +169,7 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.MaxDevices, Value: "0", Type: conf.TypeNumber, Group: model.GLOBAL},
 		{Key: conf.DeviceEvictPolicy, Value: "deny", Type: conf.TypeSelect, Options: "deny,evict_oldest", Group: model.GLOBAL},
 		{Key: conf.DeviceSessionTTL, Value: "86400", Type: conf.TypeNumber, Group: model.GLOBAL},
+		{Key: conf.MetaNotFoundCacheExpire, Value: "60", Type: conf.TypeNumber, Group: model.GLOBAL, Flag: model.PRIVATE, Help: "Negative cache expiration for missing meta records, in seconds. Set 0 to disable."},
 
 		// single settings
 		{Key: conf.Token, Value: token, Type: conf.TypeString, Group: model.SINGLE, Flag: model.PRIVATE},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -52,6 +52,7 @@ const (
 	MaxDevices              = "max_devices"
 	DeviceEvictPolicy       = "device_evict_policy"
 	DeviceSessionTTL        = "device_session_ttl"
+	MetaNotFoundCacheExpire = "meta_not_found_cache_expire"
 
 	// index
 	SearchIndex     = "search_index"

--- a/internal/op/meta.go
+++ b/internal/op/meta.go
@@ -2,9 +2,11 @@ package op
 
 import (
 	stdpath "path"
+	"strconv"
 	"time"
 
 	"github.com/Xhofe/go-cache"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/db"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -18,6 +20,17 @@ var metaCache = cache.NewMemCache(cache.WithShards[*model.Meta](2))
 
 // metaG maybe not needed
 var metaG singleflight.Group[*model.Meta]
+
+const (
+	metaCacheExpiration         = time.Hour
+	defaultMetaNotFoundCacheSec = 60
+)
+
+func init() {
+	RegisterSettingChangingCallback(func() {
+		metaCache.Clear()
+	})
+}
 
 func GetNearestMeta(path string) (*model.Meta, error) {
 	return getNearestMeta(utils.FixAndCleanPath(path))
@@ -51,15 +64,32 @@ func getMetaByPath(path string) (*model.Meta, error) {
 		_meta, err := db.GetMetaByPath(path)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				metaCache.Set(path, nil)
+				if ex := metaNotFoundCacheExpiration(); ex > 0 {
+					metaCache.Set(path, nil, cache.WithEx[*model.Meta](ex))
+				}
 				return nil, errs.MetaNotFound
 			}
 			return nil, err
 		}
-		metaCache.Set(path, _meta, cache.WithEx[*model.Meta](time.Hour))
+		metaCache.Set(path, _meta, cache.WithEx[*model.Meta](metaCacheExpiration))
 		return _meta, nil
 	})
 	return meta, err
+}
+
+func metaNotFoundCacheExpiration() time.Duration {
+	item, err := GetSettingItemByKey(conf.MetaNotFoundCacheExpire)
+	if err != nil || item == nil {
+		return time.Second * defaultMetaNotFoundCacheSec
+	}
+	seconds, err := strconv.Atoi(item.Value)
+	if err != nil {
+		return time.Second * defaultMetaNotFoundCacheSec
+	}
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Second * time.Duration(seconds)
 }
 
 func DeleteMetaById(id uint) error {
@@ -78,6 +108,7 @@ func UpdateMeta(u *model.Meta) error {
 		return err
 	}
 	metaCache.Del(old.Path)
+	metaCache.Del(u.Path)
 	return db.UpdateMeta(u)
 }
 


### PR DESCRIPTION
## Summary
- expire missing-meta negative cache instead of caching it indefinitely
- clear both old and new meta paths when updating a meta record
- add a backend setting to configure missing meta negative cache expiration in seconds
- clear meta cache when settings change so the new expiration takes effect immediately

## Companion frontend PR
- AlistGo/alist-web#302

## Testing
- go test ./internal/op ./internal/bootstrap/data

Refs #9501