### PR TITLE
fix(net): bound overload retries and fail fast on unrecoverable download errors

### DIFF
--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -331,6 +331,7 @@ func (d *downloader) downloadChunk(ch *chunk) error {
 	params := d.getParamsFromChunk(ch)
 	var n int64
 	var err error
+	overloadRetry := 0
 	for retry := 0; retry <= d.cfg.PartBodyMaxRetries; retry++ {
 		if d.getErr() != nil {
 			return nil
@@ -363,7 +364,21 @@ func (d *downloader) downloadChunk(ch *chunk) error {
 			}
 			log.Warnf("err chunk_%d, object part download error %s, retrying attempt %d. %v",
 				ch.id, params.URL, retry, err)
-		} else if err == errInfiniteRetry {
+		} else if err == errOverloadRetry {
+			overloadRetry++
+			if overloadRetry > d.cfg.PartBodyMaxRetries*10 {
+				err = fmt.Errorf("chunk_%d: giving up after %d retries while server is overloaded", ch.id, overloadRetry)
+				break
+			}
+			backoff := time.Duration(overloadRetry) * 100 * time.Millisecond
+			if backoff > 2*time.Second {
+				backoff = 2 * time.Second
+			}
+			select {
+			case <-d.ctx.Done():
+				return d.ctx.Err()
+			case <-time.After(backoff):
+			}
 			retry--
 			continue
 		} else {
@@ -375,7 +390,7 @@ func (d *downloader) downloadChunk(ch *chunk) error {
 }
 
 var errCancelConcurrency = fmt.Errorf("cancel concurrency")
-var errInfiniteRetry = fmt.Errorf("infinite retry")
+var errOverloadRetry = fmt.Errorf("overload retry")
 
 func (d *downloader) tryDownloadChunk(params *HttpRequestParams, ch *chunk) (int64, error) {
 	resp, err := d.cfg.HttpClient(d.ctx, params)
@@ -400,7 +415,12 @@ func (d *downloader) tryDownloadChunk(params *HttpRequestParams, ch *chunk) (int
 		}
 
 		// 来到这 说明第1个分片下载 连接成功了
-		// 后续分片下载出错都当超载处理
+		// 后续分片仅在限流/网关类错误时当超载处理，其余错误（如链接过期 403）直接失败
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		default:
+			return 0, err
+		}
 		log.Debugf("err chunk_%d, try downloading:%v", ch.id, err)
 
 		d.m.Lock()
@@ -422,7 +442,7 @@ func (d *downloader) tryDownloadChunk(params *HttpRequestParams, ch *chunk) (int
 			defer d.m2.Unlock()
 			<-time.After(time.Millisecond * 200)
 		}
-		return 0, errInfiniteRetry
+		return 0, errOverloadRetry
 	}
 	defer resp.Body.Close()
 	//only check file size on the first task

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -264,7 +264,7 @@ func (ss *SeekableStream) Read(p []byte) (n int, err error) {
 		}
 		rc, err := ss.rangeReadCloser.RangeRead(ss.Ctx, http_range.Range{Length: -1})
 		if err != nil {
-			return 0, nil
+			return 0, err
 		}
 		ss.Reader = io.NopCloser(rc)
 	}


### PR DESCRIPTION
Fixes the busy-loop that pegs the CPU during multi-file copies from Quark (and any driver that forces the concurrent range downloader).

Root cause: for chunks other than the first one, any HTTP error was treated as server overload and retried forever (`retry--` on `errInfiniteRetry`), with no sleep at all when the failing chunk was the one currently being read. Once a download link expired mid-transfer (e.g. 403 from Quark), the downloader spun on the dead URL indefinitely, and the stuck task never released its global concurrency slots, dragging every other task into the same busy-wait.

Changes:
- Only 429/502/503/504 take the overload-retry path for subsequent chunks; other statuses (expired links, 403/404, ...) fail the chunk immediately so the task layer can retry with a fresh link.
- Overload retries are now bounded (`PartBodyMaxRetries * 10`) with incremental backoff (100ms per attempt, capped at 2s) and honor context cancellation.
- `SeekableStream.Read` no longer swallows `RangeRead` errors by returning `(0, nil)`, which made callers like `io.ReadFull`/`CopyWithBuffer` re-invoke the whole download path in a tight loop; the error now propagates.

Note: `TestDownloadOrder` already fails on main (verified on a clean checkout); no new test regressions are introduced.

The upload-side memory fix for the same copy scenario is submitted separately.

Close #9288
Ref #9374