### PR TITLE
feat(settings): add preview_settings for per-extension preview management

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -137,6 +137,7 @@ func InitialSettings() []model.SettingItem {
 		"EPUB.js":"https://alist-org.github.io/static/epub.js/viewer.html?url=$e_url"
 	}
 }`, Type: conf.TypeText, Group: model.PREVIEW},
+		{Key: "preview_settings", Value: `{}`, Type: conf.TypeText, Group: model.PREVIEW},
 		//		{Key: conf.OfficeViewers, Value: `{
 		//	"Microsoft":"https://view.officeapps.live.com/op/view.aspx?src=$url",
 		//	"Google":"https://docs.google.com/gview?url=$url&embedded=true",


### PR DESCRIPTION
## Summary

- Adds a new admin setting `preview_settings` (text/JSON, default `{}`) in the PREVIEW group. This is the per-extension override layer (which preview tabs to show, what order, what's disabled) consumed by the new admin UI in alist-web.
- Ships the spec, implementation plan, and brainstorm record under `docs/superpowers/` so reviewers have the design context.

## Architecture

The setting is orthogonal to the existing `iframe_previews` and `external_previews` — it doesn't replace them and doesn't require any migration. The frontend reads all three and merges them into the visible preview list per file extension.

Format (admin-edited indirectly via the new alist-web GUI):

```json
{
  "pdf":  { "order": ["iframe:PDF.js", "builtin:doubao"], "disabled": ["builtin:doubao"] },
  "docx": { "order": ["iframe:Microsoft"] }
}
```

- IDs: `builtin:<key>` / `iframe:<name>` / `external:<name>`.
- Missing extension key = no override = pure defaults.

## Backup / restore

- Old → new restore: legacy `iframe_previews` / `external_previews` restored; `preview_settings` stays at the bootstrap default `{}` — renderer behaves identically to old.
- New → old restore: old version silently ignores the unknown key; reads `iframe_previews` as before.
- New → new restore: direct roundtrip.

No new migration code in this PR.

## Companion frontend PR

https://github.com/AlistGo/alist-web/pull/306 — the actual admin UI that reads/writes this setting and removes the broken built-in PDF previewer that triggered issue #9542.

## Test plan

- [ ] Boot a clean build; confirm `preview_settings` appears in `/admin/setting/list?group=3` and `/public/settings` with value `{}`.
- [ ] Boot on a pre-existing database; confirm the setting is added with `{}` without disturbing other PREVIEW group entries.
- [ ] Save a non-trivial JSON value via the admin API; confirm it round-trips through `/admin/setting/list` and `/public/settings`.