### PR TITLE
fix(thunder): persist login token and clear consumed credit key

### DIFF
--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-resty/resty/v2"
+	log "github.com/sirupsen/logrus"
 )
 
 type Thunder struct {
@@ -121,16 +122,26 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 		// 优先使用已保存的 RefreshToken 恢复登录态，避免每次重启都触发风控验证
 		if x.Addition.RefreshToken != "" {
 			token, err := x.XunLeiCommon.RefreshToken(x.Addition.RefreshToken)
-			if err == nil && token != nil && token.RefreshToken != "" {
+			if err == nil && token != nil && token.AccessToken != "" {
 				x.SetTokenResp(token)
-				// 更新并持久化最新的 refresh token
-				x.Addition.RefreshToken = token.RefreshToken
+				// 更新并持久化最新的 refresh token（服务端未轮换时保留旧值）
+				if token.RefreshToken != "" {
+					x.Addition.RefreshToken = token.RefreshToken
+				}
 				// 清空已消费的信任密钥并落库
 				x.Addition.CreditKey = ""
 				op.MustSaveDriverStorage(x)
+				log.Infof("thunder: session restored via refresh token for %s", x.MountPath)
 				return nil
 			}
 			// 刷新失败，回退到账号密码登录
+			if err != nil {
+				log.Warnf("thunder: refresh token failed for %s: %v, fallback to login", x.MountPath, err)
+			} else {
+				log.Warnf("thunder: refresh token response has no access token for %s, fallback to login", x.MountPath)
+			}
+		} else {
+			log.Infof("thunder: no saved refresh token for %s, login with username/password", x.MountPath)
 		}
 		// 登录
 		token, err := x.Login(x.Username, x.Password)
@@ -142,6 +153,7 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 		x.SetTokenResp(token)
 		x.Addition.RefreshToken = token.RefreshToken
 		op.MustSaveDriverStorage(x)
+		log.Infof("thunder: logged in for %s", x.MountPath)
 	}
 	return nil
 }
@@ -544,7 +556,9 @@ func (xc *XunLeiCommon) RefreshToken(refreshToken string) (*TokenResp, error) {
 		return nil, err
 	}
 
-	if resp.RefreshToken == "" {
+	// 以 access token 是否有效作为刷新成功的判据：
+	// 部分场景下服务端不轮换 refresh token（响应里该字段为空），此时保留旧值即可
+	if resp.AccessToken == "" {
 		return nil, errs.EmptyToken
 	}
 	return &resp, nil

--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -75,18 +75,23 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 			},
 			refreshTokenFunc: func() error {
 				// 通过RefreshToken刷新
-				token, err := x.RefreshToken(x.TokenResp.RefreshToken)
+				token, err := x.XunLeiCommon.RefreshToken(x.TokenResp.RefreshToken)
 				if err != nil {
 					// 重新登录
 					token, err = x.Login(x.Username, x.Password)
 					if err != nil {
 						x.GetStorage().SetStatus(fmt.Sprintf("%+v", err.Error()))
-						op.MustSaveDriverStorage(x)
+					} else {
+						// 登录成功，清空已消费的信任密钥
+						x.Addition.CreditKey = ""
 					}
-					// 清空 信任密钥
-					x.Addition.CreditKey = ""
 				}
-				x.SetTokenResp(token)
+				if token != nil {
+					x.SetTokenResp(token)
+					// 持久化最新的 refresh token，避免重启后重新登录
+					x.Addition.RefreshToken = token.RefreshToken
+				}
+				op.MustSaveDriverStorage(x)
 				return err
 			},
 		}
