### PR TITLE
fix(guangyapan): rate-limit API requests to avoid flooding on batch copy

### DIFF
--- a/drivers/guangyapan/driver.go
+++ b/drivers/guangyapan/driver.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -19,6 +20,7 @@ import (
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -36,7 +38,14 @@ type GuangYaPan struct {
 
 	resolvedRootFolderID string
 	rootFolderResolved   bool
+
+	// apiRateLimit throttles requests per API endpoint so that batch operations
+	// (e.g. copying many files cross-storage) don't flood the upstream API.
+	apiRateLimit sync.Map
 }
+
+// apiRateInterval is the minimum gap between two requests to the same endpoint.
+const apiRateInterval = 500 * time.Millisecond
 
 func (d *GuangYaPan) Config() driver.Config {
 	return config
@@ -793,9 +802,17 @@ func (d *GuangYaPan) accountErr(desc, short string, resp *resty.Response) string
 	return msg
 }
 
+func (d *GuangYaPan) apiRateLimitWait(ctx context.Context, path string) error {
+	value, _ := d.apiRateLimit.LoadOrStore(path, rate.NewLimiter(rate.Every(apiRateInterval), 1))
+	return value.(*rate.Limiter).Wait(ctx)
+}
+
 func (d *GuangYaPan) postAPI(ctx context.Context, path string, body any, out any) error {
 	if strings.TrimSpace(d.AccessToken) == "" {
 		return errors.New("access token is empty")
+	}
+	if err := d.apiRateLimitWait(ctx, path); err != nil {
+		return err
 	}
 	resp, err := d.apiClient.R().
 		SetContext(ctx).


### PR DESCRIPTION
## 问题
光鸭（GuangYaPan）驱动所有 API 请求都经过 `postAPI`，但没有任何限流。跨盘复制多个文件时，每个复制任务都会并发调用光鸭接口（`Link`/`get_res_download_url`、`copy_file`、`get_file_list` 等），瞬间打满上游接口、被风控。其它国产网盘驱动（如 `123`、`aliyundrive_open`）都自带限流，光鸭没有，所以表现为「复制多个文件到其他网盘时任务数/请求不受控」。

## 修改
在 `postAPI` 入口加一个 **per-endpoint** 的 `rate.Limiter`（每个接口路径 500ms 一次，burst 1），参照 `123` 驱动的 `APIRateLimit` 模式。这样并发的复制任务会被按节奏排队，而不是同时打满光鸭接口；不同接口（列目录 / 取链接 / 复制）各自独立限流，互不影响。

- 新增 `GuangYaPan.apiRateLimit sync.Map` 与常量 `apiRateInterval = 500ms`
- 新增 `apiRateLimitWait(ctx, path)`，在 `postAPI` 发请求前调用

## 影响
- 所有走 `postAPI` 的操作（List/Link/Copy/Move 等）都会被限流，行为与其它「正常」网盘一致。
- 取舍：超大文件夹的分页列表会略微变慢（每页间隔 500ms），与 `123` 驱动相同。

## 测试
`go build ./drivers/guangyapan/` 通过。