### PR TITLE
fix(lanzou): handle acw_sc__v2 anti-crawler challenge on all requests

### DIFF
--- a/drivers/lanzou/help.go
+++ b/drivers/lanzou/help.go
@@ -1,7 +1,6 @@
 package lanzou
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -144,11 +143,13 @@ func Unbox(hex string) string {
 }
 
 func HexXor(hex1, hex2 string) string {
-	out := bytes.NewBuffer(make([]byte, len(hex1)))
-	for i := 0; i < len(hex1) && i < len(hex2); i += 2 {
+	var out strings.Builder
+	out.Grow(len(hex1))
+	for i := 0; i+2 <= len(hex1) && i+2 <= len(hex2); i += 2 {
 		v1, _ := strconv.ParseInt(hex1[i:i+2], 16, 64)
 		v2, _ := strconv.ParseInt(hex2[i:i+2], 16, 64)
-		out.WriteString(strconv.FormatInt(v1^v2, 16))
+		// 必须补足前导 0,否则异或结果 < 0x10 时只输出一个字符,导致整个 hex 串错位
+		fmt.Fprintf(&out, "%02x", v1^v2)
 	}
 	return out.String()
 }

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -95,35 +95,55 @@ func (d *LanZou) _post(url string, callback base.ReqCallback, resp interface{}, 
 }
 
 func (d *LanZou) request(url string, method string, callback base.ReqCallback, up bool) ([]byte, error) {
-	var req *resty.Request
+	var client *resty.Client
 	if up {
 		once.Do(func() {
 			upClient = base.NewRestyClient().SetTimeout(120 * time.Second)
 		})
-		req = upClient.R()
+		client = upClient
 	} else {
-		req = base.RestyClient.R()
+		client = base.RestyClient
 	}
 
-	req.SetHeaders(map[string]string{
-		"Referer":    "https://pc.woozooo.com",
-		"User-Agent": d.UserAgent,
-	})
+	// acw_sc__v2 反爬挑战可能出现在任意页面/接口(分享页、iframe 页、ajaxm.php 等)。
+	// 挑战页内嵌 arg1,需据此算出 cookie 后用同一请求重试,故在最底层统一处理。
+	var acwScV2 string
+	var body []byte
+	for i := 0; i < 3; i++ {
+		req := client.R()
+		req.SetHeaders(map[string]string{
+			"Referer":    "https://pc.woozooo.com",
+			"User-Agent": d.UserAgent,
+		})
+		if d.Cookie != "" {
+			req.SetHeader("cookie", d.Cookie)
+		}
+		if acwScV2 != "" {
+			req.SetCookie(&http.Cookie{Name: "acw_sc__v2", Value: acwScV2})
+		}
+		if callback != nil {
+			callback(req)
+		}
 
-	if d.Cookie != "" {
-		req.SetHeader("cookie", d.Cookie)
-	}
+		res, err := req.Execute(method, url)
+		if err != nil {
+			return nil, err
+		}
+		body = res.Body()
+		log.Debugf("lanzou request: url=>%s ,stats=>%d ,body => %s\n", res.Request.URL, res.StatusCode(), res.String())
 
-	if callback != nil {
-		callback(req)
+		if findAcwScV2Reg.Match(body) {
+			vs, e := CalcAcwScV2(string(body))
+			if e != nil {
+				log.Errorf("lanzou: err => acw_sc__v2 validation error  ,data => %s\n", body)
+				return body, e
+			}
+			acwScV2 = vs
+			continue
+		}
+		return body, nil
 	}
-
-	res, err := req.Execute(method, url)
-	if err != nil {
-		return nil, err
-	}
-	log.Debugf("lanzou request: url=>%s ,stats=>%d ,body => %s\n", res.Request.URL, res.StatusCode(), res.String())
-	return res.Body(), err
+	return body, errors.New("acw_sc__v2 validation error")
 }
 
 func (d *LanZou) Login() ([]*http.Cookie, error) {
@@ -267,42 +287,28 @@ var findDownPageParamReg = regexp.MustCompile(`<iframe.*?src="(.+?)"`)
 // 获取文件ID
 var findFileIDReg = regexp.MustCompile(`'/ajaxm\.php\?file=(\d+)'`)
 
+// GET 页面并去除注释(acw_sc__v2 反爬挑战已在 request 层统一处理)
+func (d *LanZou) getHtml(url string, callback base.ReqCallback) (string, error) {
+	data, err := d.get(url, callback)
+	if err != nil {
+		return "", err
+	}
+	return RemoveNotes(string(data)), nil
+}
+
 // 获取分享链接主界面
 func (d *LanZou) getShareUrlHtml(shareID string) (string, error) {
-	var vs string
-	for i := 0; i < 3; i++ {
-		firstPageData, err := d.get(fmt.Sprint(d.ShareUrl, "/", shareID),
-			func(req *resty.Request) {
-				if vs != "" {
-					req.SetCookie(&http.Cookie{
-						Name:  "acw_sc__v2",
-						Value: vs,
-					})
-				}
-			})
-		if err != nil {
-			return "", err
-		}
-
-		firstPageDataStr := RemoveNotes(string(firstPageData))
-		if strings.Contains(firstPageDataStr, "取消分享") {
-			return "", ErrFileShareCancel
-		}
-		if strings.Contains(firstPageDataStr, "文件不存在") {
-			return "", ErrFileNotExist
-		}
-
-		// acw_sc__v2
-		if strings.Contains(firstPageDataStr, "acw_sc__v2") {
-			if vs, err = CalcAcwScV2(firstPageDataStr); err != nil {
-				log.Errorf("lanzou: err => acw_sc__v2 validation error  ,data => %s\n", firstPageDataStr)
-				return "", err
-			}
-			continue
-		}
-		return firstPageDataStr, nil
+	htmlStr, err := d.getHtml(fmt.Sprint(d.ShareUrl, "/", shareID), nil)
+	if err != nil {
+		return "", err
 	}
-	return "", errors.New("acw_sc__v2 validation error")
+	if strings.Contains(htmlStr, "取消分享") {
+		return "", ErrFileShareCancel
+	}
+	if strings.Contains(htmlStr, "文件不存在") {
+		return "", ErrFileNotExist
+	}
+	return htmlStr, nil
 }
 
 // 通过分享链接获取文件或文件夹
@@ -386,11 +392,10 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 			log.Errorf("lanzou: err => not find file page param ,data => %s\n", sharePageData)
 			return nil, fmt.Errorf("not find file page param")
 		}
-		data, err := d.get(fmt.Sprint(d.ShareUrl, urlpaths[1]), nil)
+		nextPageData, err := d.getHtml(fmt.Sprint(d.ShareUrl, urlpaths[1]), nil)
 		if err != nil {
 			return nil, err
 		}
-		nextPageData := RemoveNotes(string(data))
 		param, err = htmlJsonToMap(nextPageData)
 		if err != nil {
 			return nil, err
@@ -542,8 +547,8 @@ func (d *LanZou) getFileRealInfo(downURL string) (*int64, *time.Time) {
 }
 
 func (d *LanZou) getVeiAndUid() (vei string, uid string, err error) {
-	var resp []byte
-	resp, err = d.get("https://pc.woozooo.com/mydisk.php", func(req *resty.Request) {
+	// mydisk.php 同样可能返回 acw_sc__v2 反爬挑战页,需经 getHtml 处理后再解析
+	html, err := d.getHtml("https://pc.woozooo.com/mydisk.php", func(req *resty.Request) {
 		req.SetQueryParams(map[string]string{
 			"item":   "files",
 			"action": "index",
@@ -553,7 +558,7 @@ func (d *LanZou) getVeiAndUid() (vei string, uid string, err error) {
 		return
 	}
 	// uid
-	uids := regexp.MustCompile(`uid=([^'"&;]+)`).FindStringSubmatch(string(resp))
+	uids := regexp.MustCompile(`uid=([^'"&;]+)`).FindStringSubmatch(html)
 	if len(uids) < 2 {
 		err = fmt.Errorf("uid variable not find")
 		return
@@ -561,7 +566,6 @@ func (d *LanZou) getVeiAndUid() (vei string, uid string, err error) {
 	uid = uids[1]
 
 	// vei
-	html := RemoveNotes(string(resp))
 	data, err := htmlJsonToMap(html)
 	if err != nil {
 		return


### PR DESCRIPTION
## 问题

蓝奏云(账号密码登录)能列文件，但获取下载地址间歇性失败，报错形式不一：

- `failed get link: acw_sc__v2 validation error`
- `failed get link: not find data`
- `failed get link:`（message 为空）
- 初始化时 `Failed init storage: uid variable not find`

## 根因

蓝奏云的 `acw_sc__v2` 反爬挑战会出现在**任意** `pan.lanzoui.com` 请求上（分享页、iframe 下载页、`ajaxm.php`），以及初始化时的 `pc.woozooo.com/mydisk.php`。但原代码只对第一个分享页做了挑战处理，导致：

- `mydisk.php` 返回挑战页 → 找不到 `uid=` → `uid variable not find`
- iframe 下载页返回挑战页 → 解析不到 JSON → `not find data`
- `ajaxm.php` 的 POST 返回挑战页 → 被当成 JSON 解析，`zt=0` 走 default 分支且 `info` 为空 → 空错误

此外 `HexXor` 自驱动引入起就是坏的，使得挑战根本无法被正确求解：

1. `bytes.NewBuffer(make([]byte, len(hex1)))` 用的是**长度**而非容量，结果被 `len(hex1)` 个 `\x00` 前缀污染；
2. 缺少前导 0 补齐，异或结果 `< 0x10` 时只输出一个十六进制字符，导致整串错位/长度不足。

## 改动

- 修复 `HexXor`：改用 `strings.Builder` + `%02x` 补零，并修正循环边界。
- 将 acw_sc__v2 的「检测挑战 → 计算 cookie → 带 cookie 重试同一请求」逻辑下沉到最底层的 `request()`，所有 GET/POST 透明解挑战（最多 3 次）。
- 相应简化 `getHtml`，`getVeiAndUid` / `getShareUrlHtml` / iframe 页统一走该链路。

## 验证

用真实账号密码联调（账号密码登录）：

- 修复前：列根目录 5 个文件，逐个取下载地址 3 轮 → **全部失败**（`ajaxm.php` POST 被挑战，空错误）。
- 修复后：相同文件 3 文件 × 3 轮 → **全部成功**返回真实直链（`webgetstore.com` / `lanosso.com`）；`mydisk.php` 的 uid/vei 正常获取。

仅改动 `drivers/lanzou/help.go` 与 `drivers/lanzou/util.go`，`go build ./drivers/lanzou/` 通过。