### PR TITLE
feat(search): add index-free (no_index) live search mode

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -175,7 +175,7 @@ func InitialSettings() []model.SettingItem {
 
 		// single settings
 		{Key: conf.Token, Value: token, Type: conf.TypeString, Group: model.SINGLE, Flag: model.PRIVATE},
-		{Key: conf.SearchIndex, Value: "none", Type: conf.TypeSelect, Options: "database,database_non_full_text,bleve,meilisearch,none", Group: model.INDEX},
+		{Key: conf.SearchIndex, Value: "none", Type: conf.TypeSelect, Options: "database,database_non_full_text,bleve,meilisearch,no_index,none", Group: model.INDEX},
 		{Key: conf.AutoUpdateIndex, Value: "false", Type: conf.TypeBool, Group: model.INDEX},
 		{Key: conf.IgnorePaths, Value: "", Type: conf.TypeText, Group: model.INDEX, Flag: model.PRIVATE, Help: `one path per line`},
 		{Key: conf.MaxIndexDepth, Value: "20", Type: conf.TypeNumber, Group: model.INDEX, Flag: model.PRIVATE, Help: `max depth of index`},

--- a/internal/search/import.go
+++ b/internal/search/import.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/alist-org/alist/v3/internal/search/db"
 	_ "github.com/alist-org/alist/v3/internal/search/db_non_full_text"
 	_ "github.com/alist-org/alist/v3/internal/search/meilisearch"
+	_ "github.com/alist-org/alist/v3/internal/search/noindex"
 )

--- a/internal/search/noindex/init.go
+++ b/internal/search/noindex/init.go
@@ -1,0 +1,17 @@
+package noindex
+
+import (
+	"github.com/alist-org/alist/v3/internal/search/searcher"
+)
+
+var config = searcher.Config{
+	Name: "no_index",
+	// no persisted index, so there is nothing to auto-update
+	AutoUpdate: false,
+}
+
+func init() {
+	searcher.RegisterSearcher(config, func() (searcher.Searcher, error) {
+		return &NoIndex{}, nil
+	})
+}

