### PR TITLE
ci: replace blocked issues-helper action and fix release event race

### DIFF
--- a/.github/workflows/issue_close_question.yml
+++ b/.github/workflows/issue_close_question.yml
@@ -5,18 +5,42 @@ on:
     - cron: "0 0 */1 * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   close-need-info:
     runs-on: ubuntu-latest
     steps:
-      - name: close-issues
-        uses: actions-cool/issues-helper@v3
+      - name: Close inactive question issues
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'question'
-          inactive-day: 3
-          close-reason: 'not_planned'
-          body: |
-            Hello @${{ github.event.issue.user.login }}, this issue was closed due to no activities in 3 days.
-            你好 @${{ github.event.issue.user.login }}，此issue因超过3天未回复被关闭。
+          script: |
+            const label = 'question';
+            const inactiveDays = 3;
+            const cutoff = Date.now() - inactiveDays * 24 * 60 * 60 * 1000;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (new Date(issue.updated_at).getTime() > cutoff) continue;
+              const user = issue.user.login;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Hello @${user}, this issue was closed due to no activities in 3 days.\n你好 @${user}，此issue因超过3天未回复被关闭。`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }

--- a/.github/workflows/issue_close_stale.yml
+++ b/.github/workflows/issue_close_stale.yml
@@ -5,17 +5,42 @@ on:
     - cron: "0 0 */7 * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   close-inactive:
     runs-on: ubuntu-latest
     steps:
-      - name: close-issues
-        uses: actions-cool/issues-helper@v3
+      - name: Close inactive stale issues
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'stale'
-          inactive-day: 8
-          close-reason: 'not_planned'
-          body: |
-            Hello @${{ github.event.issue.user.login }}, this issue was closed due to inactive more than 52 days. You can reopen or recreate it if you think it should continue. Thank you for your contributions again.
+          script: |
+            const label = 'stale';
+            const inactiveDays = 8;
+            const cutoff = Date.now() - inactiveDays * 24 * 60 * 60 * 1000;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (new Date(issue.updated_at).getTime() > cutoff) continue;
+              const user = issue.user.login;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Hello @${user}, this issue was closed due to inactive more than 52 days. You can reopen or recreate it if you think it should continue. Thank you for your contributions again.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }

--- a/.github/workflows/issue_duplicate.yml
+++ b/.github/workflows/issue_duplicate.yml
@@ -4,22 +4,29 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   create-comment:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'duplicate'
     steps:
-      - name: Create comment
-        uses: actions-cool/issues-helper@v3
+      - name: Comment and close
+        uses: actions/github-script@v7
         with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}, your issue is a duplicate and will be closed.
-            你好 @${{ github.event.issue.user.login }}，你的issue是重复的，将被关闭。
-      - name: Close issue
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const user = context.payload.issue.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Hello @${user}, your issue is a duplicate and will be closed.\n你好 @${user}，你的issue是重复的，将被关闭。`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/issue_invalid.yml
+++ b/.github/workflows/issue_invalid.yml
@@ -4,22 +4,29 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   create-comment:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'invalid'
     steps:
-      - name: Create comment
-        uses: actions-cool/issues-helper@v3
+      - name: Comment and close
+        uses: actions/github-script@v7
         with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}, your issue is invalid and will be closed.
-            你好 @${{ github.event.issue.user.login }}，你的issue无效，将被关闭。
-      - name: Close issue
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const user = context.payload.issue.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Hello @${user}, your issue is invalid and will be closed.\n你好 @${user}，你的issue无效，将被关闭。`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/issue_on_close.yml
+++ b/.github/workflows/issue_on_close.yml
@@ -4,14 +4,28 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  issues: write
+
 jobs:
   rm-working:
     runs-on: ubuntu-latest
     steps:
       - name: Remove working label
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'working,pr-welcome'
+          script: |
+            const labels = ['working', 'pr-welcome'];
+            for (const name of labels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+              } catch (e) {
+                // 404 means the label was not present on the issue; ignore it.
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/.github/workflows/issue_question.yml
+++ b/.github/workflows/issue_question.yml
@@ -4,17 +4,22 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   create-comment:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'question'
     steps:
       - name: Create comment
-        uses: actions-cool/issues-helper@v3.6.0
+        uses: actions/github-script@v7
         with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}, please input issue by template and add detail. Issues labeled by `question` will be closed if no activities in 3 days.
-            你好 @${{ github.event.issue.user.login }}，请按照issue模板填写, 并详细说明问题/日志记录/复现步骤/复现链接/实现思路或提供更多信息等, 3天内未回复issue自动关闭。
+          script: |
+            const user = context.payload.issue.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Hello @${user}, please input issue by template and add detail. Issues labeled by \`question\` will be closed if no activities in 3 days.\n你好 @${user}，请按照issue模板填写, 并详细说明问题/日志记录/复现步骤/复现链接/实现思路或提供更多信息等, 3天内未回复issue自动关闭。`,
+            });

