### PR TITLE
fix(115): restore Cookie on download link so proxied downloads work (#9452)

### DIFF
--- a/drivers/115/driver.go
+++ b/drivers/115/driver.go
@@ -2,6 +2,7 @@ package _115
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -77,6 +78,16 @@ func (d *Pan115) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	link := &model.Link{
 		URL:    downloadInfo.Url.Url,
 		Header: downloadInfo.Header,
+	}
+	// The 115 CDN requires the account Cookie on the download request, but the
+	// SDK sends cookies at the transport layer so they are absent from
+	// downloadInfo.Header. Without it, proxied downloads fail with
+	// 403 "no cookie value". Restore the Cookie so proxy mode works.
+	if link.Header == nil {
+		link.Header = http.Header{}
+	}
+	if link.Header.Get("Cookie") == "" {
+		link.Header.Set("Cookie", d.Cookie)
 	}
 	return link, nil
 }


### PR DESCRIPTION
Fixes #9452

## 现象
群晖 Cloud Sync 经 WebDAV 下载 115 文件失败；115 CDN（`cdnfhnfile.115cdn.net`）返回 `403 {"message":"no cookie value"}`。3.57.0 正常，3.58.0+ 复现（回归）。

## 根因
3.58.0 的 115 驱动/SDK 重构后，`Link` 直接用 SDK 的 `downloadInfo.Header` 作为 `model.Link.Header`，而该 Header 取自 resty 的请求头 map（`download.go` 里 `info.Header = resp.Request.Header`）。115 账号 Cookie 是 resty 在**传输层**注入的，**不在**这个 Header map 里，于是 `link.Header` 丢了 `Cookie`。

115 CDN 要求带 Cookie，所以 AList **代理**下载时用 `link.Header` 拼上游请求会得到 `403 no cookie value`；这正是 issue 中「本地代理模式 AList 后台报 403」的来源。3.57.0 的驱动在本地 `DownloadWithUA` 里**显式** `req.Header.Set("Cookie", d.Cookie)`，所以没有这个问题。

## 修复
在 `Link` 返回前，若 `link.Header` 缺少 `Cookie`，用账号 `d.Cookie` 补上（幂等、不覆盖 SDK 已有值）。这样代理下载会带上 Cookie + 原有 UA，不再 403。

## 说明（群晖等 WebDAV 客户端）
115 下载链接绑定 Cookie（还绑 UA/IP），**302 重定向无法把 Cookie 传给客户端**，因此 115 经 WebDAV 下载需使用**代理模式**（存储/WebDAV 设为本地代理）。本 PR 修复的正是代理模式此前也失效的问题；302 直链对 115 本质上不可行。未强制 `OnlyProxy`，以免增加服务器带宽负担。

## 测试
`go build ./drivers/115/` 与 `go vet ./drivers/115/` 通过。