### PR TITLE
fix(mcp): initialize task manager so async fs operations don't panic

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -14,6 +14,7 @@ var MCPCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		Init()
 		bootstrap.LoadStorages()
+		bootstrap.InitTaskManager()
 		username, _ := cmd.Flags().GetString("user")
 		if err := mcpserver.ServeStdio(username); err != nil {
 			utils.Log.Fatalf("MCP STDIO server error: %v", err)


### PR DESCRIPTION
## Summary
- `cmd/mcp.go` (added in v3.60.0) calls `Init()` + `LoadStorages()` but skips `bootstrap.InitTaskManager()`, unlike `cmd/server.go`.
- `fs.CopyTaskManager`, `fs.UploadTaskManager`, `fs.MoveTaskManager` are therefore nil; any MCP `fs_copy` / `fs_move` that crosses storage targets panics at `internal/fs/copy.go` on `CopyTaskManager.Add` with nil pointer dereference, surfaced to the MCP client as:

  ```
  panic recovered in fs_copy tool handler:
  runtime error: invalid memory address or nil pointer dereference
  ```

- Fix: mirror the `cmd/server.go` bootstrap order so the MCP command initializes the task manager too.

## Test plan
- [x] stdio JSON-RPC `fs_copy` against patched MCP binary returns `copied successfully`.
- [x] Same call against unpatched binary reproducibly panics.