### PR TITLE
fix: safe type assertion for IoBuffPool.Get()

### DIFF
--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -213,7 +213,7 @@ var IoBuffPool = &sync.Pool{
 }
 
 func CopyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
-	buff := IoBuffPool.Get().([]byte)
+	buff, _ := IoBuffPool.Get().([]byte)
 	defer IoBuffPool.Put(buff)
 	written, err = io.CopyBuffer(dst, src, buff)
 	if err != nil {


### PR DESCRIPTION
Fixes #9527