@@ -113,14 +118,30 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 	identity := x.GetIdentity()
 	if x.identity != identity || !x.IsLogin() {
 		x.identity = identity
+		// 优先使用已保存的 RefreshToken 恢复登录态，避免每次重启都触发风控验证
+		if x.Addition.RefreshToken != "" {
+			token, err := x.XunLeiCommon.RefreshToken(x.Addition.RefreshToken)
+			if err == nil && token != nil && token.RefreshToken != "" {
+				x.SetTokenResp(token)
+				// 更新并持久化最新的 refresh token
+				x.Addition.RefreshToken = token.RefreshToken
+				// 清空已消费的信任密钥并落库
+				x.Addition.CreditKey = ""
+				op.MustSaveDriverStorage(x)
+				return nil
+			}
+			// 刷新失败，回退到账号密码登录
+		}
 		// 登录
 		token, err := x.Login(x.Username, x.Password)
 		if err != nil {
 			return err
 		}
-		// 清空 信任密钥
+		// 清空已消费的信任密钥并落库
 		x.Addition.CreditKey = ""
 		x.SetTokenResp(token)
+		x.Addition.RefreshToken = token.RefreshToken
+		op.MustSaveDriverStorage(x)
 	}
 	return nil
 }

--- a/drivers/thunder/driver_test.go
+++ b/drivers/thunder/driver_test.go
@@ -118,6 +118,41 @@ func TestThunderInitRestoresSessionWithRefreshToken(t *testing.T) {
 	}
 }
 
