### PR TITLE
fix(net): synchronize Buf.Close with Write/Read to prevent nil-pointer panic

### DIFF
--- a/internal/net/buf_race_test.go
+++ b/internal/net/buf_race_test.go
@@ -1,0 +1,44 @@
+package net
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestBufCloseWriteRace exercises the race fixed for issue #9537/#9190:
+// Buf.Close() must synchronize with concurrent Buf.Write() calls so that
+// nilling the underlying bytes.Buffer cannot panic an in-flight writer.
+// Run with `go test -race ./internal/net/...` to be meaningful.
+func TestBufCloseWriteRace(t *testing.T) {
+	const iters = 200
+	const writers = 8
+
+	for i := 0; i < iters; i++ {
+		buf := NewBuf(context.Background(), 1024)
+		var wg sync.WaitGroup
+		for w := 0; w < writers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("panic in Write: %v", r)
+					}
+				}()
+				for j := 0; j < 50; j++ {
+					_, _ = buf.Write([]byte("x"))
+				}
+			}()
+		}
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic in Close: %v", r)
+				}
+			}()
+			buf.Close()
+		}()
+		wg.Wait()
+	}
+}

--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -643,6 +643,10 @@ func (br *Buf) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 	br.rw.Lock()
+	if br.buffer == nil {
+		br.rw.Unlock()
+		return 0, io.ErrClosedPipe
+	}
 	n, err = br.buffer.Read(p)
 	br.rw.Unlock()
 	if err == nil {
@@ -672,10 +676,15 @@ func (br *Buf) Write(p []byte) (n int, err error) {
 	}
 	br.rw.Lock()
 	defer br.rw.Unlock()
+	if br.buffer == nil {
+		return 0, io.ErrClosedPipe
+	}
 	n, err = br.buffer.Write(p)
 	return
 }
 
 func (br *Buf) Close() {
+	br.rw.Lock()
+	defer br.rw.Unlock()
 	br.buffer = nil
 }


### PR DESCRIPTION
## Summary
- `internal/net.Buf.Close()` nilled the underlying `bytes.Buffer` without taking the `rw` mutex, racing concurrent `Write()` / `Read()` calls.
- When `downloader.interrupt()` fires (consumer closes mid-download), in-flight chunk goroutines dereferenced the nil buffer and the process SIGSEGV'd, matching the stack reported in #9190 and one crash mode from #9537.
- Fix: `Close()` takes the lock; `Read()` / `Write()` return `io.ErrClosedPipe` after close instead of panicking.
- Adds race-detector regression test `TestBufCloseWriteRace` that panics many times without the fix and is clean with it.

## Scope
Addresses Quark / Quark UC TV / Chaoxing / Vtencent source-side crash paths (these set `Link.Concurrency > 0` and hit the `Buf` codepath). Does **not** cover the 115/Baidu-source cases reported in #9537 — single-connection download path, different codepath; reporter has been asked for a panic stack to continue.

Fixes #9190. Partial fix for #9537.

## Test plan
- [x] `go test -race -run TestBufCloseWriteRace -count=1 ./internal/net/...` passes; without the fix the same test reproduces many `nil pointer dereference` panics + race detector hits.
- [x] Manual: 3-file concurrent cross-storage copy via patched binary completes without crash.