### PR TITLE
fix(139): honor use_large_thumbnail for family/personal/group clouds

### DIFF
--- a/drivers/139/types.go
+++ b/drivers/139/types.go
@@ -58,8 +58,8 @@ type Content struct {
 	CreateTime string `json:"createTime"`
 	UpdateTime string `json:"updateTime"`
 	//CommentCount    int         `json:"commentCount"`
-	ThumbnailURL string `json:"thumbnailURL"`
-	//BigthumbnailURL string      `json:"bigthumbnailURL"`
+	ThumbnailURL    string `json:"thumbnailURL"`
+	BigthumbnailURL string `json:"bigthumbnailURL"`
 	//PresentURL      string      `json:"presentURL"`
 	//PresentLURL     string      `json:"presentLURL"`
 	//PresentHURL     string      `json:"presentHURL"`
@@ -162,10 +162,10 @@ type CloudContent struct {
 	//ContentDesc      string      `json:"contentDesc"`
 	CreateTime string `json:"createTime"`
 	//Shottime         interface{} `json:"shottime"`
-	LastUpdateTime string `json:"lastUpdateTime"`
-	ThumbnailURL   string `json:"thumbnailURL"`
+	LastUpdateTime  string `json:"lastUpdateTime"`
+	ThumbnailURL    string `json:"thumbnailURL"`
+	BigthumbnailURL string `json:"bigthumbnailURL"`
 	//MidthumbnailURL  string      `json:"midthumbnailURL"`
-	//BigthumbnailURL  string      `json:"bigthumbnailURL"`
 	//PresentURL       string      `json:"presentURL"`
 	//PresentLURL      string      `json:"presentLURL"`
 	//PresentHURL      string      `json:"presentHURL"`

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -314,8 +314,7 @@ func (d *Yun139) getFiles(catalogID string) ([]model.Obj, error) {
 					Modified: getTime(content.UpdateTime),
 					HashInfo: utils.NewHashInfo(utils.MD5, content.Digest),
 				},
-				Thumbnail: model.Thumbnail{Thumbnail: content.ThumbnailURL},
-				//Thumbnail: content.BigthumbnailURL,
+				Thumbnail: model.Thumbnail{Thumbnail: d.pickThumbnail(content.ThumbnailURL, content.BigthumbnailURL)},
 			}
 			files = append(files, &f)
 		}
@@ -325,6 +324,16 @@ func (d *Yun139) getFiles(catalogID string) ([]model.Obj, error) {
 		start += limit
 	}
 	return files, nil
+}
+
+// pickThumbnail returns the large thumbnail URL when UseLargeThumbnail is
+// enabled and the API provided one, otherwise it falls back to the regular
+// thumbnail URL.
+func (d *Yun139) pickThumbnail(thumbnailURL, bigThumbnailURL string) string {
+	if d.UseLargeThumbnail && bigThumbnailURL != "" {
+		return bigThumbnailURL
+	}
+	return thumbnailURL
 }
 
 func (d *Yun139) newJson(data map[string]interface{}) base.Json {
@@ -381,8 +390,7 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 					Ctime:    getTime(content.CreateTime),
 					Path:     path, // 文件所在目录的Path
 				},
-				Thumbnail: model.Thumbnail{Thumbnail: content.ThumbnailURL},
-				//Thumbnail: content.BigthumbnailURL,
+				Thumbnail: model.Thumbnail{Thumbnail: d.pickThumbnail(content.ThumbnailURL, content.BigthumbnailURL)},
 			}
 			files = append(files, &f)
 		}
@@ -436,8 +444,7 @@ func (d *Yun139) groupGetFiles(catalogID string) ([]model.Obj, error) {
 					Ctime:    getTime(content.CreateTime),
 					Path:     path, // 文件所在目录的Path
 				},
-				Thumbnail: model.Thumbnail{Thumbnail: content.ThumbnailURL},
-				//Thumbnail: content.BigthumbnailURL,
+				Thumbnail: model.Thumbnail{Thumbnail: d.pickThumbnail(content.ThumbnailURL, content.BigthumbnailURL)},
 			}
 			files = append(files, &f)
 		}
@@ -784,11 +791,9 @@ func (d *Yun139) shareGetFiles(pCaID string) ([]model.Obj, error) {
 		}
 		files = append(files, &f)
 	}
-    
+
 	return files, nil
 }
-
-
 
 type YunCrypto struct {
 	Key       []byte
@@ -1001,7 +1006,7 @@ func (d *Yun139) shareGetLink(coID string) (*model.Link, error) {
 			},
 		}, nil
 	}
-	
+
 	if res.DownloadURL != "" {
 		return &model.Link{URL: res.DownloadURL}, nil
 	}


### PR DESCRIPTION
### 问题 / Problem
139 移动云盘的「是否使用大缩略图」(`use_large_thumbnail`) 开关仅在 `personal_new` 路径生效；家庭云（family）、个人云（personal）、群组（group）始终使用小图 `thumbnailURL`，开关无效。对应 #9391。

The `use_large_thumbnail` toggle only took effect on the `personal_new` path; family/personal/group listings always used the small `thumbnailURL`.

### 改动 / Change
139 的 queryContentList 系列接口本身就返回 `bigthumbnailURL` 字段（此前在结构体里被注释掉）。本 PR：
- 解析 `Content` / `CloudContent` 的 `bigthumbnailURL`；
- 新增 `pickThumbnail` 辅助函数，在 `use_large_thumbnail` 开启且存在大图 URL 时使用大图，否则回退到小图（不存在大图时行为与现状一致，零回归）；
- 应用到 family / personal / group 三条 List 路径。

### 验证 / Verification
`go build ./drivers/139/` 与 `go vet` 通过。

Fixes #9391
