### PR TITLE
feat(driver): add sjtu netdisk driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -69,6 +69,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/s3"
 	_ "github.com/alist-org/alist/v3/drivers/seafile"
 	_ "github.com/alist-org/alist/v3/drivers/sftp"
+	_ "github.com/alist-org/alist/v3/drivers/sjtu_netdisk"
 	_ "github.com/alist-org/alist/v3/drivers/smb"
 	_ "github.com/alist-org/alist/v3/drivers/streamtape"
 	_ "github.com/alist-org/alist/v3/drivers/strm"

--- a/drivers/sjtu_netdisk/driver.go
+++ b/drivers/sjtu_netdisk/driver.go
@@ -1,0 +1,718 @@
+package sjtu_netdisk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/go-resty/resty/v2"
+)
+
+type SJTUNetdisk struct {
+	model.Storage
+	Addition
+	ref *SJTUNetdisk
+
+	accessToken  string
+	libraryId    string
+	spaceId      string
+	tokenExpires time.Time
+	tokenMutex   sync.Mutex
+}
+
+func (d *SJTUNetdisk) Config() driver.Config {
+	return config
+}
+
+func (d *SJTUNetdisk) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *SJTUNetdisk) Init(ctx context.Context) error {
+	return d.refreshToken(ctx)
+}
+
+func (d *SJTUNetdisk) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*SJTUNetdisk)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return errs.NotSupport
+}
+
+func (d *SJTUNetdisk) Drop(ctx context.Context) error {
+	d.ref = nil
+	return nil
+}
+
+func (d *SJTUNetdisk) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		ID:       "root",
+		Path:     "/",
+		Name:     "root",
+		Size:     0,
+		IsFolder: true,
+	}, nil
+}
+
+func (d *SJTUNetdisk) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	listURL := fmt.Sprintf("%s/directory/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(dir.GetPath()))
+
+	var allObjs []model.Obj
+	page := 1
+
+	for {
+		var resp FolderListResp
+		_, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParams(map[string]string{
+				"access_token":  d.accessToken,
+				"page":          strconv.Itoa(page),
+				"page_size":     "200",
+				"order_by":      d.OrderBy,
+				"order_by_type": d.OrderByType,
+				"space_org_id":  "1",
+			}).
+			SetResult(&resp).
+			Execute(http.MethodGet, listURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		objs, err := utils.SliceConvert(resp.Contents, func(src NetdiskObj) (model.Obj, error) {
+			fileSize, _ := strconv.ParseInt(src.Size, 10, 64)
+
+			var objPath string
+			dirPath := dir.GetPath()
+			if dirPath == "" || dirPath == "/" {
+				objPath = "/" + src.Name
+			} else {
+				objPath = path.Join(dirPath, src.Name)
+			}
+
+			return &model.Object{
+				Name:     src.Name,
+				Size:     fileSize,
+				IsFolder: src.Type != "file",
+				Modified: src.ModificationTime,
+				Ctime:    src.CreationTime,
+				Path:     objPath,
+			}, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		allObjs = append(allObjs, objs...)
+
+		// stop if we have fetched all items
+		if len(allObjs) >= resp.TotalNum || len(resp.Contents) < 200 {
+			break
+		}
+		page++
+	}
+
+	return allObjs, nil
+}
+
+func (d *SJTUNetdisk) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	linkURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(file.GetPath()))
+
+	client := d.newClient()
+	client.SetRedirectPolicy(resty.RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}))
+
+	resp, err := client.R().
+		SetContext(ctx).
+		SetQueryParams(map[string]string{
+			"access_token":        d.accessToken,
+			"user_id":             d.UserId,
+			"content_disposition": "attachment",
+			"purpose":             "download",
+			"space_org_id":        "1",
+		}).
+		Execute(http.MethodGet, linkURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// status code is not 301 and 302
+	if resp.StatusCode() != http.StatusFound && resp.StatusCode() != http.StatusMovedPermanently {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode())
+	}
+
+	s3URL := resp.Header().Get("Location")
+	if s3URL == "" {
+		return nil, fmt.Errorf("no Location header in redirect response")
+	}
+
+	// parse TTL from S3 presigned URL's X-Amz-Expires parameter
+	ttl := 2 * time.Hour
+	if u, parseErr := url.Parse(s3URL); parseErr == nil {
+		if expiresSec, convErr := strconv.Atoi(u.Query().Get("X-Amz-Expires")); convErr == nil && expiresSec > 0 {
+			ttl = time.Duration(expiresSec) * time.Second
+		}
+	}
+
+	return &model.Link{
+		URL:        s3URL,
+		Expiration: &ttl,
+	}, nil
+}
+
+func (d *SJTUNetdisk) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	infoURL := fmt.Sprintf("%s/directory/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(parentDir.GetPath()+"/"+dirName))
+
+	resp, err := d.newClient().R().
+		SetContext(ctx).
+		SetQueryParam("access_token", d.accessToken).
+		SetQueryParam("user_id", d.UserId).
+		SetQueryParam("conflict_resolution_strategy", "ask").
+		Execute(http.MethodPut, infoURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// 409 means folder with the same name exists (treated as success for idempotency); 201 means created
+	if resp.StatusCode() != http.StatusConflict && resp.StatusCode() != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode())
+	}
+
+	return &model.Object{
+		Name:     dirName,
+		IsFolder: true,
+		Modified: time.Now(),
+		Ctime:    time.Now(),
+		Path:     buildPath(parentDir.GetPath(), dirName),
+	}, nil
+}
+
+func (d *SJTUNetdisk) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	srcPath := srcObj.GetPath()
+	targetPath := path.Join(dstDir.GetPath(), srcObj.GetName())
+
+	// file move: use overwrite strategy
+	if !srcObj.IsDir() {
+		apiURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(targetPath))
+
+		var moveResp MoveCopyResp
+		_, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParam("access_token", d.accessToken).
+			SetQueryParam("conflict_resolution_strategy", "overwrite").
+			SetBody(map[string]interface{}{"from": srcPath}).
+			SetResult(&moveResp).
+			Execute(http.MethodPut, apiURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		actualName := srcObj.GetName()
+		if len(moveResp.Path) > 0 {
+			actualName = moveResp.Path[len(moveResp.Path)-1]
+		}
+		return &model.Object{
+			Name:     actualName,
+			Size:     srcObj.GetSize(),
+			IsFolder: false,
+			Modified: srcObj.ModTime(),
+			Ctime:    srcObj.CreateTime(),
+			Path:     buildPath(dstDir.GetPath(), actualName),
+		}, nil
+		// folder move
+	} else {
+		// use ask strategy to detect conflict
+		err := d.moveItem(ctx, srcPath, dstDir.GetPath(), srcObj.GetName(), true, "ask")
+		if err == nil {
+			return &model.Object{
+				Name:     srcObj.GetName(),
+				Size:     srcObj.GetSize(),
+				IsFolder: true,
+				Modified: srcObj.ModTime(),
+				Ctime:    srcObj.CreateTime(),
+				Path:     targetPath,
+			}, nil
+		}
+
+		// 409 means conflict name, needs merge
+		if !errors.Is(err, errs.ObjectNotFound) {
+			return nil, err
+		}
+
+		// list all child item of srcObj
+		children, listErr := d.List(ctx, srcObj, model.ListArgs{})
+		if listErr != nil {
+			return nil, fmt.Errorf("merge: list source folder failed: %w", listErr)
+		}
+
+		// move every child item to dstDir recursively
+		for _, child := range children {
+			childSrcPath := path.Join(srcPath, child.GetName())
+			targetDstPath := targetPath
+
+			// subfolder: recursive Move
+			if child.IsDir() {
+				childErr := d.moveItem(ctx, childSrcPath, targetDstPath, child.GetName(), true, "ask")
+				if childErr != nil && errors.Is(childErr, errs.ObjectNotFound) {
+					childObj := &model.Object{
+						Name:     child.GetName(),
+						Path:     childSrcPath,
+						Size:     child.GetSize(),
+						IsFolder: true,
+					}
+					_, mergeErr := d.Move(ctx, childObj, &model.Object{
+						Path:     targetPath,
+						Name:     srcObj.GetName(),
+						IsFolder: true,
+					})
+					if mergeErr != nil {
+						return nil, fmt.Errorf("merge subfolder %s: %w", child.GetName(), mergeErr)
+					}
+				} else if childErr != nil {
+					return nil, fmt.Errorf("merge subfolder %s: %w", child.GetName(), childErr)
+				}
+			} else {
+				// child item is file
+				fileErr := d.moveItem(ctx, childSrcPath, targetDstPath, child.GetName(), false, "overwrite")
+				if fileErr != nil {
+					return nil, fmt.Errorf("merge file %s: %w", child.GetName(), fileErr)
+				}
+			}
+		}
+
+		// delete empty srcObj folder
+		_ = d.Remove(ctx, srcObj)
+
+		return &model.Object{
+			Name:     srcObj.GetName(),
+			Size:     srcObj.GetSize(),
+			IsFolder: true,
+			Modified: srcObj.ModTime(),
+			Ctime:    srcObj.CreateTime(),
+			Path:     targetPath,
+		}, nil
+	}
+}
+
+func (d *SJTUNetdisk) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	parentPath := path.Dir(strings.ReplaceAll(srcObj.GetPath(), "\\", "/"))
+	dstPath := buildPath(parentPath, newName)
+
+	// file rename
+	if !srcObj.IsDir() {
+		renameURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(dstPath))
+
+		var moveResp MoveCopyResp
+		_, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParam("access_token", d.accessToken).
+			SetQueryParam("conflict_resolution_strategy", "overwrite").
+			SetBody(map[string]interface{}{"from": srcObj.GetPath()}).
+			SetResult(&moveResp).
+			Execute(http.MethodPut, renameURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		actualName := newName
+		if len(moveResp.Path) > 0 {
+			actualName = moveResp.Path[len(moveResp.Path)-1]
+		}
+		return &model.Object{
+			Name:     actualName,
+			Size:     srcObj.GetSize(),
+			IsFolder: false,
+			Modified: srcObj.ModTime(),
+			Ctime:    srcObj.CreateTime(),
+			Path:     buildPath(parentPath, actualName),
+		}, nil
+	} else {
+		// folder rename
+		renameURL := fmt.Sprintf("%s/directory/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(dstPath))
+
+		resp, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParam("access_token", d.accessToken).
+			SetQueryParam("conflict_resolution_strategy", "ask").
+			SetQueryParam("move_authority", "true").
+			SetBody(map[string]interface{}{"from": srcObj.GetPath()}).
+			Execute(http.MethodPut, renameURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		// 204 means no conflict
+		if resp.StatusCode() == http.StatusNoContent {
+			return &model.Object{
+				Name:     newName,
+				Size:     srcObj.GetSize(),
+				IsFolder: true,
+				Modified: srcObj.ModTime(),
+				Ctime:    srcObj.CreateTime(),
+				Path:     dstPath,
+			}, nil
+		}
+
+		// 409 means conflict name
+		if resp.StatusCode() == http.StatusConflict {
+			children, listErr := d.List(ctx, srcObj, model.ListArgs{})
+			if listErr != nil {
+				return nil, fmt.Errorf("rename merge: list source folder failed: %w", listErr)
+			}
+
+			targetDirObj := &model.Object{Path: dstPath, Name: newName, IsFolder: true}
+
+			for _, child := range children {
+				childSrcPath := path.Join(srcObj.GetPath(), child.GetName())
+
+				if child.IsDir() {
+					childObj := &model.Object{
+						Name: child.GetName(), Path: childSrcPath,
+						Size: child.GetSize(), IsFolder: true,
+					}
+					if _, mergeErr := d.Move(ctx, childObj, targetDirObj); mergeErr != nil {
+						return nil, fmt.Errorf("rename merge subfolder %s: %w", child.GetName(), mergeErr)
+					}
+				} else {
+					fileErr := d.moveItem(ctx, childSrcPath, dstPath, child.GetName(), false, "overwrite")
+					if fileErr != nil {
+						return nil, fmt.Errorf("rename merge file %s: %w", child.GetName(), fileErr)
+					}
+				}
+			}
+
+			_ = d.Remove(ctx, srcObj)
+
+			return &model.Object{
+				Name:     newName,
+				Size:     srcObj.GetSize(),
+				IsFolder: true,
+				Modified: srcObj.ModTime(),
+				Ctime:    srcObj.CreateTime(),
+				Path:     dstPath,
+			}, nil
+		}
+
+		return nil, fmt.Errorf("unexpected rename folder response: status=%d", resp.StatusCode())
+	}
+}
+
+func (d *SJTUNetdisk) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	srcPath := srcObj.GetPath()
+	targetPath := path.Join(dstDir.GetPath(), srcObj.GetName())
+
+	// file copy
+	if !srcObj.IsDir() {
+		copyURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(targetPath))
+
+		var copyResp MoveCopyResp
+		_, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParam("access_token", d.accessToken).
+			SetQueryParam("conflict_resolution_strategy", "overwrite").
+			SetBody(map[string]interface{}{"copyFrom": srcPath}).
+			SetResult(&copyResp).
+			Execute(http.MethodPut, copyURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		actualName := srcObj.GetName()
+		if len(copyResp.Path) > 0 {
+			actualName = copyResp.Path[len(copyResp.Path)-1]
+		}
+		return &model.Object{
+			Name:     actualName,
+			Size:     srcObj.GetSize(),
+			IsFolder: false,
+			Modified: srcObj.ModTime(),
+			Ctime:    time.Now(),
+			Path:     buildPath(dstDir.GetPath(), actualName),
+		}, nil
+	} else {
+		// folder copy
+		infoURL := fmt.Sprintf("%s/directory/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(targetPath))
+
+		resp, err := d.newClient().R().
+			SetContext(ctx).
+			SetQueryParam("access_token", d.accessToken).
+			SetQueryParam("conflict_resolution_strategy", "ask").
+			SetBody(map[string]interface{}{"copyFrom": srcPath}).
+			Execute(http.MethodPut, infoURL)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode() == http.StatusConflict {
+			children, listErr := d.List(ctx, srcObj, model.ListArgs{})
+			if listErr != nil {
+				return nil, fmt.Errorf("copy merge: list source folder failed: %w", listErr)
+			}
+
+			targetDirObj := &model.Object{
+				Path:     targetPath,
+				Name:     srcObj.GetName(),
+				IsFolder: true,
+			}
+
+			for _, child := range children {
+				childSrcPath := path.Join(srcPath, child.GetName())
+
+				if child.IsDir() {
+					childObj := &model.Object{
+						Name:     child.GetName(),
+						Path:     childSrcPath,
+						Size:     child.GetSize(),
+						IsFolder: true,
+					}
+					if _, mergeErr := d.Copy(ctx, childObj, targetDirObj); mergeErr != nil {
+						return nil, fmt.Errorf("copy merge subfolder %s: %w", child.GetName(), mergeErr)
+					}
+				} else {
+					childEncoded := d.encodePath(path.Join(targetPath, child.GetName()))
+					childURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, childEncoded)
+					if _, fileErr := d.newClient().R().
+						SetContext(ctx).
+						SetQueryParam("access_token", d.accessToken).
+						SetQueryParam("conflict_resolution_strategy", "overwrite").
+						SetBody(map[string]interface{}{"copyFrom": childSrcPath}).
+						Execute(http.MethodPut, childURL); fileErr != nil {
+						return nil, fmt.Errorf("copy merge file %s: %w", child.GetName(), fileErr)
+					}
+				}
+			}
+
+			return &model.Object{
+				Name:     srcObj.GetName(),
+				Size:     srcObj.GetSize(),
+				IsFolder: true,
+				Modified: srcObj.ModTime(),
+				Ctime:    time.Now(),
+				Path:     targetPath,
+			}, nil
+		}
+
+		// 202 Accepted：polling task status
+		if resp.StatusCode() != http.StatusAccepted {
+			return nil, fmt.Errorf("unexpected copy folder response: status=%d", resp.StatusCode())
+		}
+
+		var taskResp TaskInitResp
+		if err := json.Unmarshal(resp.Body(), &taskResp); err != nil || taskResp.TaskId == 0 {
+			return nil, fmt.Errorf("failed to parse task id: %w", err)
+		}
+
+		taskURL := fmt.Sprintf("%s/task/%s/%s/%d", API_URL, d.libraryId, d.spaceId, taskResp.TaskId)
+		actualName := srcObj.GetName()
+		taskDone := false
+
+		for i := 0; i < 30 && !taskDone; i++ {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(1 * time.Second):
+			}
+
+			var taskStatus []TaskStatusItem
+			_, pollErr := d.newClient().R().
+				SetContext(ctx).
+				SetQueryParam("access_token", d.accessToken).
+				SetResult(&taskStatus).
+				Execute(http.MethodGet, taskURL)
+
+			if pollErr != nil {
+				return nil, pollErr
+			}
+			if len(taskStatus) == 0 {
+				continue
+			}
+
+			switch taskStatus[0].Status {
+			case 200:
+				if taskStatus[0].Result != nil && len(taskStatus[0].Result.Path) > 0 {
+					actualName = taskStatus[0].Result.Path[len(taskStatus[0].Result.Path)-1]
+				}
+				taskDone = true
+			case 204:
+				taskDone = true
+			}
+		}
+
+		return &model.Object{
+			Name:     actualName,
+			Size:     srcObj.GetSize(),
+			IsFolder: true,
+			Modified: srcObj.ModTime(),
+			Ctime:    time.Now(),
+			Path:     buildPath(dstDir.GetPath(), actualName),
+		}, nil
+	}
+}
+
+func (d *SJTUNetdisk) Remove(ctx context.Context, obj model.Obj) error {
+	if err := d.refreshToken(ctx); err != nil {
+		return err
+	}
+
+	var endpoint string
+	if obj.IsDir() {
+		endpoint = "directory"
+	} else {
+		endpoint = "file"
+	}
+
+	removeURL := fmt.Sprintf("%s/%s/%s/%s/%s", API_URL, endpoint, d.libraryId, d.spaceId, d.encodePath(obj.GetPath()))
+	resp, err := d.newClient().R().
+		SetContext(ctx).
+		SetQueryParam("access_token", d.accessToken).
+		SetQueryParam("permanent", "0").
+		SetQueryParam("space_org_id", "1").
+		Execute(http.MethodDelete, removeURL)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return fmt.Errorf("remove failed: status=%d", resp.StatusCode())
+	}
+
+	return nil
+}
+
+func (d *SJTUNetdisk) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	if err := d.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	parentPath := strings.TrimPrefix(strings.ReplaceAll(dstDir.GetPath(), "\\", "/"), "/")
+
+	// step 1: apply for confirm key
+	initURL := fmt.Sprintf("%s/file/%s/%s/%s", API_URL, d.libraryId, d.spaceId, d.encodePath(buildPath(parentPath, stream.GetName())))
+
+	mainClient := d.newClient()
+
+	var initResp UploadInitResp
+	_, err := mainClient.R().
+		SetContext(ctx).
+		SetQueryParams(map[string]string{
+			"access_token":                 d.accessToken,
+			"user_id":                      d.UserId,
+			"conflict_resolution_strategy": "overwrite",
+			"filesize":                     strconv.FormatInt(stream.GetSize(), 10),
+		}).
+		SetBody("{}").
+		SetResult(&initResp).
+		Execute(http.MethodPut, initURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if initResp.Domain == "" || initResp.Path == "" {
+		return nil, err
+	}
+
+	// step 2: upload file
+	s3URL := fmt.Sprintf("https://%s%s", initResp.Domain, initResp.Path)
+
+	s3Client := resty.New()
+	s3Request := s3Client.R().SetContext(ctx)
+	for headerKey, headerValue := range initResp.Headers {
+		s3Request.SetHeader(headerKey, headerValue)
+	}
+	s3Request.SetBody(driver.NewLimitedUploadStream(ctx, stream))
+
+	res, err := s3Request.Execute(http.MethodPut, s3URL)
+
+	if err != nil || (res.StatusCode() != http.StatusOK && res.StatusCode() != http.StatusCreated && res.StatusCode() != http.StatusNoContent) {
+		return nil, err
+	}
+
+	// step 3: confirm the upload
+	confirmURL := fmt.Sprintf("%s/file/%s/%s/%s?confirm", API_URL, d.libraryId, d.spaceId, initResp.ConfirmKey)
+
+	var confirmResp ConfirmResp
+	_, err = mainClient.R().
+		SetContext(ctx).
+		SetQueryParams(map[string]string{
+			"access_token":                 d.accessToken,
+			"user_id":                      d.UserId,
+			"conflict_resolution_strategy": "overwrite",
+		}).
+		SetBody("{}").
+		SetResult(&confirmResp).
+		Execute(http.MethodPost, confirmURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.Object{
+		Name:     stream.GetName(),
+		Size:     stream.GetSize(),
+		IsFolder: false,
+		Modified: time.Now(),
+		Ctime:    time.Now(),
+		Path:     buildPath(dstDir.GetPath(), stream.GetName()),
+	}, nil
+}
+
+func (d *SJTUNetdisk) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {
+	return nil, errs.NotSupport
+}
+
+var _ driver.Driver = (*SJTUNetdisk)(nil)
+var _ driver.Other = (*SJTUNetdisk)(nil)
+var _ driver.MkdirResult = (*SJTUNetdisk)(nil)
+var _ driver.MoveResult = (*SJTUNetdisk)(nil)
+var _ driver.RenameResult = (*SJTUNetdisk)(nil)
+var _ driver.PutResult = (*SJTUNetdisk)(nil)
+var _ driver.GetRooter = (*SJTUNetdisk)(nil)

--- a/drivers/sjtu_netdisk/meta.go
+++ b/drivers/sjtu_netdisk/meta.go
@@ -1,0 +1,39 @@
+package sjtu_netdisk
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	OrderBy     string `json:"order_by" type:"select" required:"true" options:"name,modificationTime,size" default:"name"`
+	OrderByType string `json:"order_by_type" type:"select" required:"true" options:"asc,desc" default:"asc"`
+	UserToken   string `json:"user_token" required:"true"`
+	UserId      string `json:"user_id" required:"true"`
+	KeepAlive   string `json:"keep_alive" required:"true"`
+}
+
+var config = driver.Config{
+	Name:              "SJTUNetdisk",
+	LocalSort:         false,
+	OnlyLocal:         false,
+	OnlyProxy:         false,
+	NoCache:           false,
+	NoUpload:          false,
+	NeedMs:            false,
+	DefaultRoot:       "/",
+	CheckStatus:       false,
+	Alert:             "",
+	NoOverwriteUpload: false,
+}
+
+var API_URL = "https://pan.sjtu.edu.cn/api/v1"
+
+// used by refreshToken
+var TOKEN_URL = "https://pan.sjtu.edu.cn/user/v1/space/1/personal"
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &SJTUNetdisk{}
+	})
+}

