### PR TITLE
fix: support all pagination mode

### DIFF
--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -82,6 +82,7 @@ type ObjLabelResp struct {
 const (
 	DefaultPerPage = 200
 	MaxPerPage     = 500
+	AllPerPage     = -1
 )
 
 func FsList(c *gin.Context) {
@@ -136,7 +137,7 @@ func FsList(c *gin.Context) {
 	total, pageObjs := pagination(filtered, &req.PageReq)
 	respContent := toObjsResp(pageObjs, reqPath, isEncrypt(meta, reqPath))
 	pagesTotal := calcPagesTotal(total, req.PerPage)
-	hasMore := req.Page*req.PerPage < total
+	hasMore := req.PerPage != AllPerPage && req.Page*req.PerPage < total
 
 	common.SuccessResp(c, FsListResp{
 		Content:       respContent,
@@ -253,7 +254,10 @@ func normalizeListPage(page, perPage int) (int, int) {
 		effPage = 1
 	}
 	effPerPage := perPage
-	if effPerPage <= 0 {
+	if effPerPage < 0 {
+		return effPage, AllPerPage
+	}
+	if effPerPage == 0 {
 		effPerPage = DefaultPerPage
 	}
 	if effPerPage > MaxPerPage {
@@ -263,6 +267,12 @@ func normalizeListPage(page, perPage int) (int, int) {
 }
 
 func calcPagesTotal(total, perPage int) int {
+	if perPage == AllPerPage {
+		if total > 0 {
+			return 1
+		}
+		return 0
+	}
 	if total <= 0 || perPage <= 0 {
 		return 0
 	}
@@ -272,6 +282,9 @@ func calcPagesTotal(total, perPage int) int {
 func pagination(objs []model.Obj, req *model.PageReq) (int, []model.Obj) {
 	pageIndex, pageSize := req.Page, req.PerPage
 	total := len(objs)
+	if pageSize == AllPerPage {
+		return total, objs
+	}
 	start := (pageIndex - 1) * pageSize
 	if start > total {
 		return total, []model.Obj{}

--- a/server/handles/share_public.go
+++ b/server/handles/share_public.go
@@ -147,7 +147,7 @@ func ListPublicShare(c *gin.Context) {
 		Total:      int64(total),
 		Page:       req.Page,
 		PerPage:    req.PerPage,
-		HasMore:    req.Page*req.PerPage < total,
+		HasMore:    req.PerPage != AllPerPage && req.Page*req.PerPage < total,
 		PagesTotal: calcPagesTotal(total, req.PerPage),
 	})
 }


### PR DESCRIPTION
## Summary
- support `per_page=-1` as the ALL pagination sentinel
- return full list content and disable `has_more` in ALL mode
- apply the same behavior to public share list responses

## Tests
- `go test ./server/handles ./server/common`

Frontend PR: https://github.com/AlistGo/alist-web/pull/305
Fix: https://github.com/AlistGo/alist/issues/9510