+func TestThunderInitRestoresSessionWithoutRotatedRefreshToken(t *testing.T) {
+	ms := newMockServer()
+	ms.handler = func(path string, w http.ResponseWriter, r *http.Request) {
+		switch path {
+		case "/v1/auth/token":
+			// 服务端刷新成功但未轮换 refresh token（响应里该字段为空）
+			writeJSON(w, TokenResp{
+				TokenType: "Bearer", AccessToken: "at-1",
+				ExpiresIn: 7200, UserID: "u1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	defer ms.Close()
+
+	x := newTestThunder("thunder-test-no-rotate")
+	x.Addition.RefreshToken = "rt-old"
+
+	if err := x.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// 刷新成功：不应回退到账号密码登录
+	if got := ms.Paths(); !reflect.DeepEqual(got, []string{"/v1/auth/token"}) {
+		t.Fatalf("unexpected requests: %v", got)
+	}
+	// refresh token 未轮换时应保留旧值
+	if x.Addition.RefreshToken != "rt-old" {
+		t.Fatalf("RefreshToken = %q, want preserved %q", x.Addition.RefreshToken, "rt-old")
+	}
+	if x.Token() != "Bearer at-1" {
+		t.Fatalf("Token() = %q, want %q", x.Token(), "Bearer at-1")
+	}
+}
+
 func TestThunderInitFallsBackToLoginAndPersists(t *testing.T) {
 	ms := newMockServer()
 	ms.handler = func(path string, w http.ResponseWriter, r *http.Request) {

--- a/drivers/thunder/driver_test.go
+++ b/drivers/thunder/driver_test.go
@@ -1,0 +1,235 @@
+package thunder
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/db"
+	"github.com/alist-org/alist/v3/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestMain(m *testing.M) {
+	// 初始化内存数据库，保证 op.MustSaveDriverStorage 在测试中安全执行
+	conf.Conf = conf.DefaultConfig()
+	d, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+	db.Init(d)
+	os.Exit(m.Run())
+}
+
+// mockServer 记录收到的请求路径，并按路径返回模拟响应
+type mockServer struct {
+	mu      sync.Mutex
+	paths   []string
+	handler func(path string, w http.ResponseWriter, r *http.Request)
+	server  *httptest.Server
+	orig    string
+}
+
+func newMockServer() *mockServer {
+	ms := &mockServer{}
+	ms.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ms.mu.Lock()
+		ms.paths = append(ms.paths, r.URL.Path)
+		ms.mu.Unlock()
+		ms.handler(r.URL.Path, w, r)
+	}))
+	// 两个 URL 变量都是包加载时初始化的，必须一并覆盖
+	ms.orig = XLUSER_API_BASE_URL
+	XLUSER_API_BASE_URL = ms.server.URL
+	XLUSER_API_URL = ms.server.URL + "/v1"
+	return ms
+}
+
+func (ms *mockServer) Close() {
+	XLUSER_API_BASE_URL = ms.orig
+	XLUSER_API_URL = ms.orig + "/v1"
+	ms.server.Close()
+}
+
+func (ms *mockServer) Paths() []string {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	return append([]string(nil), ms.paths...)
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newTestThunder(mountPath string) *Thunder {
+	return &Thunder{
+		Storage: model.Storage{MountPath: mountPath},
+		Addition: Addition{
+			Username:     "13800138000",
+			Password:     "secret",
+			DeviceID:     "0123456789abcdef0123456789abcdef",
+			CaptchaToken: "",
+			CreditKey:    "",
+		},
+	}
+}
+
+func TestThunderInitRestoresSessionWithRefreshToken(t *testing.T) {
+	ms := newMockServer()
+	ms.handler = func(path string, w http.ResponseWriter, r *http.Request) {
+		switch path {
+		case "/v1/auth/token":
+			writeJSON(w, TokenResp{
+				TokenType: "Bearer", AccessToken: "at-1", RefreshToken: "rt-new",
+				ExpiresIn: 7200, UserID: "u1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	defer ms.Close()
+
+	x := newTestThunder("thunder-test-refresh")
+	x.Addition.RefreshToken = "rt-old"
+	x.Addition.CreditKey = "consumed-credit-key"
+
+	if err := x.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// 只应调用 refresh token 接口，不应走账号密码登录
+	if got := ms.Paths(); !reflect.DeepEqual(got, []string{"/v1/auth/token"}) {
+		t.Fatalf("unexpected requests: %v", got)
+	}
+	if x.Addition.RefreshToken != "rt-new" {
+		t.Fatalf("RefreshToken = %q, want %q", x.Addition.RefreshToken, "rt-new")
+	}
+	if x.Addition.CreditKey != "" {
+		t.Fatalf("CreditKey = %q, want cleared", x.Addition.CreditKey)
+	}
+	if x.Token() != "Bearer at-1" {
+		t.Fatalf("Token() = %q, want %q", x.Token(), "Bearer at-1")
+	}
+}
+
+func TestThunderInitFallsBackToLoginAndPersists(t *testing.T) {
+	ms := newMockServer()
+	ms.handler = func(path string, w http.ResponseWriter, r *http.Request) {
+		switch path {
+		case "/v1/auth/token":
+			// refresh token 已失效
+			writeJSON(w, ErrResp{ErrorCode: 4001, ErrorMsg: "invalid_grant"})
+		case "/xluser.core.login/v3/login":
+			writeJSON(w, CoreLoginResp{SessionID: "sid-1", UserID: "u1"})
+		case "/v1/shield/captcha/init":
+			writeJSON(w, CaptchaTokenResponse{CaptchaToken: "ct-1", ExpiresIn: 3600})
+		case "/v1/auth/signin/token":
+			writeJSON(w, TokenResp{
+				TokenType: "Bearer", AccessToken: "at-2", RefreshToken: "rt-2",
+				ExpiresIn: 7200, UserID: "u1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	defer ms.Close()
+
+	x := newTestThunder("thunder-test-login")
+	x.Addition.RefreshToken = "rt-stale"
+	x.Addition.CreditKey = "consumed-credit-key"
+
+	if err := x.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	want := []string{
+		"/v1/auth/token",
+		"/xluser.core.login/v3/login",
+		"/v1/shield/captcha/init",
+		"/v1/auth/signin/token",
+	}
+	if got := ms.Paths(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected requests: %v", got)
+	}
+	if x.Addition.CreditKey != "" {
+		t.Fatalf("CreditKey = %q, want cleared", x.Addition.CreditKey)
+	}
+	if x.Addition.RefreshToken != "rt-2" {
+		t.Fatalf("RefreshToken = %q, want %q", x.Addition.RefreshToken, "rt-2")
+	}
+	if x.Addition.CaptchaToken != "ct-1" {
+		t.Fatalf("CaptchaToken = %q, want %q", x.Addition.CaptchaToken, "ct-1")
+	}
+	if x.Token() != "Bearer at-2" {
+		t.Fatalf("Token() = %q, want %q", x.Token(), "Bearer at-2")
+	}
+}
+
+func TestThunderRefreshTokenFuncPersistsRotatedToken(t *testing.T) {
+	var (
+		meCalls  int
+		tokCalls int
+	)
+	ms := newMockServer()
+	ms.handler = func(path string, w http.ResponseWriter, r *http.Request) {
+		switch path {
+		case "/v1/auth/token":
+			ms.mu.Lock()
+			tokCalls++
+			call := tokCalls
+			ms.mu.Unlock()
+			if call == 1 {
+				// Init 阶段：通过 refresh token 恢复登录
+				writeJSON(w, TokenResp{
+					TokenType: "Bearer", AccessToken: "at-1", RefreshToken: "rt-new",
+					ExpiresIn: 7200, UserID: "u1",
+				})
+				return
+			}
+			// refreshTokenFunc 阶段：服务端轮换 refresh token
+			writeJSON(w, TokenResp{
+				TokenType: "Bearer", AccessToken: "at-rotated", RefreshToken: "rt-rotated",
+				ExpiresIn: 7200, UserID: "u1",
+			})
+		case "/v1/user/me":
+			ms.mu.Lock()
+			meCalls++
+			call := meCalls
+			ms.mu.Unlock()
+			if call == 1 {
+				// 第一次返回 access token 过期，触发 refreshTokenFunc
+				writeJSON(w, ErrResp{ErrorCode: 4122, ErrorMsg: "access token expired"})
+				return
+			}
+			writeJSON(w, map[string]string{"userID": "u1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	defer ms.Close()
+
+	x := newTestThunder("thunder-test-rotate")
+	x.Addition.RefreshToken = "rt-old"
+
+	if err := x.Init(nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if x.Addition.RefreshToken != "rt-new" {
+		t.Fatalf("RefreshToken after Init = %q, want %q", x.Addition.RefreshToken, "rt-new")
+	}
+	if !x.IsLogin() {
+		t.Fatal("IsLogin() = false, want true")
+	}
+	// IsLogin 触发 4122 → refreshTokenFunc → 轮换后的 refresh token 应持久化
+	if x.Addition.RefreshToken != "rt-rotated" {
+		t.Fatalf("RefreshToken = %q, want rotated %q", x.Addition.RefreshToken, "rt-rotated")
+	}
+	if x.Token() != "Bearer at-rotated" {
+		t.Fatalf("Token() = %q, want %q", x.Token(), "Bearer at-rotated")
+	}
+}

--- a/drivers/thunder/meta.go
+++ b/drivers/thunder/meta.go
@@ -80,6 +80,8 @@ type Addition struct {
 	CreditKey string `json:"credit_key" help:"credit key,used for login"`
 	// 登录设备ID
 	DeviceID string `json:"device_id" default:""`
+	// 登录令牌（登录成功后自动保存，用于重启后恢复登录态，避免每次重启重新触发验证）
+	RefreshToken string `json:"refresh_token"`
 }
 
 // 登录特征,用于判断是否重新登录

--- a/drivers/thunder/util.go
+++ b/drivers/thunder/util.go
@@ -17,9 +17,13 @@ import (
 )
 
 const (
-	API_URL             = "https://api-pan.xunlei.com/drive/v1"
-	FILE_API_URL        = API_URL + "/files"
-	TASK_API_URL        = API_URL + "/tasks"
+	API_URL      = "https://api-pan.xunlei.com/drive/v1"
+	FILE_API_URL = API_URL + "/files"
+	TASK_API_URL = API_URL + "/tasks"
+)
+
+// 可变量，便于测试时指向本地 mock 服务
+var (
 	XLUSER_API_BASE_URL = "https://xluser-ssl.xunlei.com"
 	XLUSER_API_URL      = XLUSER_API_BASE_URL + "/v1"
 )


### PR DESCRIPTION
The normal Thunder driver never persisted the login state: TokenResp was
kept in memory only, so every restart re-logged in with username/password
and accounts under risk control triggered the review flow again. The
consumed credit key was also only cleared in memory, so the stale one-use
key was submitted again after restart.

- add refresh_token field to Addition and persist it after login
- restore the session via refresh token first in Init, fall back to
  username/password login only when refresh fails
- persist the rotated refresh token in refreshTokenFunc and avoid calling
  SetTokenResp(nil) when both refresh and login fail
- clear and persist the consumed credit key on every success path
- make XLUSER_API_BASE_URL/XLUSER_API_URL vars so tests can point to a mock
- add unit tests for restart restore, login fallback and token rotation