--- a/drivers/sjtu_netdisk/types.go
+++ b/drivers/sjtu_netdisk/types.go
@@ -1,0 +1,67 @@
+package sjtu_netdisk
+
+import (
+	"time"
+)
+
+// for refreshToken
+type TokenResp struct {
+	LibraryId   string `json:"libraryId"`
+	SpaceId     string `json:"spaceId"`
+	AccessToken string `json:"accessToken"`
+	ExpiresIn   int    `json:"expiresIn"`
+}
+
+// for List
+type FolderListResp struct {
+	Path        []string     `json:"path"`
+	SubDirCount int          `json:"subDirCount"`
+	FileCount   int          `json:"fileCount"`
+	TotalNum    int          `json:"totalNum"`
+	Contents    []NetdiskObj `json:"contents"`
+}
+
+// for "contents" embedded in FolderListResp
+type NetdiskObj struct {
+	Name             string    `json:"name"`
+	Type             string    `json:"type"`
+	Size             string    `json:"size"`
+	ModificationTime time.Time `json:"modificationTime"`
+	CreationTime     time.Time `json:"creationTime"`
+	ContentType      string    `json:"contentType"`
+}
+
+// for step 1 of Put (apply for confirm key)
+type UploadInitResp struct {
+	Domain     string            `json:"domain"`  // domain
+	Path       string            `json:"path"`    // hashed path
+	Headers    map[string]string `json:"headers"` // AWS signature request headers
+	ConfirmKey string            `json:"confirmKey"`
+	Expiration string            `json:"expiration"`
+}
+
+// for step 3 of Put (confirm the upload)
+type ConfirmResp struct {
+	Path          []string `json:"path"`
+	Name          string   `json:"name"`
+	Type          string   `json:"type"`
+	Size          string   `json:"size"`
+	IsOverwritten bool     `json:"isOverwritten"`
+}
+
+// for Move, Copy, Rename
+type MoveCopyResp struct {
+	Path []string `json:"path"` // path is divided and the last one is name
+}
+
+// for folder Copy, Move with task (no conflict)
+type TaskInitResp struct {
+	TaskId int64 `json:"taskId"`
+}
+
+// for the result of polling task status
+type TaskStatusItem struct {
+	TaskId int64         `json:"taskId"`
+	Status int           `json:"status"` // 204=complete without conflict
+	Result *MoveCopyResp `json:"result,omitempty"`
+}

