### PR TITLE
fix(archive): limit total decompressed size to prevent disk exhaustion

### DIFF
--- a/internal/archive/archives/archives.go
+++ b/internal/archive/archives/archives.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/archive/tool"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/setting"
 	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
@@ -96,6 +98,7 @@ func (Archives) Decompress(ss []*stream.SeekableStream, outputPath string, args 
 	if err != nil {
 		return err
 	}
+	limiter := tool.NewSizeLimiter(int64(setting.GetInt(conf.MaxExtractSize, 0)) << 30)
 	isDir := false
 	path := strings.TrimPrefix(args.InnerPath, "/")
 	if path == "" {
@@ -148,7 +151,7 @@ func (Archives) Decompress(ss []*stream.SeekableStream, outputPath string, args 
 			if err := os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 				return err
 			}
-			return decompress(fsys, p, dstPath, func(_ float64) {})
+			return decompress(fsys, p, dstPath, func(_ float64) {}, limiter)
 		})
 	} else {
 		entryName := stdpath.Base(path)
@@ -159,7 +162,7 @@ func (Archives) Decompress(ss []*stream.SeekableStream, outputPath string, args 
 		if err = os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 			return err
 		}
-		err = decompress(fsys, path, dstPath, up)
+		err = decompress(fsys, path, dstPath, up, limiter)
 	}
 	return filterPassword(err)
 }

--- a/internal/archive/archives/utils.go
+++ b/internal/archive/archives/utils.go
@@ -60,7 +60,7 @@ func filterPassword(err error) error {
 	return err
 }
 