--- a/.github/workflows/issue_wontfix.yml
+++ b/.github/workflows/issue_wontfix.yml
@@ -4,22 +4,29 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   lock-issue:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'wontfix'
     steps:
-      - name: Create comment
-        uses: actions-cool/issues-helper@v3
+      - name: Comment and close
+        uses: actions/github-script@v7
         with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}, this issue will not be worked on and will be closed.
-            你好 @${{ github.event.issue.user.login }}，这不会被处理，将被关闭。
-      - name: Close issue
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const user = context.payload.issue.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Hello @${user}, this issue will not be worked on and will be closed.\n你好 @${user}，这不会被处理，将被关闭。`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ published ]
 
+# Re-publishing the same tag recreates the release (new id), which would leave
+# any in-flight run pointing at a deleted release id and fail with 404. Cancel
+# the stale run so only the newest publish for a given tag proceeds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   release:
     strategy:

--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ published ]
 
+# Re-publishing the same tag recreates the release (new id), which would leave
+# any in-flight run pointing at a deleted release id and fail with 404. Cancel
+# the stale run so only the newest publish for a given tag proceeds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   release_android:
     strategy:

--- a/.github/workflows/release_freebsd.yml
+++ b/.github/workflows/release_freebsd.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ published ]
 
+# Re-publishing the same tag recreates the release (new id), which would leave
+# any in-flight run pointing at a deleted release id and fail with 404. Cancel
+# the stale run so only the newest publish for a given tag proceeds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   release_freebsd:
     strategy:

--- a/.github/workflows/release_linux_musl.yml
+++ b/.github/workflows/release_linux_musl.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ published ]
 
+# Re-publishing the same tag recreates the release (new id), which would leave
+# any in-flight run pointing at a deleted release id and fail with 404. Cancel
+# the stale run so only the newest publish for a given tag proceeds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   release_linux_musl:
     strategy:

--- a/.github/workflows/release_linux_musl_arm.yml
+++ b/.github/workflows/release_linux_musl_arm.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ published ]
 
+# Re-publishing the same tag recreates the release (new id), which would leave
+# any in-flight run pointing at a deleted release id and fail with 404. Cancel
+# the stale run so only the newest publish for a given tag proceeds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   release_linux_musl_arm:
     strategy:


### PR DESCRIPTION
## 背景 / Why

仓库里多个 GitHub Actions 报错,定位到两类根因:

### 1. Issue 自动化 —— 依赖的 action 被 GitHub 封禁

所有 issue 相关 workflow 都依赖 `actions-cool/issues-helper`。该仓库已于 **2026-05-19 因违反服务条款(ToS)被 GitHub 封禁**:

```json
{"message":"Repository access blocked","block":{"reason":"tos","created_at":"2026-05-19T00:33:29Z"}}
```

因此这些 workflow 一律在 `Getting action download info` 阶段失败:`##[error]Repository access blocked`。受影响 7 个文件。

### 2. Release 系列 —— 重复发布同一 tag 导致 404 竞态

`v3.61.0` 发版时观察到:失败的 `release.yml` 引用 release id `332851420`,而成功的 freebsd job 引用 `332851481` —— **同一 tag 被发布了两次,旧 release 被删/重建**。旧那批 job 仍指向已删除的 release id,于是:

- `release.yml` 的 `irongut/EditRelease` 步骤 → `Octokit.NotFoundException - Not Found`
- `release_freebsd.yml` 的 `softprops/action-gh-release` → `Not Found - update-a-release-asset`

## 改动 / What

**Issue workflows** —— 全部改用官方 `actions/github-script@v7` 内联实现,去掉被封依赖:

| 文件 | 行为 |
|------|------|
| `issue_on_close.yml` | 移除 `working`/`pr-welcome` 标签(忽略 404) |
| `issue_duplicate.yml` / `issue_invalid.yml` / `issue_wontfix.yml` | 评论 + 关闭 |
| `issue_question.yml` | 仅评论 |
| `issue_close_stale.yml` / `issue_close_question.yml` | 分页拉取带标签的 open issue,关闭超过不活跃阈值的 |

- 定时任务里的评论现在 @ 真实 issue 作者(旧代码在 schedule 上下文里 `github.event.issue` 为 undefined,会变成空的 `@`)。
- 每个 workflow 都加了最小权限 `permissions: issues: write`。

**Release workflows** —— 5 个文件加按 tag 命名的并发组,重新发布同一 tag 时取消引用旧 release id 的过期运行:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
  cancel-in-progress: true
```

不同平台 `github.workflow` 不同,仍各自并行,不影响发版完整性。

## 说明 / Note

> [!NOTE]
> 若在**单次干净发布**下 `EditRelease` 仍报 404,则需另查 `MY_TOKEN` secret 是否过期/权限不足 —— 那是密钥轮换问题,无法在代码层修复。本 PR 处理的是观测到的重复发布竞态。

YAML 已全部本地校验通过。