--- a/drivers/sjtu_netdisk/util.go
+++ b/drivers/sjtu_netdisk/util.go
@@ -1,0 +1,112 @@
+package sjtu_netdisk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/go-resty/resty/v2"
+)
+
+// refresh and cache access_token, libraryId, spaceId
+func (d *SJTUNetdisk) refreshToken(ctx context.Context) error {
+	d.tokenMutex.Lock()
+	defer d.tokenMutex.Unlock()
+
+	// if token exist and is more than 2 min away from expiration, it will be reused directly
+	if d.accessToken != "" && time.Now().Add(2*time.Minute).Before(d.tokenExpires) {
+		return nil
+	}
+
+	client := d.newClient()
+	var resp TokenResp
+
+	_, err := client.R().
+		SetContext(ctx).
+		SetQueryParam("user_token", d.UserToken).
+		SetBody("{}").
+		SetResult(&resp).
+		Execute(http.MethodPost, TOKEN_URL)
+
+	if err != nil {
+		return err
+	}
+
+	d.accessToken = resp.AccessToken
+	d.libraryId = resp.LibraryId
+	d.spaceId = resp.SpaceId
+
+	expiresIn := resp.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 1800
+	}
+	d.tokenExpires = time.Now().Add(time.Duration(expiresIn) * time.Second)
+
+	return nil
+}
+
+// create a resty client with preloaded USER_TOKEN and keep_alive
+func (d *SJTUNetdisk) newClient() *resty.Client {
+	client := base.NewRestyClient()
+	client.SetCookie(&http.Cookie{Name: "USER_TOKEN", Value: d.UserToken, Path: "/"})
+	if d.KeepAlive != "" {
+		client.SetCookie(&http.Cookie{Name: "keep_alive", Value: d.KeepAlive, Path: "/"})
+	}
+	return client
+}
+
+// standardize and encode the internal path of alist
+func (d *SJTUNetdisk) encodePath(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	if p == "/" || p == "" {
+		return ""
+	}
+	return url.PathEscape(strings.TrimPrefix(p, "/"))
+}
+
+// concatenate basic paths and file names, handling root directory boundary situation
+func buildPath(base, name string) string {
+	if base == "/" || base == "" {
+		return "/" + name
+	}
+	return path.Join(base, name)
+}
+
+// move a single file or folder
+func (d *SJTUNetdisk) moveItem(ctx context.Context, srcPath, dstDirPath, name string, isDir bool, strategy string) error {
+	var endpoint string
+	if isDir {
+		endpoint = "directory"
+	} else {
+		endpoint = "file"
+	}
+
+	moveItemURL := fmt.Sprintf("%s/%s/%s/%s/%s", API_URL, endpoint, d.libraryId, d.spaceId, d.encodePath(path.Join(dstDirPath, name)))
+
+	req := d.newClient().R().
+		SetContext(ctx).
+		SetQueryParam("access_token", d.accessToken).
+		SetQueryParam("conflict_resolution_strategy", strategy).
+		SetBody(map[string]interface{}{"from": srcPath})
+
+	if isDir {
+		req.SetQueryParam("move_authority", "true")
+	}
+
+	resp, err := req.Execute(http.MethodPut, moveItemURL)
+	if err != nil {
+		return err
+	}
+
+	// 409 means conflict name
+	if resp.StatusCode() == http.StatusConflict {
+		return errs.ObjectNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
Add SJTU Netdisk (pan.sjtu.edu.cn) driver with full file operations:
- List files with pagination support
- Download via S3 presigned URL with X-Amz-Expires TTL parsing
- Upload with three-step S3 presigned flow
- Create directory, rename, move (with conflict merge), copy, delete
- Token auto-refresh with expiration caching and fallback

Driver registered in drivers/all.go via init() side-effect import.