### PR TITLE
fix: use constant format strings for fmt.Errorf and logrus calls across drivers

### DIFF
--- a/drivers/123/util.go
+++ b/drivers/123/util.go
@@ -174,7 +174,7 @@ func (d *Pan123) login() error {
 		return err
 	}
 	if utils.Json.Get(res.Body(), "code").ToInt() != 200 {
-		err = fmt.Errorf(utils.Json.Get(res.Body(), "message").ToString())
+		err = fmt.Errorf("%s", utils.Json.Get(res.Body(), "message").ToString())
 	} else {
 		d.AccessToken = utils.Json.Get(res.Body(), "data", "token").ToString()
 	}

--- a/drivers/189/util.go
+++ b/drivers/189/util.go
@@ -261,7 +261,7 @@ func (d *Cloud189) oldUpload(dstDir model.Obj, file model.FileStreamer) error {
 	if utils.Json.Get(res.Body(), "MD5").ToString() != "" {
 		return nil
 	}
-	log.Debugf(res.String())
+	log.Debugf("%s", res.String())
 	return errors.New(res.String())
 }
 

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -359,7 +359,7 @@ func (y *Cloud189PC) login() (err error) {
 		return &erron
 	}
 	if tokenInfo.ResCode != 0 {
-		err = fmt.Errorf(tokenInfo.ResMessage)
+		err = fmt.Errorf("%s", tokenInfo.ResMessage)
 		return
 	}
 	y.tokenInfo = &tokenInfo

--- a/drivers/chaoxing/driver.go
+++ b/drivers/chaoxing/driver.go
@@ -54,13 +54,13 @@ func (d *ChaoXing) refreshCookie() error {
 func (d *ChaoXing) Init(ctx context.Context) error {
 	err := d.refreshCookie()
 	if err != nil {
-		log.Errorf(ctx, err.Error())
+		log.Errorf(ctx, "%s", err.Error())
 	}
 	d.cron = cron.NewCron(time.Hour * 12)
 	d.cron.Do(func() {
 		err = d.refreshCookie()
 		if err != nil {
-			log.Errorf(ctx, err.Error())
+log.Errorf(ctx, "%s", err.Error())
 		}
 	})
 	return nil

--- a/drivers/doubao_new/util.go
+++ b/drivers/doubao_new/util.go
@@ -64,7 +64,7 @@ func (d *DoubaoNew) request(ctx context.Context, path string, method string, cal
 			string(body),
 			err,
 		)
-		return body, fmt.Errorf(msg)
+		return body, fmt.Errorf("%s", msg)
 	}
 	if common.Code != 0 {
 		errMsg := common.Msg
@@ -247,7 +247,7 @@ func (d *DoubaoNew) createFolder(ctx context.Context, parentToken, name string) 
 			string(body),
 			err,
 		)
-		return Node{}, fmt.Errorf(msg)
+		return Node{}, fmt.Errorf("%s", msg)
 	}
 
 	var node Node
@@ -374,7 +374,7 @@ func decodeBaseResp(body []byte, res *resty.Response) error {
 			string(body),
 			err,
 		)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 	if common.Code != 0 {
 		errMsg := common.Msg
@@ -485,7 +485,7 @@ func (d *DoubaoNew) removeObj(ctx context.Context, tokens []string) error {
 			string(body),
 			err,
 		)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 	if resp.Code != 0 {
 		errMsg := resp.Msg
@@ -534,7 +534,7 @@ func (d *DoubaoNew) getUserStorage(ctx context.Context) (UserStorageData, error)
 			string(body),
 			err,
 		)
-		return UserStorageData{}, fmt.Errorf(msg)
+		return UserStorageData{}, fmt.Errorf("%s", msg)
 	}
 	if resp.Code != 0 {
 		errMsg := resp.Msg
@@ -607,7 +607,7 @@ func (d *DoubaoNew) getTaskStatus(ctx context.Context, taskID string) (TaskStatu
 			string(body),
 			err,
 		)
-		return TaskStatusData{}, fmt.Errorf(msg)
+		return TaskStatusData{}, fmt.Errorf("%s", msg)
 	}
 	if resp.Code != 0 {
 		errMsg := resp.Msg
@@ -778,7 +778,7 @@ func (d *DoubaoNew) mergeUploadBlocks(ctx context.Context, uploadID string, seqL
 			string(body),
 			err,
 		)
-		return UploadMergeData{}, fmt.Errorf(msg)
+		return UploadMergeData{}, fmt.Errorf("%s", msg)
 	}
 	if resp.Code != 0 {
 		if res != nil && res.StatusCode() == http.StatusBadRequest && resp.Code == 2 {

--- a/drivers/gitee/util.go
+++ b/drivers/gitee/util.go
@@ -40,5 +40,5 @@ func toErr(res *resty.Response) error {
 	if err := utils.Json.Unmarshal(res.Body(), &errMsg); err == nil && errMsg.Message != "" {
 		return fmt.Errorf("%s: %s", res.Status(), errMsg.Message)
 	}
-	return fmt.Errorf(res.Status())
+	return fmt.Errorf("%s", res.Status())
 }

--- a/drivers/google_drive/util.go
+++ b/drivers/google_drive/util.go
@@ -122,7 +122,7 @@ func (d *GoogleDrive) refreshToken() error {
 		}
 		log.Debug(res.String())
 		if e.Error != "" {
-			return fmt.Errorf(e.Error)
+			return fmt.Errorf("%s", e.Error)
 		}
 		d.AccessToken = resp.AccessToken
 		return nil
@@ -144,7 +144,7 @@ func (d *GoogleDrive) refreshToken() error {
 	}
 	log.Debug(res.String())
 	if e.Error != "" {
-		return fmt.Errorf(e.Error)
+		return fmt.Errorf("%s", e.Error)
 	}
 	d.AccessToken = resp.AccessToken
 	return nil

--- a/drivers/google_photo/util.go
+++ b/drivers/google_photo/util.go
@@ -32,7 +32,7 @@ func (d *GooglePhoto) refreshToken() error {
 		return err
 	}
 	if e.Error != "" {
-		return fmt.Errorf(e.Error)
+		return fmt.Errorf("%s", e.Error)
 	}
 	d.AccessToken = resp.AccessToken
 	return nil

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -90,7 +90,7 @@ func (d *LanZou) _post(url string, callback base.ReqCallback, resp interface{}, 
 		if info == "" {
 			info = utils.Json.Get(data, "info").ToString()
 		}
-		return data, fmt.Errorf(info)
+		return data, fmt.Errorf("%s", info)
 	}
 }
 

--- a/internal/offline_download/115/client.go
+++ b/internal/offline_download/115/client.go
@@ -126,7 +126,7 @@ func (p *Cloud115) Status(task *tool.DownloadTask) (*tool.Status, error) {
 			s.Completed = t.IsDone()
 			s.TotalBytes = t.Size
 			if t.IsFailed() {
-				s.Err = fmt.Errorf(t.GetStatus())
+				s.Err = fmt.Errorf("%s", t.GetStatus())
 			}
 			return s, nil
 		}

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -128,7 +128,7 @@ func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 				s.TotalBytes = 0
 			}
 			if t.Phase == "PHASE_TYPE_ERROR" {
-				s.Err = fmt.Errorf(t.Message)
+				s.Err = fmt.Errorf("%s", t.Message)
 			}
 			return s, nil
 		}


### PR DESCRIPTION
Fixes #9526