### PR TITLE
fix(123pan): proxy IP-bound downloads

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -81,16 +81,9 @@ func (d *Pan123) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 	})
 }
 
-func (d *Pan123) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+func (d *Pan123) Link(ctx context.Context, file model.Obj, _ model.LinkArgs) (*model.Link, error) {
 	if f, ok := file.(File); ok {
 		//var resp DownResp
-		var headers map[string]string
-		if !utils.IsLocalIPAddr(args.IP) {
-			headers = map[string]string{
-				//"X-Real-IP":       "1.1.1.1",
-				"X-Forwarded-For": args.IP,
-			}
-		}
 		data := base.Json{
 			"driveId":   0,
 			"etag":      f.Etag,
@@ -101,8 +94,7 @@ func (d *Pan123) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 			"type":      f.Type,
 		}
 		resp, err := d.Request(DownloadInfo, http.MethodPost, func(req *resty.Request) {
-
-			req.SetBody(data).SetHeaders(headers)
+			req.SetBody(data)
 		}, nil)
 		if err != nil {
 			return nil, err

--- a/drivers/123/meta.go
+++ b/drivers/123/meta.go
@@ -19,6 +19,8 @@ var config = driver.Config{
 	Name:        "123Pan",
 	DefaultRoot: "0",
 	LocalSort:   true,
+	// Download URLs are bound to the IP that requests them from 123Pan.
+	OnlyProxy: true,
 }
 
 func init() {

--- a/drivers/123/meta_test.go
+++ b/drivers/123/meta_test.go
@@ -1,0 +1,9 @@
+package _123
+
+import "testing"
+
+func TestConfigRequiresProxy(t *testing.T) {
+	if !config.MustProxy() {
+		t.Fatal("123Pan downloads must be proxied because direct links are bound to the requester's IP")
+	}
+}

--- a/drivers/123/util.go
+++ b/drivers/123/util.go
@@ -174,7 +174,7 @@ func (d *Pan123) login() error {
 		return err
 	}
 	if utils.Json.Get(res.Body(), "code").ToInt() != 200 {
-		err = fmt.Errorf(utils.Json.Get(res.Body(), "message").ToString())
+		err = errors.New(utils.Json.Get(res.Body(), "message").ToString())
 	} else {
 		d.AccessToken = utils.Json.Get(res.Body(), "data", "token").ToString()
 	}


### PR DESCRIPTION
## Summary

- force 123Pan downloads through AList's proxy
- remove ineffective client IP forwarding from download-info requests
- add a regression test for the proxy requirement
- return provider login errors without treating them as format strings

## Background

123Pan now binds the final CDN URL to the egress IP that resolves the download link. In a real deployment, the same freshly generated link returned HTTP 200 from the AList host but HTTP 403 with code 1010 and download err: 50001 from a client using a different egress IP.

Passing the client address through X-Forwarded-For, X-Real-IP, or both did not change the result. Proxying the file through AList keeps link resolution and download on the same egress IP and fixes the failure for existing storages regardless of their web_proxy setting.

This intentionally makes 123Pan downloads consume AList server bandwidth.

## Testing

- GOTOOLCHAIN=go1.25.0 go test ./drivers/123
- go test ./internal/driver ./internal/fs ./server/handles
