### PR TITLE
feat: add GuangYaPan offline download

### DIFF
--- a/drivers/guangyapan/offline.go
+++ b/drivers/guangyapan/offline.go
@@ -1,0 +1,165 @@
+package guangyapan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	stdpath "path"
+	"strings"
+
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+func (d *GuangYaPan) ResolveOfflineResource(ctx context.Context, fileURL string) (*OfflineResolveData, error) {
+	if err := d.ensureAccessToken(ctx); err != nil {
+		return nil, err
+	}
+	fileURL = strings.TrimSpace(fileURL)
+	if fileURL == "" {
+		return nil, errors.New("offline url is empty")
+	}
+
+	var resp offlineResolveResp
+	if err := d.postAPI(ctx, "/cloudcollection/v1/resolve_res", map[string]any{
+		"url": fileURL,
+	}, &resp); err != nil {
+		return nil, err
+	}
+	if !isSuccessMsg(resp.Msg) {
+		return nil, fmt.Errorf("resolve offline resource failed: %s", strings.TrimSpace(resp.Msg))
+	}
+	return &resp.Data, nil
+}
+
+func (d *GuangYaPan) OfflineDownload(ctx context.Context, fileURL string, parentDir model.Obj, fileName string) (*OfflineTask, error) {
+	resolved, err := d.ResolveOfflineResource(ctx, fileURL)
+	if err != nil {
+		return nil, err
+	}
+
+	parentID := parentDir.GetID()
+	if parentID == d.RootFolderID {
+		parentID = ""
+	}
+
+	taskURL := strings.TrimSpace(resolved.URL)
+	if taskURL == "" {
+		taskURL = strings.TrimSpace(fileURL)
+	}
+	name := strings.TrimSpace(fileName)
+	if name == "" {
+		name = resolved.defaultName(taskURL)
+	}
+
+	body := map[string]any{
+		"url":      taskURL,
+		"parentId": parentID,
+		"newName":  name,
+	}
+	if indexes := resolved.fileIndexes(); len(indexes) > 0 {
+		body["fileIndexes"] = indexes
+	}
+
+	var resp offlineCreateResp
+	if err := d.postAPI(ctx, "/cloudcollection/v1/create_task", body, &resp); err != nil {
+		return nil, err
+	}
+	if !isSuccessMsg(resp.Msg) {
+		return nil, fmt.Errorf("create offline task failed: %s", strings.TrimSpace(resp.Msg))
+	}
+	taskID := strings.TrimSpace(resp.Data.TaskID)
+	if taskID == "" {
+		return nil, errors.New("create offline task failed: empty task id")
+	}
+	return &OfflineTask{
+		TaskID:   taskID,
+		FileName: name,
+		Res:      taskURL,
+	}, nil
+}
+
+func (d *GuangYaPan) OfflineList(ctx context.Context, taskIDs []string, statuses []int, cursor string, pageSize int) ([]OfflineTask, error) {
+	if err := d.ensureAccessToken(ctx); err != nil {
+		return nil, err
+	}
+	body := map[string]any{}
+	if len(taskIDs) > 0 {
+		body["taskIds"] = taskIDs
+	}
+	if len(statuses) > 0 {
+		body["status"] = statuses
+	}
+	if cursor = strings.TrimSpace(cursor); cursor != "" {
+		body["cursor"] = cursor
+	}
+	if pageSize > 0 {
+		body["pageSize"] = pageSize
+	}
+
+	var resp offlineListResp
+	if err := d.postAPI(ctx, "/cloudcollection/v1/list_task", body, &resp); err != nil {
+		return nil, err
+	}
+	if !isSuccessMsg(resp.Msg) {
+		return nil, fmt.Errorf("list offline tasks failed: %s", strings.TrimSpace(resp.Msg))
+	}
+	return resp.Data.List, nil
+}
+
+func (d *GuangYaPan) DeleteOfflineTasks(ctx context.Context, taskIDs []string, deleteFiles bool) error {
+	if err := d.ensureAccessToken(ctx); err != nil {
+		return err
+	}
+	if len(taskIDs) == 0 {
+		return nil
+	}
+
+	var resp offlineDeleteResp
+	if err := d.postAPI(ctx, "/cloudcollection/v2/delete_task", map[string]any{
+		"taskIds": taskIDs,
+	}, &resp); err != nil {
+		return err
+	}
+	if !isSuccessMsg(resp.Msg) {
+		return fmt.Errorf("delete offline tasks failed: %s", strings.TrimSpace(resp.Msg))
+	}
+	return nil
+}
+
+func (d OfflineResolveData) defaultName(fileURL string) string {
+	if d.BTResInfo != nil && strings.TrimSpace(d.BTResInfo.FileName) != "" {
+		return strings.TrimSpace(d.BTResInfo.FileName)
+	}
+	u, err := url.Parse(fileURL)
+	if err == nil {
+		name := strings.TrimSpace(stdpath.Base(u.Path))
+		if name != "" && name != "." && name != "/" {
+			if decoded, err := url.PathUnescape(name); err == nil {
+				name = decoded
+			}
+			return name
+		}
+	}
+	return "offline_download"
+}
+
+func (d OfflineResolveData) fileIndexes() []int {
+	if d.BTResInfo == nil || len(d.BTResInfo.Subfiles) == 0 {
+		return nil
+	}
+	indexes := make([]int, 0, len(d.BTResInfo.Subfiles))
+	for i, file := range d.BTResInfo.Subfiles {
+		if file.FileIndex != nil {
+			indexes = append(indexes, *file.FileIndex)
+			continue
+		}
+		indexes = append(indexes, i)
+	}
+	return indexes
+}
+
+func isSuccessMsg(msg string) bool {
+	msg = strings.TrimSpace(msg)
+	return msg == "" || strings.EqualFold(msg, "success")
+}

