### PR TITLE
fix(archive): use named struct fields for MultipartExtension literals

### DIFF
--- a/internal/archive/rardecode/rardecode.go
+++ b/internal/archive/rardecode/rardecode.go
@@ -23,7 +23,7 @@ func (RarDecoder) AcceptedExtensions() []string {
 
 func (RarDecoder) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".part1.rar": {".part%d.rar", 2},
+		".part1.rar": {PartFileFormat: ".part%d.rar", SecondPartIndex: 2},
 	}
 }
 

--- a/internal/archive/sevenzip/sevenzip.go
+++ b/internal/archive/sevenzip/sevenzip.go
@@ -18,7 +18,7 @@ func (SevenZip) AcceptedExtensions() []string {
 
 func (SevenZip) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".7z.001": {".7z.%.3d", 2},
+		".7z.001": {PartFileFormat: ".7z.%.3d", SecondPartIndex: 2},
 	}
 }
 

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -20,8 +20,8 @@ func (Zip) AcceptedExtensions() []string {
 
 func (Zip) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".zip":     {".z%.2d", 1},
-		".zip.001": {".zip.%.3d", 2},
+		".zip":     {PartFileFormat: ".z%.2d", SecondPartIndex: 1},
+		".zip.001": {PartFileFormat: ".zip.%.3d", SecondPartIndex: 2},
 	}
 }
 


### PR DESCRIPTION
Fixes #9525