### PR TITLE
Support stateless JWT validation

### DIFF
--- a/server/common/auth.go
+++ b/server/common/auth.go
@@ -3,7 +3,6 @@ package common
 import (
 	"time"
 
-	"github.com/Xhofe/go-cache"
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/golang-jwt/jwt/v4"
@@ -17,8 +16,6 @@ type UserClaims struct {
 	PwdTS    int64  `json:"pwd_ts"`
 	jwt.RegisteredClaims
 }
-
-var validTokenCache = cache.NewMemCache[bool]()
 
 func GenerateToken(user *model.User) (tokenString string, err error) {
 	claim := UserClaims{
@@ -34,7 +31,6 @@ func GenerateToken(user *model.User) (tokenString string, err error) {
 	if err != nil {
 		return "", err
 	}
-	validTokenCache.Set(tokenString, true)
 	return tokenString, err
 }
 
@@ -42,9 +38,6 @@ func ParseToken(tokenString string) (*UserClaims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &UserClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return SecretKey, nil
 	})
-	if IsTokenInvalidated(tokenString) {
-		return nil, errors.New("token is invalidated")
-	}
 	if err != nil {
 		if ve, ok := err.(*jwt.ValidationError); ok {
 			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
@@ -68,11 +61,11 @@ func InvalidateToken(tokenString string) error {
 	if tokenString == "" {
 		return nil // don't invalidate empty guest token
 	}
-	validTokenCache.Del(tokenString)
+	// JWT validation is intentionally stateless so tokens work across multiple
+	// instances. Revocation is handled by password timestamps and device sessions.
 	return nil
 }
 
 func IsTokenInvalidated(tokenString string) bool {
-	_, ok := validTokenCache.Get(tokenString)
-	return !ok
+	return false
 }

--- a/server/common/auth_test.go
+++ b/server/common/auth_test.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func setupAuthTest(t *testing.T) {
+	t.Helper()
+
+	oldConf := conf.Conf
+	oldSecretKey := SecretKey
+	conf.Conf = &conf.Config{TokenExpiresIn: 1}
+	SecretKey = []byte("test-secret")
+
+	t.Cleanup(func() {
+		conf.Conf = oldConf
+		SecretKey = oldSecretKey
+	})
+}
+
+func TestParseTokenDoesNotRequireLocalTokenState(t *testing.T) {
+	setupAuthTest(t)
+
+	tokenString, err := jwt.NewWithClaims(jwt.SigningMethodHS256, UserClaims{
+		Username: "alice",
+		PwdTS:    123,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+		},
+	}).SignedString(SecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claims, err := ParseToken(tokenString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.Username != "alice" || claims.PwdTS != 123 {
+		t.Fatalf("unexpected claims: %+v", claims)
+	}
+}
+
+func TestInvalidateTokenDoesNotBreakStatelessJWTValidation(t *testing.T) {
+	setupAuthTest(t)
+
+	tokenString, err := GenerateToken(&model.User{Username: "alice", PwdTS: 456})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InvalidateToken(tokenString); err != nil {
+		t.Fatal(err)
+	}
+	if IsTokenInvalidated(tokenString) {
+		t.Fatal("token should not be invalidated by local process state")
+	}
+
+	claims, err := ParseToken(tokenString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.Username != "alice" || claims.PwdTS != 456 {
+		t.Fatalf("unexpected claims: %+v", claims)
+	}
+}


### PR DESCRIPTION
JWT 本身支持无状态验证, 感觉 MemCache 有点多余了; 集群所有实例使用同一个 JWT_SECRET 并使用共享数据库；退出登录、踢设备、密码变更等失效能力现在主要依赖共享的 device session 表和 PwdTS, 这样就支持集群及 lambda 等 serverless 部署了, 爽歪歪