### PR TITLE
fix(weiyun): bump weiyun-sdk-go to v0.1.4 to fix nil pointer panic on mount

### DIFF
--- a/drivers/weiyun/driver.go
+++ b/drivers/weiyun/driver.go
@@ -67,7 +67,7 @@ func (d *WeiYun) Init(ctx context.Context) error {
 	})
 
 	// qqCookie保活
-	if d.client.LoginType() == 1 {
+	if d.client.LoginType() == weiyunsdkgo.AccountTypeQQ {
 		d.cron = cron.NewCron(time.Minute * 5)
 		d.cron.Do(func() {
 			_ = d.client.KeepAlive()

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/dustinxie/ecc v0.0.0-20210511000915-959544187564
 	github.com/fatedier/frp v0.68.0
 	github.com/foxxorcat/mopan-sdk-go v0.1.6
-	github.com/foxxorcat/weiyun-sdk-go v0.1.3
+	github.com/foxxorcat/weiyun-sdk-go v0.1.4
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-resty/resty/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/foxxorcat/mopan-sdk-go v0.1.6 h1:6J37oI4wMZLj8EPgSCcSTTIbnI5D6RCNW/sr
 github.com/foxxorcat/mopan-sdk-go v0.1.6/go.mod h1:UaY6D88yBXWGrcu/PcyLWyL4lzrk5pSxSABPHftOvxs=
 github.com/foxxorcat/weiyun-sdk-go v0.1.3 h1:I5c5nfGErhq9DBumyjCVCggRA74jhgriMqRRFu5jeeY=
 github.com/foxxorcat/weiyun-sdk-go v0.1.3/go.mod h1:TPxzN0d2PahweUEHlOBWlwZSA+rELSUlGYMWgXRn9ps=
+github.com/foxxorcat/weiyun-sdk-go v0.1.4 h1:X2tFvdqikkJ7awCBbMH7XXk7+uQoJlQksJz9CUU6ZgA=
+github.com/foxxorcat/weiyun-sdk-go v0.1.4/go.mod h1:TPxzN0d2PahweUEHlOBWlwZSA+rELSUlGYMWgXRn9ps=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
### 问题 / Problem
挂载腾讯微云（weiyun）存储时，`Init` 阶段触发 nil pointer panic，导致存储无法初始化。崩溃源自上游 SDK `github.com/foxxorcat/weiyun-sdk-go@v0.1.3` 的 `Resp.HasError()`，它在 `r.Data` 为 nil 时直接解引用 `r.Data.RspHeader`（types.go:38）。

When mounting Tencent Weiyun storage, a nil pointer panic occurs during `Init`. The panic originates from the upstream SDK v0.1.3 `Resp.HasError()` dereferencing `r.Data` without a nil check.

### 改动 / Change
- 将 `weiyun-sdk-go` 从 v0.1.3 升级到 v0.1.4（上游已修复 nil 解引用：`r.Data != nil && ...`）。
- v0.1.4 把 `LoginType()` 的返回类型从 `int8` 改成了 string 枚举，相应地把 QQ cookie 保活的判断改为 `weiyunsdkgo.AccountTypeQQ`。

### 验证 / Verification
`go build ./...` 与 `go vet ./drivers/weiyun/` 通过。

Fixes #9551