-func decompress(fsys fs2.FS, filePath, dstPath string, up model.UpdateProgress) error {
+func decompress(fsys fs2.FS, filePath, dstPath string, up model.UpdateProgress, limiter *tool.SizeLimiter) error {
 	rc, err := fsys.Open(filePath)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func decompress(fsys fs2.FS, filePath, dstPath string, up model.UpdateProgress) 
 		return err
 	}
 	defer f.Close()
-	_, err = utils.CopyWithBuffer(f, &stream.ReaderUpdatingProgress{
+	_, err = utils.CopyWithBuffer(limiter.WrapWriter(f), &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: rc,
 			Size:   stat.Size(),

--- a/internal/archive/iso9660/iso9660.go
+++ b/internal/archive/iso9660/iso9660.go
@@ -5,8 +5,10 @@ import (
 	"os"
 
 	"github.com/alist-org/alist/v3/internal/archive/tool"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/setting"
 	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/kdomanski/iso9660"
 )
@@ -76,6 +78,7 @@ func (ISO9660) Decompress(ss []*stream.SeekableStream, outputPath string, args m
 	if err != nil {
 		return err
 	}
+	limiter := tool.NewSizeLimiter(int64(setting.GetInt(conf.MaxExtractSize, 0)) << 30)
 	if obj.IsDir() {
 		if args.InnerPath != "/" {
 			outputPath, err = tool.SecureJoin(outputPath, obj.Name())
@@ -88,10 +91,10 @@ func (ISO9660) Decompress(ss []*stream.SeekableStream, outputPath string, args m
 		}
 		var children []*iso9660.File
 		if children, err = obj.GetChildren(); err == nil {
-			err = decompressAll(children, outputPath)
+			err = decompressAll(children, outputPath, limiter)
 		}
 	} else {
-		err = decompress(obj, outputPath, up)
+		err = decompress(obj, outputPath, up, limiter)
 	}
 	return err
 }

--- a/internal/archive/iso9660/utils.go
+++ b/internal/archive/iso9660/utils.go
@@ -63,11 +63,11 @@ func toModelObj(file *iso9660.File) model.Obj {
 	}
 }
 
-func decompress(f *iso9660.File, path string, up model.UpdateProgress) error {
-	return decompressEntry(f.Reader(), f.Size(), path, f.Name(), up)
+func decompress(f *iso9660.File, path string, up model.UpdateProgress, limiter *tool.SizeLimiter) error {
+	return decompressEntry(f.Reader(), f.Size(), path, f.Name(), up, limiter)
 }
 
-func decompressEntry(reader io.Reader, size int64, path, entryName string, up model.UpdateProgress) error {
+func decompressEntry(reader io.Reader, size int64, path, entryName string, up model.UpdateProgress, limiter *tool.SizeLimiter) error {
 	dstPath, err := tool.SecureJoin(path, entryName)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func decompressEntry(reader io.Reader, size int64, path, entryName string, up mo
 		return err
 	}
 	defer file.Close()
-	_, err = utils.CopyWithBuffer(file, &stream.ReaderUpdatingProgress{
+	_, err = utils.CopyWithBuffer(limiter.WrapWriter(file), &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: reader,
 			Size:   size,
@@ -90,7 +90,7 @@ func decompressEntry(reader io.Reader, size int64, path, entryName string, up mo
 	return err
 }
 
-func decompressAll(children []*iso9660.File, path string) error {
+func decompressAll(children []*iso9660.File, path string, limiter *tool.SizeLimiter) error {
 	for _, child := range children {
 		if child.IsDir() {
 			nextChildren, err := child.GetChildren()
@@ -104,11 +104,11 @@ func decompressAll(children []*iso9660.File, path string) error {
 			if err = os.MkdirAll(nextPath, 0700); err != nil {
 				return err
 			}
-			if err = decompressAll(nextChildren, nextPath); err != nil {
+			if err = decompressAll(nextChildren, nextPath, limiter); err != nil {
 				return err
 			}
 		} else {
-			if err := decompress(child, path, func(_ float64) {}); err != nil {
+			if err := decompress(child, path, func(_ float64) {}, limiter); err != nil {
 				return err
 			}
 		}

--- a/internal/archive/rardecode/rardecode.go
+++ b/internal/archive/rardecode/rardecode.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/archive/tool"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/setting"
 	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/nwaples/rardecode/v2"
 )
@@ -74,6 +76,7 @@ func (RarDecoder) Decompress(ss []*stream.SeekableStream, outputPath string, arg
 	if err != nil {
 		return err
 	}
+	limiter := tool.NewSizeLimiter(int64(setting.GetInt(conf.MaxExtractSize, 0)) << 30)
 	if args.InnerPath == "/" {
 		for {
 			var header *rardecode.FileHeader
@@ -92,7 +95,7 @@ func (RarDecoder) Decompress(ss []*stream.SeekableStream, outputPath string, arg
 			if e != nil {
 				return e
 			}
-			err = decompress(reader, header, dstPath)
+			err = decompress(reader, header, dstPath, limiter)
 			if err != nil {
 				return err
 			}
@@ -139,7 +142,7 @@ func (RarDecoder) Decompress(ss []*stream.SeekableStream, outputPath string, arg
 				if err = os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 					return err
 				}
-				err = _decompress(reader, header, dstPath, up)
+				err = _decompress(reader, header, dstPath, up, limiter)
 				if err != nil {
 					return err
 				}
@@ -164,7 +167,7 @@ func (RarDecoder) Decompress(ss []*stream.SeekableStream, outputPath string, arg
 				if e != nil {
 					return e
 				}
-				err = decompress(reader, header, dstPath)
+				err = decompress(reader, header, dstPath, limiter)
 				if err != nil {
 					return err
 				}

--- a/internal/archive/rardecode/utils.go
+++ b/internal/archive/rardecode/utils.go
@@ -181,7 +181,7 @@ func getReader(ss []*stream.SeekableStream, password string) (*rardecode.Reader,
 	return &rc.Reader, nil
 }
 
-func decompress(reader *rardecode.Reader, header *rardecode.FileHeader, dstPath string) error {
+func decompress(reader *rardecode.Reader, header *rardecode.FileHeader, dstPath string, limiter *tool.SizeLimiter) error {
 	if header.IsDir {
 		return os.MkdirAll(dstPath, 0700)
 	}
@@ -191,16 +191,16 @@ func decompress(reader *rardecode.Reader, header *rardecode.FileHeader, dstPath 
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 		return err
 	}
-	return _decompress(reader, header, dstPath, func(_ float64) {})
+	return _decompress(reader, header, dstPath, func(_ float64) {}, limiter)
 }
 
-func _decompress(reader *rardecode.Reader, header *rardecode.FileHeader, dstPath string, up model.UpdateProgress) error {
+func _decompress(reader *rardecode.Reader, header *rardecode.FileHeader, dstPath string, up model.UpdateProgress, limiter *tool.SizeLimiter) error {
 	f, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	_, err = io.Copy(f, &stream.ReaderUpdatingProgress{
+	_, err = io.Copy(limiter.WrapWriter(f), &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: reader,
 			Size:   header.UnPackedSize,

--- a/internal/archive/sevenzip/sevenzip.go
+++ b/internal/archive/sevenzip/sevenzip.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/archive/tool"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/setting"
 	"github.com/alist-org/alist/v3/internal/stream"
 )
 
@@ -62,7 +64,8 @@ func (SevenZip) Decompress(ss []*stream.SeekableStream, outputPath string, args 
 	if err != nil {
 		return err
 	}
-	return tool.DecompressFromFolderTraversal(&WrapReader{Reader: reader}, outputPath, args, up)
+	limiter := tool.NewSizeLimiter(int64(setting.GetInt(conf.MaxExtractSize, 0)) << 30)
+	return tool.DecompressFromFolderTraversal(&WrapReader{Reader: reader}, outputPath, args, up, limiter)
 }
 
 var _ tool.Tool = (*SevenZip)(nil)

--- a/internal/archive/tool/helper.go
+++ b/internal/archive/tool/helper.go
@@ -115,7 +115,7 @@ type WrapFileInfo struct {
 	model.Obj
 }
 
-func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args model.ArchiveInnerArgs, up model.UpdateProgress) error {
+func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args model.ArchiveInnerArgs, up model.UpdateProgress, limiter *SizeLimiter) error {
 	var err error
 	files := r.Files()
 	if args.InnerPath == "/" {
@@ -144,7 +144,7 @@ func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args mode
 			if err = os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 				return err
 			}
-			err = _decompress(file, dstPath, args.Password, func(_ float64) {})
+			err = _decompress(file, dstPath, args.Password, func(_ float64) {}, limiter)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args mode
 				if err = os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 					return err
 				}
-				err = _decompress(file, dstPath, args.Password, up)
+				err = _decompress(file, dstPath, args.Password, up, limiter)
 				if err != nil {
 					return err
 				}
@@ -227,7 +227,7 @@ func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args mode
 				if err = os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
 					return err
 				}
-				err = _decompress(file, dstPath, args.Password, func(_ float64) {})
+				err = _decompress(file, dstPath, args.Password, func(_ float64) {}, limiter)
 				if err != nil {
 					return err
 				}
@@ -237,7 +237,7 @@ func DecompressFromFolderTraversal(r ArchiveReader, outputPath string, args mode
 	return nil
 }
 
-func _decompress(file SubFile, dstPath, password string, up model.UpdateProgress) error {
+func _decompress(file SubFile, dstPath, password string, up model.UpdateProgress, limiter *SizeLimiter) error {
 	if encrypt, ok := file.(CanEncryptSubFile); ok && encrypt.IsEncrypted() {
 		encrypt.SetPassword(password)
 	}
@@ -251,7 +251,7 @@ func _decompress(file SubFile, dstPath, password string, up model.UpdateProgress
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	_, err = io.Copy(f, &stream.ReaderUpdatingProgress{
+	_, err = io.Copy(limiter.WrapWriter(f), &stream.ReaderUpdatingProgress{
 		Reader: &stream.SimpleReaderWithSize{
 			Reader: rc,
 			Size:   file.FileInfo().Size(),

--- a/internal/archive/tool/limiter.go
+++ b/internal/archive/tool/limiter.go
@@ -1,0 +1,42 @@
+package tool
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+)
+
+var ErrExtractSizeExceeded = errors.New("total size of decompressed files exceeds the limit")
+
+// SizeLimiter limits the total bytes written by one decompress task.
+// A non-positive max means no limit.
+type SizeLimiter struct {
+	remain  int64
+	limited bool
+}
+
+func NewSizeLimiter(max int64) *SizeLimiter {
+	if max <= 0 {
+		return &SizeLimiter{}
+	}
+	return &SizeLimiter{remain: max, limited: true}
+}
+
+func (l *SizeLimiter) WrapWriter(w io.Writer) io.Writer {
+	if l == nil || !l.limited {
+		return w
+	}
+	return &limitedWriter{w: w, limiter: l}
+}
+
+type limitedWriter struct {
+	w       io.Writer
+	limiter *SizeLimiter
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if atomic.AddInt64(&lw.limiter.remain, -int64(len(p))) < 0 {
+		return 0, ErrExtractSizeExceeded
+	}
+	return lw.w.Write(p)
+}

--- a/internal/archive/tool/limiter_test.go
+++ b/internal/archive/tool/limiter_test.go
@@ -1,0 +1,38 @@
+package tool
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSizeLimiterExceeded(t *testing.T) {
+	l := NewSizeLimiter(10)
+	var buf bytes.Buffer
+	_, err := io.Copy(l.WrapWriter(&buf), strings.NewReader("0123456789abcdef"))
+	if !errors.Is(err, ErrExtractSizeExceeded) {
+		t.Fatalf("expected ErrExtractSizeExceeded, got %v", err)
+	}
+}
+
+func TestSizeLimiterSharedAcrossWriters(t *testing.T) {
+	l := NewSizeLimiter(10)
+	var a, b bytes.Buffer
+	if _, err := l.WrapWriter(&a).Write([]byte("123456")); err != nil {
+		t.Fatalf("first write should pass, got %v", err)
+	}
+	if _, err := l.WrapWriter(&b).Write([]byte("123456")); !errors.Is(err, ErrExtractSizeExceeded) {
+		t.Fatalf("expected ErrExtractSizeExceeded, got %v", err)
+	}
+}
+
+func TestSizeLimiterUnlimited(t *testing.T) {
+	l := NewSizeLimiter(0)
+	var buf bytes.Buffer
+	n, err := io.Copy(l.WrapWriter(&buf), strings.NewReader("0123456789abcdef"))
+	if err != nil || n != 16 {
+		t.Fatalf("unlimited limiter should pass all data, n=%d err=%v", n, err)
+	}
+}

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/archive/tool"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/setting"
 	"github.com/alist-org/alist/v3/internal/stream"
 )
 
@@ -122,7 +124,8 @@ func (Zip) Decompress(ss []*stream.SeekableStream, outputPath string, args model
 	if err != nil {
 		return err
 	}
-	return tool.DecompressFromFolderTraversal(&WrapReader{Reader: zipReader}, outputPath, args, up)
+	limiter := tool.NewSizeLimiter(int64(setting.GetInt(conf.MaxExtractSize, 0)) << 30)
+	return tool.DecompressFromFolderTraversal(&WrapReader{Reader: zipReader}, outputPath, args, up, limiter)
 }
 
 var _ tool.Tool = (*Zip)(nil)

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -172,6 +172,7 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.DeviceEvictPolicy, Value: "deny", Type: conf.TypeSelect, Options: "deny,evict_oldest", Group: model.GLOBAL},
 		{Key: conf.DeviceSessionTTL, Value: "86400", Type: conf.TypeNumber, Group: model.GLOBAL},
 		{Key: conf.MetaNotFoundCacheExpire, Value: "60", Type: conf.TypeNumber, Group: model.GLOBAL, Flag: model.PRIVATE, Help: "Negative cache expiration for missing meta records, in seconds. Set 0 to disable."},
+		{Key: conf.MaxExtractSize, Value: "0", Type: conf.TypeNumber, Group: model.GLOBAL, Flag: model.PRIVATE, Help: "Max total size of files decompressed by a single task, in GB. Set 0 for unlimited."},
 
 		// single settings
 		{Key: conf.Token, Value: token, Type: conf.TypeString, Group: model.SINGLE, Flag: model.PRIVATE},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -54,6 +54,7 @@ const (
 	DeviceEvictPolicy       = "device_evict_policy"
 	DeviceSessionTTL        = "device_session_ttl"
 	MetaNotFoundCacheExpire = "meta_not_found_cache_expire"
+	MaxExtractSize          = "max_extract_size"
 
 	// index
 	SearchIndex     = "search_index"


### PR DESCRIPTION
Adds an output-size cap for archive decompression to address the disk exhaustion issue reported in #9582.

- New global setting `max_extract_size` (GB, private, default 0 = unlimited): max total size of files written by a single decompress task.
- `tool.SizeLimiter` wraps the destination writer and aborts the task with an error once the cap is reached. The counter is shared across all entries of one task, so many small files are limited the same as one huge file.
- Enforced in all decompress paths: zip, 7z (folder traversal helper), rar, tar/gz/bz2/xz family (mholt/archives), and iso9660.
- Default stays unlimited to avoid breaking existing large extract workflows; admins can set a cap under global settings.

Close #9582