--- a/internal/search/noindex/search.go
+++ b/internal/search/noindex/search.go
@@ -1,0 +1,136 @@
+package noindex
+
+import (
+	"context"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/fs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/search/searcher"
+	"github.com/alist-org/alist/v3/internal/setting"
+	"github.com/pkg/errors"
+)
+
+// maxResults caps how many matches a single live search collects, to bound the
+// cost of walking large storages without an index.
+const maxResults = 1000
+
+// errStop aborts the walk once enough matches have been collected.
+var errStop = errors.New("enough results collected")
+
+// NoIndex is an index-free searcher: instead of querying a prebuilt index it
+// walks the filesystem under the requested parent on every search and matches
+// object names against the keywords. It trades query speed for not having to
+// build and maintain an index. See issue #9468.
+type NoIndex struct{}
+
+func (NoIndex) Config() searcher.Config {
+	return config
+}
+
+func (NoIndex) Search(ctx context.Context, req model.SearchReq) ([]model.SearchNode, int64, error) {
+	keywords := strings.Fields(req.Keywords)
+	parent := req.Parent
+	rootObj, err := fs.Get(ctx, parent, &fs.GetArgs{NoLog: true})
+	if err != nil {
+		return nil, 0, errors.WithMessagef(err, "failed get dir [%s]", parent)
+	}
+	maxDepth := setting.GetInt(conf.MaxIndexDepth, 20)
+	ignorePaths := conf.SlicesMap[conf.IgnorePaths]
+
+	var nodes []model.SearchNode
+	walkFn := func(reqPath string, info model.Obj) error {
+		// the parent itself is not a search result
+		if reqPath == parent {
+			return nil
+		}
+		for _, ignore := range ignorePaths {
+			if strings.HasPrefix(reqPath, ignore) {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		// scope: 0 for all, 1 for dir, 2 for file
+		if (req.Scope == 1 && !info.IsDir()) || (req.Scope == 2 && info.IsDir()) {
+			return nil
+		}
+		if matchKeywords(info.GetName(), keywords) {
+			nodes = append(nodes, model.SearchNode{
+				Parent: path.Dir(reqPath),
+				Name:   info.GetName(),
+				IsDir:  info.IsDir(),
+				Size:   info.GetSize(),
+			})
+			if len(nodes) >= maxResults {
+				return errStop
+			}
+		}
+		return nil
+	}
+	if err := fs.WalkFS(ctx, maxDepth, parent, rootObj, walkFn); err != nil && !errors.Is(err, errStop) {
+		return nil, 0, err
+	}
+
+	// stable ordering so pagination is consistent across repeated calls
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Name != nodes[j].Name {
+			return nodes[i].Name < nodes[j].Name
+		}
+		return nodes[i].Parent < nodes[j].Parent
+	})
+
+	total := int64(len(nodes))
+	start := (req.Page - 1) * req.PerPage
+	if start >= len(nodes) {
+		return []model.SearchNode{}, total, nil
+	}
+	end := start + req.PerPage
+	if end > len(nodes) {
+		end = len(nodes)
+	}
+	return nodes[start:end], total, nil
+}
+
+// matchKeywords reports whether name contains every keyword (case-insensitive),
+// matching the AND semantics of the indexed searchers. Empty keywords match all.
+func matchKeywords(name string, keywords []string) bool {
+	lower := strings.ToLower(name)
+	for _, kw := range keywords {
+		if !strings.Contains(lower, strings.ToLower(kw)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (NoIndex) Index(ctx context.Context, node model.SearchNode) error {
+	return nil
+}
+
+func (NoIndex) BatchIndex(ctx context.Context, nodes []model.SearchNode) error {
+	return nil
+}
+
+func (NoIndex) Get(ctx context.Context, parent string) ([]model.SearchNode, error) {
+	return []model.SearchNode{}, nil
+}
+
+func (NoIndex) Del(ctx context.Context, prefix string) error {
+	return nil
+}
+
+func (NoIndex) Release(ctx context.Context) error {
+	return nil
+}
+
+func (NoIndex) Clear(ctx context.Context) error {
+	return nil
+}
+
+var _ searcher.Searcher = (*NoIndex)(nil)

--- a/internal/search/noindex/search_test.go
+++ b/internal/search/noindex/search_test.go
@@ -1,0 +1,24 @@
+package noindex
+
+import "testing"
+
+func TestMatchKeywords(t *testing.T) {
+	cases := []struct {
+		name     string
+		keywords []string
+		want     bool
+	}{
+		{"Death.End.Cursed.2024.mkv", []string{"death", "cursed"}, true},
+		{"Death.End.Cursed.2024.mkv", []string{"Death", "CURSED"}, true}, // case-insensitive
+		{"Death.End.Cursed.2024.mkv", []string{"death", "missing"}, false},
+		{"holiday photos", nil, true}, // no keywords matches everything
+		{"holiday photos", []string{}, true},
+		{"a.txt", []string{"a", "txt"}, true},
+		{"a.txt", []string{"b"}, false},
+	}
+	for _, c := range cases {
+		if got := matchKeywords(c.name, c.keywords); got != c.want {
+			t.Fatalf("matchKeywords(%q, %v) = %v, want %v", c.name, c.keywords, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
### 需求 / Motivation
构建并维护搜索索引需要额外存储与定期维护，且索引可能滞后；对偶尔搜索的场景过重。对应 #9468。

### 改动 / Change
在「搜索索引」设置新增 `no_index` 选项。选中后搜索不再查预建索引，而是从当前目录用 `fs.WalkFS` 实时遍历子树、对文件/目录名做关键词匹配（大小写不敏感、AND 语义，与索引后端一致）：
- 受 `max_index_depth`、`ignore_paths` 约束，并对单次结果封顶 1000 条（提前中止遍历），避免大网盘打爆内存/耗时；
- 不落任何索引（`Index/BatchIndex/...` 均为 no-op，`AutoUpdate=false`）；
- 结果按名称排序保证分页稳定；权限/隐藏路径过滤仍由搜索 handler 逐条处理。

`Init`/中间件无需改动（仅精确等于 `none` 才禁用搜索）。默认仍为 `none`，零回归，需用户手动切到 No index 才启用。

### 验证 / Verification
`go build ./...`、`go test ./internal/search/noindex/` 通过。

Closes #9468
