### PR TITLE
feat(fs): support skipping existing files in copy tasks

### DIFF
--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -170,5 +170,6 @@ const (
 
 // ContextKey is the type of context keys.
 const (
-	NoTaskKey = "no_task"
+	NoTaskKey       = "no_task"
+	SkipExistingKey = "skip_existing"
 )

--- a/internal/fs/copy.go
+++ b/internal/fs/copy.go
@@ -28,6 +28,7 @@ type CopyTask struct {
 	dstStorage   driver.Driver `json:"-"`
 	SrcStorageMp string        `json:"src_storage_mp"`
 	DstStorageMp string        `json:"dst_storage_mp"`
+	SkipExisting bool          `json:"skip_existing"`
 }
 
 func (t *CopyTask) GetName() string {
@@ -69,8 +70,18 @@ func _copy(ctx context.Context, srcObjPath, dstDirPath string, lazyCache ...bool
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed get dst storage")
 	}
+	skipExisting := ctx.Value(conf.SkipExistingKey) != nil
 	// copy if in the same storage, just call driver.Copy
 	if srcStorage.GetStorage() == dstStorage.GetStorage() {
+		if skipExisting {
+			if srcObj, err := op.Get(ctx, srcStorage, srcObjActualPath); err == nil && !srcObj.IsDir() {
+				dstFilePath := stdpath.Join(dstDirActualPath, srcObj.GetName())
+				if dstFile, err := op.Get(ctx, dstStorage, dstFilePath); err == nil &&
+					!dstFile.IsDir() && dstFile.GetSize() == srcObj.GetSize() {
+					return nil, nil
+				}
+			}
+		}
 		err = op.Copy(ctx, srcStorage, srcObjActualPath, dstDirActualPath, lazyCache...)
 		if !errors.Is(err, errs.NotImplement) && !errors.Is(err, errs.NotSupport) {
 			return nil, err
@@ -113,6 +124,7 @@ func _copy(ctx context.Context, srcObjPath, dstDirPath string, lazyCache ...bool
 		DstDirPath:   dstDirActualPath,
 		SrcStorageMp: srcStorage.GetStorage().MountPath,
 		DstStorageMp: dstStorage.GetStorage().MountPath,
+		SkipExisting: skipExisting,
 	}
 	CopyTaskManager.Add(t)
 	return t, nil
@@ -146,6 +158,7 @@ func copyBetween2Storages(t *CopyTask, srcStorage, dstStorage driver.Driver, src
 				DstDirPath:   dstObjPath,
 				SrcStorageMp: srcStorage.GetStorage().MountPath,
 				DstStorageMp: dstStorage.GetStorage().MountPath,
+				SkipExisting: t.SkipExisting,
 			})
 		}
 		t.Status = "src object is dir, added all copy tasks of objs"
@@ -160,6 +173,16 @@ func copyFileBetween2Storages(tsk *CopyTask, srcStorage, dstStorage driver.Drive
 		return errors.WithMessagef(err, "failed get src [%s] file", srcFilePath)
 	}
 	tsk.SetTotalBytes(srcFile.GetSize())
+	if tsk.SkipExisting {
+		dstFilePath := stdpath.Join(dstDirPath, srcFile.GetName())
+		// a failed probe falls through to a normal copy, worst case is a redundant transfer
+		if dstFile, err := op.Get(tsk.Ctx(), dstStorage, dstFilePath); err == nil &&
+			!dstFile.IsDir() && dstFile.GetSize() == srcFile.GetSize() {
+			tsk.Status = "skipped: destination file already exists"
+			tsk.SetProgress(100)
+			return nil
+		}
+	}
 	link, _, err := op.Link(tsk.Ctx(), srcStorage, srcFilePath, model.LinkArgs{
 		Header: http.Header{},
 	})

--- a/server/handles/fsmanage.go
+++ b/server/handles/fsmanage.go
@@ -1,12 +1,14 @@
 package handles
 
 import (
+	"context"
 	"fmt"
 	"io"
 	stdpath "path"
 
 	"github.com/alist-org/alist/v3/internal/task"
 
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -66,6 +68,9 @@ type MoveCopyReq struct {
 	DstDir    string   `json:"dst_dir"`
 	Names     []string `json:"names"`
 	Overwrite bool     `json:"overwrite"`
+	// SkipExisting only takes effect on copy: existing destination files
+	// with the same size are skipped instead of failing the request
+	SkipExisting bool `json:"skip_existing"`
 }
 
 func FsMove(c *gin.Context) {
@@ -169,7 +174,7 @@ func FsCopy(c *gin.Context) {
 		common.ErrorResp(c, errs.PermissionDenied, 403)
 		return
 	}
-	if !req.Overwrite {
+	if !req.Overwrite && !req.SkipExisting {
 		for _, name := range req.Names {
 			dstPath, err := utils.JoinUnderBase(dstDir, name)
 			if err != nil {
@@ -181,6 +186,10 @@ func FsCopy(c *gin.Context) {
 				return
 			}
 		}
+	}
+	var ctx context.Context = c
+	if req.SkipExisting {
+		ctx = context.WithValue(ctx, conf.SkipExistingKey, struct{}{})
 	}
 	var addedTasks []task.TaskExtensionInfo
 	for i, name := range req.Names {
@@ -194,7 +203,7 @@ func FsCopy(c *gin.Context) {
 			common.ErrorResp(c, err, 400)
 			return
 		}
-		t, err := fs.Copy(c, srcPath, dstDir, len(req.Names) > i+1)
+		t, err := fs.Copy(ctx, srcPath, dstDir, len(req.Names) > i+1)
 		if t != nil {
 			addedTasks = append(addedTasks, t)
 		}


### PR DESCRIPTION
Closes #9555

## 问题

跨网盘复制（如 pikpak → 115）任务因关机/网络问题中断后，重新发起复制时 `/api/fs/copy` 只有 `overwrite` 一个选项：不勾选则因目标已存在同名直接报错，勾选则所有文件全量重传，已完成的部分被浪费。

## 方案

为 `POST /api/fs/copy` 新增 `skip_existing` 参数：

- 目标存在**同名且同大小**的文件 → 跳过传输，任务直接标记成功（状态显示 `skipped: destination file already exists`）；
- 同名但大小不一致（上次中断留下的残缺文件）→ 重新复制覆盖；
- 不传该参数时行为与现状完全一致。

不依赖 MD5/哈希校验——各网盘驱动哈希算法不一致或缺失，跨盘场景大多不可用；同名同大小判定可同时覆盖断点续传与残缺文件重传两个诉求。

## 实现

- `MoveCopyReq` 增加 `skip_existing` 字段，`FsCopy` 在该参数开启时放行已存在的目标；
- 标志通过 context key（仿照 `conf.NoTaskKey` 模式）传入 `fs.Copy`，签名不变，既有调用点零改动；
- `CopyTask.SkipExisting` 带 json tag 持久化，进程重启恢复任务后标志不丢，目录递归生成子任务时逐层传递；
- `copyFileBetween2Storages` 在请求源文件下载链接前探测目标，命中同名同大小即跳过；探测失败（网络等原因）退化为照常复制，最坏多传一次，不会使任务失败；
- 同存储复制的快速路径对文件做相同跳过判断。

## 测试

本地两个 Local 存储间实测：

1. 不带 `skip_existing`、`overwrite=false` 复制已存在目录 → `403 file [dir] exists`（回归，行为不变）；
2. 带 `skip_existing=true` 复制目录（目标预置同大小文件、半截文件、缺失文件）→ 同大小文件跳过且内容未被覆盖，半截文件重传为完整内容，缺失文件正常复制；
3. 同请求重复执行 → 全部跳过，零传输（幂等）；
4. 同存储复制两次 → 第二次直接成功，目标文件 mtime 不变。

配套前端 PR：[AlistGo/alist-web](https://github.com/AlistGo/alist-web/pull/309)（复制对话框新增「跳过已存在文件」选项）。