### PR TITLE
ci: pin third-party actions (github-push-action, free-disk-space) to full commit SHAs

### DIFF
--- a/.github/workflows/auto_lang.yml
+++ b/.github/workflows/auto_lang.yml
@@ -63,7 +63,7 @@ jobs:
           cd ..
 
       - name: Push lang files
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.MY_TOKEN }}
           branch: main

--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -131,7 +131,7 @@ jobs:
           git commit --allow-empty -m "Trigger build for ${{ github.sha }}"
 
       - name: Push commit
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.MY_TOKEN }}
           branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
@@ -92,7 +92,7 @@ jobs:
           git tag -a $version -m "release $version"
 
       - name: Push tags
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.MY_TOKEN }}
           branch: main


### PR DESCRIPTION
### What
Pin the third-party actions referenced by `@master`/`@main` to their current commit SHA (tag kept in a comment):
| Action | Where |
|---|---|
| `ad-m/github-push-action@master` | `auto_lang.yml`, `beta_release.yml`, `release.yml` |
| `jlumbroso/free-disk-space@main` | `release.yml` |

### Why
`@master`/`@main` are moving refs. In `release.yml`, `github-push-action` is passed
`secrets.MY_TOKEN` (a write-scoped token). If that action's `master` were moved (compromise or an
accidental change), the new code would run with the token — the class of issue behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged — each SHA is the current tip of that action's default branch. Only third-party
actions touched. Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the token exposure, and the pinned SHAs myself.</sub>
