### PR TITLE
fix(index): don't auto-index wrapper drivers' underlying storage

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -92,7 +92,7 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 		return nil, errs.ObjectNotFound
 	}
 	var objs []model.Obj
-	fsArgs := &fs.ListArgs{NoLog: true, Refresh: args.Refresh}
+	fsArgs := &fs.ListArgs{NoLog: true, Refresh: args.Refresh, NoUpdateIndex: true}
 	for _, dst := range dsts {
 		tmp, err := d.list(ctx, dst, sub, fsArgs)
 		if err == nil {

--- a/drivers/chunker/util.go
+++ b/drivers/chunker/util.go
@@ -900,5 +900,5 @@ func (d *Chunker) openPartRange(ctx context.Context, link *model.Link, size, off
 }
 
 func fsList(ctx context.Context, remotePath string, refresh bool) ([]model.Obj, error) {
-	return fs.List(ctx, remotePath, &fs.ListArgs{NoLog: true, Refresh: refresh})
+	return fs.List(ctx, remotePath, &fs.ListArgs{NoLog: true, Refresh: refresh, NoUpdateIndex: true})
 }

--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -110,7 +110,7 @@ func (d *Crypt) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	//return d.list(ctx, d.RemotePath, path)
 	//remoteFull
 
-	objs, err := fs.List(ctx, d.getPathForRemote(path, true), &fs.ListArgs{NoLog: true})
+	objs, err := fs.List(ctx, d.getPathForRemote(path, true), &fs.ListArgs{NoLog: true, NoUpdateIndex: true})
 	// the obj must implement the model.SetPath interface
 	// return objs, err
 	if err != nil {

--- a/drivers/strm/driver.go
+++ b/drivers/strm/driver.go
@@ -143,7 +143,7 @@ func (d *Strm) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]
 	out := make([]model.Obj, 0)
 	for _, targetRoot := range targets {
 		realDir := stdpath.Join(targetRoot, sub)
-		objs, err := fs.List(ctx, realDir, &fs.ListArgs{NoLog: true, Refresh: args.Refresh})
+		objs, err := fs.List(ctx, realDir, &fs.ListArgs{NoLog: true, Refresh: args.Refresh, NoUpdateIndex: true})
 		if err != nil {
 			continue
 		}
@@ -188,7 +188,7 @@ func (d *Strm) rotateAllLocal(ctx context.Context) {
 }
 
 func (d *Strm) walkAndSync(ctx context.Context, virtualDir, realDir string) {
-	objs, err := fs.List(ctx, realDir, &fs.ListArgs{NoLog: true, Refresh: true})
+	objs, err := fs.List(ctx, realDir, &fs.ListArgs{NoLog: true, Refresh: true, NoUpdateIndex: true})
 	if err != nil {
 		log.Warnf("strm: rotate list failed %s: %v", realDir, err)
 		return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -20,6 +20,10 @@ import (
 type ListArgs struct {
 	Refresh bool
 	NoLog   bool
+	// NoUpdateIndex skips the auto search-index update hook for this listing.
+	// Wrapper drivers set it when listing their underlying storage so the real
+	// path is not auto-indexed alongside the wrapper's mount path.
+	NoUpdateIndex bool
 }
 
 func List(ctx context.Context, path string, args *ListArgs) ([]model.Obj, error) {

--- a/internal/fs/list.go
+++ b/internal/fs/list.go
@@ -24,8 +24,9 @@ func list(ctx context.Context, path string, args *ListArgs) ([]model.Obj, error)
 	var _objs []model.Obj
 	if storage != nil {
 		_objs, err = op.List(ctx, storage, actualPath, model.ListArgs{
-			ReqPath: path,
-			Refresh: args.Refresh,
+			ReqPath:       path,
+			Refresh:       args.Refresh,
+			NoUpdateIndex: args.NoUpdateIndex,
 		})
 		if err != nil {
 			if !args.NoLog {

--- a/internal/model/args.go
+++ b/internal/model/args.go
@@ -14,6 +14,12 @@ type ListArgs struct {
 	ReqPath           string
 	S3ShowPlaceholder bool
 	Refresh           bool
+	// NoUpdateIndex skips the objs-update hook (used to auto-build the search
+	// index) for this listing. Wrapper drivers (alias, crypt, strm, chunker)
+	// set it when listing their underlying storage so the real path is not
+	// auto-indexed alongside the wrapper's own mount path, which would create
+	// duplicate search entries.
+	NoUpdateIndex bool
 }
 
 type LinkArgs struct {

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -143,9 +143,11 @@ func List(ctx context.Context, storage driver.Driver, path string, args model.Li
 		// warp obj name
 		model.WrapObjsName(files)
 		// call hooks
-		go func(reqPath string, files []model.Obj) {
-			HandleObjsUpdateHook(reqPath, files)
-		}(utils.GetFullPath(storage.GetStorage().MountPath, path), files)
+		if !args.NoUpdateIndex {
+			go func(reqPath string, files []model.Obj) {
+				HandleObjsUpdateHook(reqPath, files)
+			}(utils.GetFullPath(storage.GetStorage().MountPath, path), files)
+		}
 
 		// sort objs
 		if storage.Config().LocalSort {


### PR DESCRIPTION
### 问题 / Problem
开启「自动构建索引」后，通过 alias（别名）等包装类驱动浏览时，搜索结果出现重复条目；手动构建索引则没有该问题。对应 #9489。

根因：alias / crypt / strm / chunker 这类包装驱动在 `List` 时会用 `fs.List` 列举底层真实存储，这条内部调用经过 `op.List` 会触发 `ObjsUpdateHook`（自动建索引）。于是底层真实路径被额外索引一次（与包装挂载路径重复），导致经别名访问的文件在搜索里出现重复。手动构建索引走显式遍历、且过程中关闭了 update hook，所以不受影响。

### 改动 / Change
- 在 `fs.ListArgs` / `model.ListArgs` 新增 `NoUpdateIndex` 标志，`op.List` 据此跳过 `ObjsUpdateHook`；
- alias / crypt / strm / chunker 列举底层存储的内部 `fs.List` 调用都带上该标志。

包装驱动自身挂载路径仍由外层 `op.List` 正常索引，直接访问底层存储也照常索引，只是去掉了"经包装驱动顺带把底层重复索引一遍"。

### 验证 / Verification
`go build ./...` 与相关包 `go vet` 通过。

Fixes #9489
