### PR TITLE
fix(quark): refresh __puus cookie periodically to keep download signa…

### DIFF
--- a/drivers/quark_uc/driver.go
+++ b/drivers/quark_uc/driver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -26,6 +27,15 @@ type QuarkOrUC struct {
 	Addition
 	config driver.Config
 	conf   Conf
+
+	// client 用于测试时注入自定义 client，nil 时使用全局 base.RestyClient
+	client *resty.Client
+
+	// cookieMu 保护 d.Cookie 的读-改-写，避免多 goroutine（定时刷新 + 并发业务请求）竞态
+	cookieMu sync.Mutex
+
+	refreshMu sync.Mutex
+	cancel    context.CancelFunc
 }
 
 func (d *QuarkOrUC) Config() driver.Config {
@@ -46,10 +56,18 @@ func (d *QuarkOrUC) Init(ctx context.Context) error {
 		}
 		op.MustSaveDriverStorage(d)
 	}
+	// 定时刷新 __puus，避免会话 cookie 过期后下载 403（见 AlistGo/alist#830）
+	d.startRefreshLoop()
 	return err
 }
 
 func (d *QuarkOrUC) Drop(ctx context.Context) error {
+	d.refreshMu.Lock()
+	defer d.refreshMu.Unlock()
+	if d.cancel != nil {
+		d.cancel()
+		d.cancel = nil
+	}
 	return nil
 }
 

