### PR TITLE
feat(quark_uc): make ranged download concurrency and part size configurable

### DIFF
--- a/drivers/quark_uc/driver.go
+++ b/drivers/quark_uc/driver.go
@@ -38,12 +38,21 @@ func (d *QuarkOrUC) GetAddition() driver.Additional {
 
 func (d *QuarkOrUC) Init(ctx context.Context) error {
 	_, err := d.request("/config", http.MethodGet, nil, nil)
-	if err == nil && d.AdditionVersion != 2 {
-		d.AdditionVersion = 2
-		if !d.UseTransCodingAddress && len(d.DownProxyUrl) == 0 {
-			d.WebProxy = true
-			d.WebdavPolicy = "native_proxy"
+	if err == nil && d.AdditionVersion != 3 {
+		if d.AdditionVersion < 2 {
+			if !d.UseTransCodingAddress && len(d.DownProxyUrl) == 0 {
+				d.WebProxy = true
+				d.WebdavPolicy = "native_proxy"
+			}
 		}
+		// 老存储没有这两个字段，补成原来的固定值，保持行为不变
+		if d.DownConcurrency <= 0 {
+			d.DownConcurrency = 3
+		}
+		if d.DownPartSize <= 0 {
+			d.DownPartSize = 10
+		}
+		d.AdditionVersion = 3
 		op.MustSaveDriverStorage(d)
 	}
 	return err

--- a/drivers/quark_uc/meta.go
+++ b/drivers/quark_uc/meta.go
@@ -12,6 +12,8 @@ type Addition struct {
 	OrderDirection        string `json:"order_direction" type:"select" options:"asc,desc" default:"asc"`
 	UseTransCodingAddress bool   `json:"use_transcoding_address" help:"You can watch the transcoded video and support 302 redirection" required:"true" default:"false"`
 	OnlyListVideoFile     bool   `json:"only_list_video_file" default:"false"`
+	DownConcurrency       int    `json:"down_concurrency" type:"number" default:"3" help:"concurrency of ranged download, 0 to disable ranged download"`
+	DownPartSize          int    `json:"down_part_size" type:"number" default:"10" help:"part size (MB) of ranged download"`
 	AdditionVersion       int
 }
 

--- a/drivers/quark_uc/util.go
+++ b/drivers/quark_uc/util.go
@@ -119,16 +119,29 @@ func (d *QuarkOrUC) getDownloadLink(file model.Obj) (*model.Link, error) {
 		return nil, err
 	}
 
-	return &model.Link{
+	link := &model.Link{
 		URL: resp.Data[0].DownloadUrl,
 		Header: http.Header{
 			"Cookie":     []string{d.Cookie},
 			"Referer":    []string{d.conf.referer},
 			"User-Agent": []string{ua},
 		},
-		Concurrency: 3,
-		PartSize:    10 * utils.MB,
-	}, nil
+	}
+	d.applyLinkLimit(link)
+	return link, nil
+}
+
+// applyLinkLimit 按存储配置设置分片下载参数，DownConcurrency 为 0 时不强制分片下载
+func (d *QuarkOrUC) applyLinkLimit(link *model.Link) {
+	if d.DownConcurrency <= 0 {
+		return
+	}
+	partSize := d.DownPartSize
+	if partSize <= 0 {
+		partSize = 10
+	}
+	link.Concurrency = d.DownConcurrency
+	link.PartSize = partSize * utils.MB
 }
 
 func (d *QuarkOrUC) getTranscodingLink(file model.Obj) (*model.Link, error) {
@@ -150,11 +163,11 @@ func (d *QuarkOrUC) getTranscodingLink(file model.Obj) (*model.Link, error) {
 
 	for _, info := range resp.Data.VideoList {
 		if info.VideoInfo.URL != "" {
-			return &model.Link{
-				URL:         info.VideoInfo.URL,
-				Concurrency: 3,
-				PartSize:    10 * utils.MB,
-			}, nil
+			link := &model.Link{
+				URL: info.VideoInfo.URL,
+			}
+			d.applyLinkLimit(link)
+			return link, nil
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #9590 / #9288. Quark and UC currently hardcode every download link to `Concurrency: 3, PartSize: 10MB`, which forces all traffic through the concurrent range downloader with no way to tune it per deployment.

- New storage options `down_concurrency` (default 3) and `down_part_size` (default 10 MB) on Quark/UC, applied to both download and transcoding links.
- Setting `down_concurrency` to 0 disables forced ranged download entirely and falls back to a plain single stream, which is easier on memory and on Quark's rate limits for multi-file copy tasks.
- Existing storages are migrated via `AdditionVersion` (bumped to 3) and get the previous fixed values, so behavior does not change unless the options are edited.

Ref #9288
Ref #9374