### PR TITLE
fix(guangyapan): resolve offline root folder lookup

### DIFF
--- a/drivers/guangyapan/offline.go
+++ b/drivers/guangyapan/offline.go
@@ -39,7 +39,11 @@ func (d *GuangYaPan) OfflineDownload(ctx context.Context, fileURL string, parent
 	}
 
 	parentID := parentDir.GetID()
-	if parentID == d.RootFolderID {
+	rootID, err := d.getRootFolderID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if parentID == rootID {
 		parentID = ""
 	}
 


### PR DESCRIPTION
This fixes the GuangYaPan offline-download code path to use the current root-folder lookup logic instead of the removed RootFolderID field.

Validation:
- go test ./drivers/guangyapan