--- a/drivers/quark_uc/util.go
+++ b/drivers/quark_uc/util.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -24,11 +25,37 @@ import (
 
 // do others that not defined in Driver interface
 
+// puusRefreshInterval __puus 有效期约 3 小时，提前定时刷新，见 AlistGo/alist#830。
+// 100 分钟刷新一次，叠加 ±5 分钟（精确到秒）的随机抖动，
+// 避免多个实例/账号在同一时刻集中刷新
+const (
+	puusRefreshInterval = 100 * time.Minute
+	puusRefreshJitter   = 5 * time.Minute
+)
+
+// refreshJitter 返回 [-5min, +5min] 的随机抖动，精确到秒
+func refreshJitter() time.Duration {
+	seconds := rand.Int63n(2*int64(puusRefreshJitter/time.Second)+1) - int64(puusRefreshJitter/time.Second)
+	return time.Duration(seconds) * time.Second
+}
+
 func (d *QuarkOrUC) request(pathname string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	d.cookieMu.Lock()
+	cookieStr := d.Cookie
+	d.cookieMu.Unlock()
+	return d.requestWithCookie(pathname, method, callback, resp, cookieStr)
+}
+
+// requestWithCookie 使用指定的 cookie 发起请求，响应中的 __puus/__pus 会合并回 d.Cookie
+func (d *QuarkOrUC) requestWithCookie(pathname string, method string, callback base.ReqCallback, resp interface{}, cookieStr string) ([]byte, error) {
 	u := d.conf.api + pathname
-	req := base.RestyClient.R()
+	client := base.RestyClient
+	if d.client != nil {
+		client = d.client
+	}
+	req := client.R()
 	req.SetHeaders(map[string]string{
-		"Cookie":  d.Cookie,
+		"Cookie":  cookieStr,
 		"Accept":  "application/json, text/plain, */*",
 		"Referer": d.conf.referer,
 	})
@@ -46,17 +73,23 @@ func (d *QuarkOrUC) request(pathname string, method string, callback base.ReqCal
 	if err != nil {
 		return nil, err
 	}
+	var updated bool
+	d.cookieMu.Lock()
 	__puus := cookie.GetCookie(res.Cookies(), "__puus")
 	if __puus != nil {
 		d.Cookie = cookie.SetStr(d.Cookie, "__puus", __puus.Value)
-		op.MustSaveDriverStorage(d)
+		updated = true
 	}
 	if d.UseTransCodingAddress && d.config.Name == "Quark" {
 		__pus := cookie.GetCookie(res.Cookies(), "__pus")
 		if __pus != nil {
 			d.Cookie = cookie.SetStr(d.Cookie, "__pus", __pus.Value)
-			op.MustSaveDriverStorage(d)
+			updated = true
 		}
+	}
+	d.cookieMu.Unlock()
+	if updated {
+		op.MustSaveDriverStorage(d)
 	}
 	if e.Status >= 400 || e.Code != 0 {
 		return nil, errors.New(e.Message)
@@ -111,10 +144,16 @@ func (d *QuarkOrUC) getDownloadLink(file model.Obj) (*model.Link, error) {
 	}
 	var resp DownResp
 	ua := d.conf.ua
-	_, err := d.request("/file/download", http.MethodPost, func(req *resty.Request) {
+	// 快照请求前的 cookie：下载 URL 的签名基于请求 /file/download 时携带的 cookie 生成，
+	// 下载请求头必须与之一致，否则会被上游判定签名无效返回 403。
+	// 请求和下载头使用同一个快照，避免定时刷新并发修改 d.Cookie 导致两者不一致。
+	d.cookieMu.Lock()
+	reqCookie := d.Cookie
+	d.cookieMu.Unlock()
+	_, err := d.requestWithCookie("/file/download", http.MethodPost, func(req *resty.Request) {
 		req.SetHeader("User-Agent", ua).
 			SetBody(data)
-	}, &resp)
+	}, &resp, reqCookie)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +161,73 @@ func (d *QuarkOrUC) getDownloadLink(file model.Obj) (*model.Link, error) {
 	return &model.Link{
 		URL: resp.Data[0].DownloadUrl,
 		Header: http.Header{
-			"Cookie":     []string{d.Cookie},
+			"Cookie":     []string{reqCookie},
 			"Referer":    []string{d.conf.referer},
 			"User-Agent": []string{ua},
 		},
 		Concurrency: 3,
 		PartSize:    10 * utils.MB,
 	}, nil
+}
+
+// startRefreshLoop 启动 __puus 定时刷新，保证会话 cookie 不过期
+func (d *QuarkOrUC) startRefreshLoop() {
+	d.refreshMu.Lock()
+	defer d.refreshMu.Unlock()
+	if d.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	d.cancel = cancel
+	go d.refreshLoop(ctx)
+}
+
+func (d *QuarkOrUC) refreshLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(puusRefreshInterval + refreshJitter()):
+			_ = d.refreshPuus()
+		}
+	}
+}
+
+// maskSecret 打码敏感值，仅用于日志展示
+func maskSecret(s string) string {
+	if len(s) <= 8 {
+		return "***"
+	}
+	return s[:8] + "***"
+}
+
+// refreshPuus 发起一次不带 __puus 的请求，让服务端重新下发会话 cookie。
+// 服务端只在请求缺失 __puus 字段时才更新该 cookie（见 AlistGo/alist#830）。
+func (d *QuarkOrUC) refreshPuus() error {
+	d.cookieMu.Lock()
+	old := d.Cookie
+	stripped := cookie.DelStr(old, "__puus")
+	d.cookieMu.Unlock()
+	_, err := d.requestWithCookie("/config", http.MethodGet, nil, nil, stripped)
+	d.cookieMu.Lock()
+	defer d.cookieMu.Unlock()
+	if err != nil {
+		// 刷新失败：仅当没有其他请求带来更新的 __puus 时才恢复旧值，
+		// 避免覆盖并发请求刚合并进来的新 cookie
+		if cookie.GetStr(d.Cookie, "__puus") == "" {
+			d.Cookie = old
+		}
+		log.Warnf("quark: refresh __puus failed: %v", err)
+		return err
+	}
+	if cookie.GetStr(d.Cookie, "__puus") == "" {
+		// 服务端未重新下发：同样只在没有并发新值时恢复旧值
+		d.Cookie = old
+		log.Infof("quark: __puus not refreshed, server did not reissue a new value, keeping existing cookie")
+		return nil
+	}
+	log.Infof("quark: __puus refreshed successfully: %s", maskSecret(cookie.GetStr(d.Cookie, "__puus")))
+	return nil
 }
 
 func (d *QuarkOrUC) getTranscodingLink(file model.Obj) (*model.Link, error) {

--- a/drivers/quark_uc/util_test.go
+++ b/drivers/quark_uc/util_test.go
@@ -1,0 +1,304 @@
+package quark
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/db"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/pkg/cookie"
+	"github.com/go-resty/resty/v2"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestMain(m *testing.M) {
+	// 初始化内存数据库，保证 op.MustSaveDriverStorage 在测试中安全执行
+	conf.Conf = conf.DefaultConfig()
+	d, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+	db.Init(d)
+	os.Exit(m.Run())
+}
+
+var testDriverSeq int
+
+func newTestDriver(srvURL string) *QuarkOrUC {
+	testDriverSeq++
+	d := &QuarkOrUC{Storage: model.Storage{MountPath: fmt.Sprintf("test-%d", testDriverSeq)}}
+	d.conf = Conf{
+		ua:      "test-ua",
+		referer: "https://pan.quark.cn",
+		api:     srvURL + "/1/clouddrive",
+		pr:      "ucpro",
+	}
+	d.client = resty.New()
+	return d
+}
+
+// recordHandler 记录收到的请求路径并转发给 handler
+type recordHandler struct {
+	mu      sync.Mutex
+	paths   []string
+	handler http.HandlerFunc
+}
+
+func (r *recordHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mu.Lock()
+	r.paths = append(r.paths, req.URL.Path)
+	r.mu.Unlock()
+	r.handler(w, req)
+}
+
+func (r *recordHandler) Paths() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.paths...)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func TestRefreshPuus(t *testing.T) {
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/clouddrive/config" {
+			http.NotFound(w, r)
+			return
+		}
+		if c := r.Header.Get("Cookie"); strings.Contains(c, "__puus") {
+			t.Errorf("refresh request must not carry __puus, got cookie: %q", c)
+		}
+		w.Header().Add("Set-Cookie", "__puus=newpuus; Path=/")
+		writeJSON(w, 200, Resp{Status: 200, Code: 0, Message: "ok"})
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "a=1; __puus=oldpuus; b=2"
+
+	if err := d.refreshPuus(); err != nil {
+		t.Fatalf("refreshPuus: %v", err)
+	}
+	if !strings.Contains(d.Cookie, "__puus=newpuus") {
+		t.Fatalf("cookie not refreshed: %q", d.Cookie)
+	}
+	if !strings.Contains(d.Cookie, "a=1") || !strings.Contains(d.Cookie, "b=2") {
+		t.Fatalf("refresh dropped unrelated cookies: %q", d.Cookie)
+	}
+	if len(rec.Paths()) != 1 || rec.Paths()[0] != "/1/clouddrive/config" {
+		t.Fatalf("unexpected requests: %v", rec.Paths())
+	}
+}
+
+func TestRefreshPuusRestoresCookieOnError(t *testing.T) {
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 500, Resp{Status: 500, Code: 0, Message: "boom"})
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "a=1; __puus=oldpuus; b=2"
+
+	if err := d.refreshPuus(); err == nil {
+		t.Fatal("want error from refreshPuus")
+	}
+	if d.Cookie != "a=1; __puus=oldpuus; b=2" {
+		t.Fatalf("cookie not restored after error: %q", d.Cookie)
+	}
+}
+
+func TestRefreshPuusRestoresCookieWhenServerDoesNotReissue(t *testing.T) {
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		// 服务端没有下发新的 __puus
+		writeJSON(w, 200, Resp{Status: 200, Code: 0, Message: "ok"})
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "a=1; __puus=oldpuus; b=2"
+
+	if err := d.refreshPuus(); err != nil {
+		t.Fatalf("refreshPuus: %v", err)
+	}
+	if d.Cookie != "a=1; __puus=oldpuus; b=2" {
+		t.Fatalf("cookie should be restored when server does not reissue: %q", d.Cookie)
+	}
+}
+
+func TestRefreshPuusWithEmptyCookie(t *testing.T) {
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		if c := r.Header.Get("Cookie"); c != "" {
+			t.Errorf("request cookie should be empty, got %q", c)
+		}
+		w.Header().Add("Set-Cookie", "__puus=newpuus; Path=/")
+		writeJSON(w, 200, Resp{Status: 200, Code: 0, Message: "ok"})
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = ""
+
+	if err := d.refreshPuus(); err != nil {
+		t.Fatalf("refreshPuus: %v", err)
+	}
+	if !strings.Contains(d.Cookie, "__puus=newpuus") {
+		t.Fatalf("cookie not refreshed: %q", d.Cookie)
+	}
+}
+
+func TestGetDownloadLinkUsesRequestTimeCookie(t *testing.T) {
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/1/clouddrive/file/download":
+			// 响应轮换 __puus，但下载 URL 签名基于请求时携带的 cookie
+			w.Header().Add("Set-Cookie", "__puus=rotated; Path=/")
+			writeJSON(w, 200, map[string]interface{}{
+				"status": 200, "code": 0, "message": "ok",
+				"data": []map[string]string{{"download_url": "https://cdn.example.com/f?sign=1"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "__puus=pre"
+
+	link, err := d.getDownloadLink(&File{Fid: "f1"})
+	if err != nil {
+		t.Fatalf("getDownloadLink: %v", err)
+	}
+	// 下载请求头必须使用生成签名时的 cookie（快照），而不是响应更新后的值
+	if got := link.Header.Get("Cookie"); got != "__puus=pre" {
+		t.Fatalf("download header cookie = %q, want snapshot %q", got, "__puus=pre")
+	}
+	if !strings.Contains(d.Cookie, "__puus=rotated") {
+		t.Fatalf("driver cookie should be updated with rotated value: %q", d.Cookie)
+	}
+	if link.URL != "https://cdn.example.com/f?sign=1" {
+		t.Fatalf("link url = %q", link.URL)
+	}
+	if link.Header.Get("User-Agent") != "test-ua" || link.Header.Get("Referer") != "https://pan.quark.cn" {
+		t.Fatalf("unexpected link headers: %v", link.Header)
+	}
+}
+
+func TestRefreshJitterWithinBounds(t *testing.T) {
+	const (
+		min = -puusRefreshJitter
+		max = puusRefreshJitter
+	)
+	for i := 0; i < 1000; i++ {
+		d := refreshJitter()
+		if d < min || d > max {
+			t.Fatalf("refreshJitter() = %v, want within [%v, %v]", d, min, max)
+		}
+		if d%time.Second != 0 {
+			t.Fatalf("refreshJitter() = %v, want precise to second", d)
+		}
+	}
+}
+
+var _ model.Obj = (*File)(nil)
+
+// TestRefreshPuusFailurePreservesConcurrentUpdate 验证：刷新失败时，
+// 如果并发请求已经带来了新的 __puus，恢复逻辑不能覆盖它
+func TestRefreshPuusFailurePreservesConcurrentUpdate(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release // 阻塞，模拟慢响应，制造并发窗口
+		writeJSON(w, 500, Resp{Status: 500, Code: 0, Message: "boom"})
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "a=1; __puus=old; b=2"
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.refreshPuus()
+	}()
+
+	<-started // 刷新请求已发出（此时请求头不带 __puus）
+	// 模拟并发业务请求的响应合并了新的 __puus
+	d.cookieMu.Lock()
+	d.Cookie = cookie.SetStr(d.Cookie, "__puus", "concurrent-new")
+	d.cookieMu.Unlock()
+	close(release) // 放行，刷新请求返回 500
+
+	if err := <-errCh; err == nil {
+		t.Fatal("want error from refreshPuus")
+	}
+	// 并发写入的新值不能被失败恢复逻辑覆盖
+	if !strings.Contains(d.Cookie, "__puus=concurrent-new") {
+		t.Fatalf("concurrent __puus update was clobbered: %q", d.Cookie)
+	}
+}
+
+// TestRefreshPuusDoesNotDisturbConcurrentDownload 验证：刷新请求在途时，
+// d.Cookie 不会被 strip，并发下载仍使用完整 cookie 快照
+func TestRefreshPuusDoesNotDisturbConcurrentDownload(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	rec := &recordHandler{handler: func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/1/clouddrive/config":
+			close(started)
+			<-release
+			writeJSON(w, 200, Resp{Status: 200, Code: 0, Message: "ok"})
+		case "/1/clouddrive/file/download":
+			writeJSON(w, 200, map[string]interface{}{
+				"status": 200, "code": 0, "message": "ok",
+				"data": []map[string]string{{"download_url": "https://cdn.example.com/f?sign=1"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	d := newTestDriver(srv.URL)
+	d.Cookie = "a=1; __puus=old; b=2"
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.refreshPuus()
+	}()
+
+	<-started // 刷新请求在途
+	// 并发下载：应拿到完整（未 strip）的 cookie 快照
+	link, err := d.getDownloadLink(&File{Fid: "f1"})
+	if err != nil {
+		t.Fatalf("getDownloadLink during refresh: %v", err)
+	}
+	if got := link.Header.Get("Cookie"); !strings.Contains(got, "__puus=old") {
+		t.Fatalf("download header cookie during refresh = %q, want it to keep __puus", got)
+	}
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("refreshPuus: %v", err)
+	}
+}

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -57,3 +57,15 @@ func GetStr(cookiesStr, name string) string {
 	}
 	return cookie.Value
 }
+
+// DelStr 从 cookie 串中删除指定名称的 cookie
+func DelStr(cookiesStr, name string) string {
+	cookies := Parse(cookiesStr)
+	for i, cookie := range cookies {
+		if cookie.Name == name {
+			cookies = append(cookies[:i], cookies[i+1:]...)
+			break
+		}
+	}
+	return ToString(cookies)
+}

--- a/pkg/cookie/cookie_test.go
+++ b/pkg/cookie/cookie_test.go
@@ -1,0 +1,36 @@
+package cookie
+
+import "testing"
+
+func TestDelStr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		del  string
+		want string
+	}{
+		{"delete middle", "a=1; __puus=old; b=2", "__puus", "a=1;b=2"},
+		{"delete first", "__puus=old; a=1", "__puus", "a=1"},
+		{"delete last", "a=1; __puus=old", "__puus", "a=1"},
+		{"missing name is no-op", "a=1; b=2", "__puus", "a=1;b=2"},
+		{"empty input", "", "__puus", ""},
+		{"only the target", "__puus=old", "__puus", ""},
+		{"only removes first occurrence", "a=1; __puus=x; b=2; __puus=y", "__puus", "a=1;b=2;__puus=y"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DelStr(c.in, c.del); got != c.want {
+				t.Fatalf("DelStr(%q, %q) = %q, want %q", c.in, c.del, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSetStrAndDelStrRoundTrip(t *testing.T) {
+	// SetStr 更新后 DelStr 删除，应回到初始状态（不含被更新的字段）
+	got := DelStr(SetStr("a=1; __puus=old; b=2", "__puus", "new"), "__puus")
+	want := "a=1;b=2"
+	if got != want {
+		t.Fatalf("round trip = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
…ture valid

The __puus session cookie expires after about 3 hours (see #830). Quark only re-issues it when a request does not carry the __puus field, but the driver always sends the stored cookie, so once it expires the driver can never refresh it in-process: file listing keeps working while downloads fail with 403 until restart.

- add a background loop that sends a /config request without __puus every 100 minutes (with jitter) and persists the reissued cookie, with success/failure logs
- use the request-time cookie snapshot for the download header so it always matches the signature generated by /file/download
- protect d.Cookie read-modify-write with a mutex to avoid races between the refresh loop and concurrent requests
- add cookie.DelStr helper and unit tests (httptest mocked endpoints, including concurrent scenarios, -race clean)

Related #830
The fix in #872 is still not correct it seems.