--- a/drivers/guangyapan/types.go
+++ b/drivers/guangyapan/types.go
@@ -133,6 +133,79 @@ type taskInfoResp struct {
 	} `json:"data"`
 }
 
+type offlineResolveResp struct {
+	Code int                `json:"code"`
+	Msg  string             `json:"msg"`
+	Data OfflineResolveData `json:"data"`
+}
+
+type OfflineResolveData struct {
+	ResType   int               `json:"resType"`
+	BTResInfo *OfflineBTResInfo `json:"btResInfo"`
+	URL       string            `json:"url"`
+}
+
+type OfflineBTResInfo struct {
+	InfoHash       string           `json:"infoHash"`
+	FileName       string           `json:"fileName"`
+	FileSize       int64            `json:"fileSize"`
+	SubfilesNum    int              `json:"subfilesNum"`
+	Subfiles       []OfflineSubfile `json:"subfiles"`
+	CreateTime     int64            `json:"createTime"`
+	ExcludeIndices []int            `json:"excludeIndices"`
+}
+
+type OfflineSubfile struct {
+	FileName  string `json:"fileName"`
+	FileIndex *int   `json:"fileIndex"`
+	FileSize  int64  `json:"fileSize"`
+}
+
+type offlineCreateResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		TaskID string `json:"taskId"`
+		URL    string `json:"url"`
+	} `json:"data"`
+}
+
+type offlineDeleteResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		TaskIDs []string `json:"taskIds"`
+	} `json:"data"`
+}
+
+type offlineListResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		StatusCounts []struct {
+			Status int `json:"status"`
+			Count  int `json:"count"`
+		} `json:"statusCounts"`
+		Cursor string        `json:"cursor"`
+		List   []OfflineTask `json:"list"`
+		Total  int           `json:"total"`
+	} `json:"data"`
+}
+
+type OfflineTask struct {
+	TaskID     string `json:"taskId"`
+	FileName   string `json:"fileName"`
+	TotalSize  int64  `json:"totalSize"`
+	Status     int    `json:"status"`
+	CreateTime int64  `json:"createTime"`
+	Res        string `json:"res"`
+	ResType    int    `json:"resType"`
+	Progress   int    `json:"progress"`
+	FileID     string `json:"fileId"`
+	IsDir      bool   `json:"isDir"`
+	Exist      bool   `json:"exist"`
+}
+
 func unixOrZero(v int64) time.Time {
 	if v <= 0 {
 		return time.Time{}

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -76,6 +76,9 @@ const (
 	// thunder
 	ThunderTempDir = "thunder_temp_dir"
 
+	// guangyapan
+	GuangYaPanTempDir = "guangyapan_temp_dir"
+
 	// single
 	Token         = "token"
 	IndexProgress = "index_progress"
@@ -126,19 +129,19 @@ const (
 	FTPTLSPublicCertPath = "ftp_tls_public_cert_path"
 
 	// frp
-	FRPEnabled      = "frp_enabled"
-	FRPServerAddr   = "frp_server_addr"
-	FRPServerPort   = "frp_server_port"
-	FRPAuthToken    = "frp_auth_token"
-	FRPProxyName    = "frp_proxy_name"
-	FRPProxyType    = "frp_proxy_type"
-	FRPCustomDomain = "frp_custom_domain"
-	FRPSubdomain    = "frp_subdomain"
-	FRPRemotePort   = "frp_remote_port"
-	FRPLocalPort    = "frp_local_port"
-	FRPTLSEnable    = "frp_tls_enable"
+	FRPEnabled       = "frp_enabled"
+	FRPServerAddr    = "frp_server_addr"
+	FRPServerPort    = "frp_server_port"
+	FRPAuthToken     = "frp_auth_token"
+	FRPProxyName     = "frp_proxy_name"
+	FRPProxyType     = "frp_proxy_type"
+	FRPCustomDomain  = "frp_custom_domain"
+	FRPSubdomain     = "frp_subdomain"
+	FRPRemotePort    = "frp_remote_port"
+	FRPLocalPort     = "frp_local_port"
+	FRPTLSEnable     = "frp_tls_enable"
 	FRPSTCPSecretKey = "frp_stcp_secret_key"
-	FRPStatus       = "frp_status"
+	FRPStatus        = "frp_status"
 
 	// traffic
 	TaskOfflineDownloadThreadsNum         = "offline_download_task_threads_num"

--- a/internal/offline_download/all.go
+++ b/internal/offline_download/all.go
@@ -3,6 +3,7 @@ package offline_download
 import (
 	_ "github.com/alist-org/alist/v3/internal/offline_download/115"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/aria2"
+	_ "github.com/alist-org/alist/v3/internal/offline_download/guangyapan"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/http"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/pikpak"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/qbit"

--- a/internal/offline_download/guangyapan/guangyapan.go
+++ b/internal/offline_download/guangyapan/guangyapan.go
@@ -1,0 +1,131 @@
+package guangyapan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	guangyapandriver "github.com/alist-org/alist/v3/drivers/guangyapan"
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/offline_download/tool"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/internal/setting"
+)
+
+type GuangYaPan struct {
+	refreshTaskCache bool
+}
+
+func (g *GuangYaPan) Name() string {
+	return "GuangYaPan"
+}
+
+func (g *GuangYaPan) Items() []model.SettingItem {
+	return nil
+}
+
+func (g *GuangYaPan) Run(task *tool.DownloadTask) error {
+	return errs.NotSupport
+}
+
+func (g *GuangYaPan) Init() (string, error) {
+	g.refreshTaskCache = false
+	return "ok", nil
+}
+
+func (g *GuangYaPan) IsReady() bool {
+	tempDir := setting.GetStr(conf.GuangYaPanTempDir)
+	if tempDir == "" {
+		return false
+	}
+	storage, _, err := op.GetStorageAndActualPath(tempDir)
+	if err != nil {
+		return false
+	}
+	if _, ok := storage.(*guangyapandriver.GuangYaPan); !ok {
+		return false
+	}
+	return true
+}
+
+func (g *GuangYaPan) AddURL(args *tool.AddUrlArgs) (string, error) {
+	g.refreshTaskCache = true
+	storage, actualPath, err := op.GetStorageAndActualPath(args.TempDir)
+	if err != nil {
+		return "", err
+	}
+	driver, ok := storage.(*guangyapandriver.GuangYaPan)
+	if !ok {
+		return "", errors.New("GuangYaPan offline download only supports GuangYaPan destination storage")
+	}
+
+	ctx := context.Background()
+	if err := op.MakeDir(ctx, storage, actualPath); err != nil {
+		return "", err
+	}
+	parentDir, err := op.GetUnwrap(ctx, storage, actualPath)
+	if err != nil {
+		return "", err
+	}
+	task, err := driver.OfflineDownload(ctx, args.Url, parentDir, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to add offline download task: %w", err)
+	}
+	return task.TaskID, nil
+}
+
+func (g *GuangYaPan) Remove(task *tool.DownloadTask) error {
+	storage, _, err := op.GetStorageAndActualPath(task.TempDir)
+	if err != nil {
+		return err
+	}
+	driver, ok := storage.(*guangyapandriver.GuangYaPan)
+	if !ok {
+		return errors.New("GuangYaPan offline download only supports GuangYaPan destination storage")
+	}
+	ctx := context.Background()
+	if err := driver.DeleteOfflineTasks(ctx, []string{task.GID}, false); err != nil {
+		return err
+	}
+	g.DelTaskCache(driver, task.GID)
+	return nil
+}
+
+func (g *GuangYaPan) Status(task *tool.DownloadTask) (*tool.Status, error) {
+	storage, _, err := op.GetStorageAndActualPath(task.TempDir)
+	if err != nil {
+		return nil, err
+	}
+	driver, ok := storage.(*guangyapandriver.GuangYaPan)
+	if !ok {
+		return nil, errors.New("GuangYaPan offline download only supports GuangYaPan destination storage")
+	}
+	tasks, err := g.GetTasks(driver, task.GID)
+	if err != nil {
+		return nil, err
+	}
+	status := &tool.Status{
+		Status: "the task has been deleted",
+	}
+	for _, t := range tasks {
+		if t.TaskID != task.GID {
+			continue
+		}
+		status.Progress = float64(t.Progress)
+		status.TotalBytes = t.TotalSize
+		status.Completed = t.Status == offlineStatusCompleted || t.Status == offlineStatusPartiallyCompleted
+		status.Status = taskStatusText(t)
+		if t.Status == offlineStatusFailed || t.Status == offlineStatusCanceled {
+			status.Err = errors.New(status.Status)
+		}
+		return status, nil
+	}
+	status.Err = errors.New("the task has been deleted")
+	return status, nil
+}
+
+func init() {
+	tool.Tools.Add(&GuangYaPan{})
+}

--- a/internal/offline_download/guangyapan/util.go
+++ b/internal/offline_download/guangyapan/util.go
@@ -1,0 +1,77 @@
+package guangyapan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Xhofe/go-cache"
+	guangyapandriver "github.com/alist-org/alist/v3/drivers/guangyapan"
+	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/alist-org/alist/v3/pkg/singleflight"
+)
+
+const (
+	offlineStatusQueued             = 0
+	offlineStatusRunning            = 1
+	offlineStatusCompleted          = 2
+	offlineStatusFailed             = 3
+	offlineStatusCanceled           = 4
+	offlineStatusPartiallyCompleted = 5
+)
+
+var taskCache = cache.NewMemCache(cache.WithShards[[]guangyapandriver.OfflineTask](16))
+var taskG singleflight.Group[[]guangyapandriver.OfflineTask]
+
+func (g *GuangYaPan) GetTasks(driver *guangyapandriver.GuangYaPan, taskID string) ([]guangyapandriver.OfflineTask, error) {
+	key := op.Key(driver, "/cloudcollection/v1/list_task/"+taskID)
+	if !g.refreshTaskCache {
+		if tasks, ok := taskCache.Get(key); ok {
+			return tasks, nil
+		}
+	}
+	g.refreshTaskCache = false
+	tasks, err, _ := taskG.Do(key, func() ([]guangyapandriver.OfflineTask, error) {
+		ctx := context.Background()
+		tasks, err := driver.OfflineList(ctx, []string{taskID}, nil, "", 0)
+		if err != nil {
+			return nil, err
+		}
+		if len(tasks) > 0 {
+			taskCache.Set(key, tasks, cache.WithEx[[]guangyapandriver.OfflineTask](time.Second*10))
+		} else {
+			taskCache.Del(key)
+		}
+		return tasks, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+func (g *GuangYaPan) DelTaskCache(driver *guangyapandriver.GuangYaPan, taskID string) {
+	taskCache.Del(op.Key(driver, "/cloudcollection/v1/list_task/"+taskID))
+}
+
+func taskStatusText(task guangyapandriver.OfflineTask) string {
+	switch task.Status {
+	case offlineStatusQueued:
+		return "queued"
+	case offlineStatusRunning:
+		if task.Progress > 0 {
+			return fmt.Sprintf("running (%d%%)", task.Progress)
+		}
+		return "running"
+	case offlineStatusCompleted:
+		return "completed"
+	case offlineStatusFailed:
+		return "failed"
+	case offlineStatusCanceled:
+		return "canceled"
+	case offlineStatusPartiallyCompleted:
+		return "partially completed"
+	default:
+		return fmt.Sprintf("unknown status %d", task.Status)
+	}
+}

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	_115 "github.com/alist-org/alist/v3/drivers/115"
+	"github.com/alist-org/alist/v3/drivers/guangyapan"
 	"github.com/alist-org/alist/v3/drivers/pikpak"
 	"github.com/alist-org/alist/v3/drivers/thunder"
 	"github.com/alist-org/alist/v3/internal/conf"
@@ -102,6 +103,16 @@ func AddURL(ctx context.Context, args *AddURLArgs) (task.TaskExtensionInfo, erro
 			tempDir = args.DstDirPath
 		} else {
 			tempDir = filepath.Join(setting.GetStr(conf.ThunderTempDir), uid)
+		}
+	case "GuangYaPan":
+		if _, ok := storage.(*guangyapan.GuangYaPan); ok {
+			tempDir = args.DstDirPath
+		} else {
+			tempBase := setting.GetStr(conf.GuangYaPanTempDir)
+			if tempBase == "" {
+				return nil, errors.New("GuangYaPan temp dir is not set")
+			}
+			tempDir = filepath.Join(tempBase, uid)
 		}
 	}
 

--- a/internal/offline_download/tool/download.go
+++ b/internal/offline_download/tool/download.go
@@ -87,6 +87,9 @@ outer:
 	if t.tool.Name() == "Thunder" {
 		return nil
 	}
+	if t.tool.Name() == "GuangYaPan" {
+		return nil
+	}
 	if t.tool.Name() == "115 Cloud" {
 		// hack for 115
 		<-time.After(time.Second * 1)
@@ -159,7 +162,7 @@ func (t *DownloadTask) Update() (bool, error) {
 
 func (t *DownloadTask) Transfer() error {
 	toolName := t.tool.Name()
-	if toolName == "115 Cloud" || toolName == "PikPak" || toolName == "Thunder" {
+	if toolName == "115 Cloud" || toolName == "PikPak" || toolName == "Thunder" || toolName == "GuangYaPan" {
 		// 如果不是直接下载到目标路径，则进行转存
 		if t.TempDir != t.DstDirPath {
 			return transferObj(t.Ctx(), t.TempDir, t.DstDirPath, t.DeletePolicy)

--- a/server/handles/offline_download.go
+++ b/server/handles/offline_download.go
@@ -2,6 +2,7 @@ package handles
 
 import (
 	_115 "github.com/alist-org/alist/v3/drivers/115"
+	guangyapandriver "github.com/alist-org/alist/v3/drivers/guangyapan"
 	"github.com/alist-org/alist/v3/drivers/pikpak"
 	"github.com/alist-org/alist/v3/drivers/thunder"
 	"github.com/alist-org/alist/v3/internal/conf"
@@ -229,6 +230,50 @@ func SetThunder(c *gin.Context) {
 		return
 	}
 	_tool, err := tool.Tools.Get("Thunder")
+	if err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+	if _, err := _tool.Init(); err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+	common.SuccessResp(c, "ok")
+}
+
+type SetGuangYaPanReq struct {
+	TempDir string `json:"temp_dir" form:"temp_dir"`
+}
+
+func SetGuangYaPan(c *gin.Context) {
+	var req SetGuangYaPanReq
+	if err := c.ShouldBind(&req); err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+	if req.TempDir != "" {
+		storage, _, err := op.GetStorageAndActualPath(req.TempDir)
+		if err != nil {
+			common.ErrorStrResp(c, "storage does not exists", 400)
+			return
+		}
+		if storage.Config().CheckStatus && storage.GetStorage().Status != op.WORK {
+			common.ErrorStrResp(c, "storage not init: "+storage.GetStorage().Status, 400)
+			return
+		}
+		if _, ok := storage.(*guangyapandriver.GuangYaPan); !ok {
+			common.ErrorStrResp(c, "unsupported storage driver for offline download, only GuangYaPan is supported", 400)
+			return
+		}
+	}
+	items := []model.SettingItem{
+		{Key: conf.GuangYaPanTempDir, Value: req.TempDir, Type: conf.TypeString, Group: model.OFFLINE_DOWNLOAD, Flag: model.PRIVATE},
+	}
+	if err := op.SaveSettingItems(items); err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+	_tool, err := tool.Tools.Get("GuangYaPan")
 	if err != nil {
 		common.ErrorResp(c, err, 500)
 		return

--- a/server/router.go
+++ b/server/router.go
@@ -181,6 +181,7 @@ func admin(g *gin.RouterGroup) {
 	setting.POST("/set_115", handles.Set115)
 	setting.POST("/set_pikpak", handles.SetPikPak)
 	setting.POST("/set_thunder", handles.SetThunder)
+	setting.POST("/set_guangyapan", handles.SetGuangYaPan)
 	setting.POST("/set_frp", handles.SetFRP)
 	setting.POST("/stop_frp", handles.StopFRP)
 	setting.GET("/frp_runtime", handles.GetFRPRuntime)


### PR DESCRIPTION
## Summary
- add GuangYaPan cloud collection API support for resolve/create/list/delete offline tasks
- register GuangYaPan as an offline download tool
- support direct downloads to GuangYaPan targets and temp-dir transfer for other targets
- add backend setting endpoint for GuangYaPan temp dir

## Related
- Frontend PR: https://github.com/AlistGo/alist-web/pull/303

## Verification
- go test ./drivers/guangyapan ./internal/offline_download/guangyapan ./internal/offline_download/tool ./server/handles
- go test -vet=off ./internal/offline_download/... ./drivers/guangyapan ./server/handles
- verified GuangYaPan resolve_res/list_task APIs with local storage credentials without creating a new task
