### PR TITLE
feat(api): add virtual_path field on fs/list and fs/get responses

### DIFF
--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -35,6 +35,7 @@ type DirReq struct {
 type ObjResp struct {
 	Id           string                     `json:"id"`
 	Path         string                     `json:"path"`
+	VirtualPath  string                     `json:"virtual_path"`
 	Name         string                     `json:"name"`
 	Size         int64                      `json:"size"`
 	IsDir        bool                       `json:"is_dir"`
@@ -65,6 +66,7 @@ type FsListResp struct {
 type ObjLabelResp struct {
 	Id           string                     `json:"id"`
 	Path         string                     `json:"path"`
+	VirtualPath  string                     `json:"virtual_path"`
 	Name         string                     `json:"name"`
 	Size         int64                      `json:"size"`
 	IsDir        bool                       `json:"is_dir"`
@@ -318,6 +320,7 @@ func toObjsResp(objs []model.Obj, parent string, encrypt bool) []ObjLabelResp {
 		resp = append(resp, ObjLabelResp{
 			Id:           obj.GetID(),
 			Path:         obj.GetPath(),
+			VirtualPath:  utils.FixAndCleanPath(stdpath.Join(parent, obj.GetName())),
 			Name:         obj.GetName(),
 			Size:         obj.GetSize(),
 			IsDir:        obj.IsDir(),
@@ -452,6 +455,7 @@ func FsGet(c *gin.Context) {
 		ObjResp: ObjResp{
 			Id:           obj.GetID(),
 			Path:         obj.GetPath(),
+			VirtualPath:  utils.FixAndCleanPath(reqPath),
 			Name:         obj.GetName(),
 			Size:         obj.GetSize(),
 			IsDir:        obj.IsDir(),


### PR DESCRIPTION
## Problem
The existing `path` field on `ObjResp` / `ObjLabelResp` (returned by `/api/fs/list` and `/api/fs/get`) returns whatever the storage driver writes into `model.Object.Path`, and that contract has quietly diverged across drivers:

| Driver | What `obj.Path` contains |
|---|---|
| Local | physical disk path (e.g. `/data/data/com.termux/files/home/storage/download/foo.tar.gz`) |
| Quark / Baidu / 115 / … | empty string |
| A few others | driver-internal id-like path |

Clients that need the canonical **alist virtual path** (for `share`, `fs/copy`, navigation, …) can't rely on `path` alone. The web frontend has been working around this with branchy code such as `pathJoin(getCurrentPath(), name)` in some places and `obj.path` in others; one such inconsistency caused a share regression on Local mounts whose `root_folder_path` differs from the mount path — visible as `failed get storage: storage not found; rawPath: ...` and surfaced as "PC right-click share works, mobile long-press doesn't" (AlistGo/alist-web#307).

## Change
Add a new `virtual_path` field on both response structs, always set to the alist virtual path of the object:

- `toObjsResp` (fs/list)  →  `FixAndCleanPath(stdpath.Join(parent, obj.Name))`
- `FsGet` (fs/get)         →  `FixAndCleanPath(reqPath)`

`path` is left untouched for backwards compatibility — existing clients that happen to use it still work. New / updated clients should prefer `virtual_path` when calling other alist APIs.

## Verification
Against an isolated server with a Local storage where `mount_path=/src` and `root_folder_path=/tmp/alist-test/src`:

```
=== fs/list /src ===
name='file_a.bin'
  path='/tmp/alist-test/src/file_a.bin'           ← unchanged (physical)
  virtual_path='/src/file_a.bin'                  ← new (alist virtual)

=== fs/get /src/file_a.bin ===
name='file_a.bin'
path='/tmp/alist-test/src/file_a.bin'             ← unchanged
virtual_path='/src/file_a.bin'                    ← new
```

## Companion
- AlistGo/alist-web#307 — frontend share fix, currently a workaround that recomputes the virtual path on the client. With this PR landed, the frontend can be updated to just read `virtual_path` everywhere (separate follow-up).

Refs: AlistGo/alist#9537 (one of the reported symptoms).