### PR TITLE
fix(lanzou): handle acw_sc__v2 anti-bot challenge on login

### DIFF
--- a/drivers/lanzou/login_test.go
+++ b/drivers/lanzou/login_test.go
@@ -1,0 +1,68 @@
+package lanzou
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+)
+
+// The login endpoint may be fronted by the acw_sc__v2 anti-bot challenge just
+// like any other lanzou page. Login must solve the challenge and retry with
+// the computed cookie instead of failing with "login err: <challenge html>".
+func TestLoginSolvesAcwScV2Challenge(t *testing.T) {
+	if conf.Conf == nil {
+		conf.Conf = conf.DefaultConfig()
+	}
+	const arg1 = "F921C7A4073A625268C31B50EAA8769EABA0927B"
+	wantAcw, err := CalcAcwScV2(fmt.Sprintf("arg1='%s'", arg1))
+	if err != nil {
+		t.Fatalf("CalcAcwScV2: %v", err)
+	}
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if c, err := r.Cookie("acw_sc__v2"); err != nil || c.Value != wantAcw {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, "<html><script>var arg1='%s';</script></html>", arg1)
+			return
+		}
+		if got := r.FormValue("uid"); got != "user1" {
+			t.Errorf("uid = %q, want user1", got)
+		}
+		http.SetCookie(w, &http.Cookie{Name: "phpdisk_info", Value: "abc"})
+		fmt.Fprint(w, `{"zt":1,"info":"成功登录","id":1}`)
+	}))
+	defer srv.Close()
+
+	oldURL := loginURL
+	loginURL = srv.URL + "/mlogin.php"
+	defer func() { loginURL = oldURL }()
+
+	d := &LanZou{}
+	d.Account = "user1"
+	d.Password = "pass1"
+
+	cookies, err := d.Login()
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if calls < 2 {
+		t.Fatalf("expected challenge retry, got %d call(s)", calls)
+	}
+	var found bool
+	for _, c := range cookies {
+		if c.Name == "phpdisk_info" && c.Value == "abc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("phpdisk_info cookie missing in %v", cookies)
+	}
+	if d.Cookie == "" {
+		t.Fatal("d.Cookie not set after login")
+	}
+}

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -146,20 +146,44 @@ func (d *LanZou) request(url string, method string, callback base.ReqCallback, u
 	return body, errors.New("acw_sc__v2 validation error")
 }
 
+var loginURL = "https://up.woozooo.com/mlogin.php"
+
 func (d *LanZou) Login() ([]*http.Cookie, error) {
-	resp, err := base.NewRestyClient().SetRedirectPolicy(resty.NoRedirectPolicy()).
-		R().SetFormData(map[string]string{
-		"task":         "3",
-		"uid":          d.Account,
-		"pwd":          d.Password,
-		"setSessionId": "",
-		"setSig":       "",
-		"setScene":     "",
-		"setTocen":     "",
-		"formhash":     "",
-	}).Post("https://up.woozooo.com/mlogin.php")
-	if err != nil {
-		return nil, err
+	client := base.NewRestyClient().SetRedirectPolicy(resty.NoRedirectPolicy())
+	// 登录接口同样可能返回 acw_sc__v2 反爬挑战页,需算出 cookie 后重试
+	var acwScV2 string
+	var resp *resty.Response
+	var err error
+	for i := 0; i < 3; i++ {
+		req := client.R().SetFormData(map[string]string{
+			"task":         "3",
+			"uid":          d.Account,
+			"pwd":          d.Password,
+			"setSessionId": "",
+			"setSig":       "",
+			"setScene":     "",
+			"setTocen":     "",
+			"formhash":     "",
+		})
+		if d.UserAgent != "" {
+			req.SetHeader("User-Agent", d.UserAgent)
+		}
+		if acwScV2 != "" {
+			req.SetCookie(&http.Cookie{Name: "acw_sc__v2", Value: acwScV2})
+		}
+		resp, err = req.Post(loginURL)
+		if err != nil {
+			return nil, err
+		}
+		if findAcwScV2Reg.Match(resp.Body()) {
+			vs, e := CalcAcwScV2(resp.String())
+			if e != nil {
+				return nil, fmt.Errorf("login err: %w, data: %s", e, resp.Body())
+			}
+			acwScV2 = vs
+			continue
+		}
+		break
 	}
 	if utils.Json.Get(resp.Body(), "zt").ToInt() != 1 {
 		return nil, fmt.Errorf("login err: %s", resp.Body())


### PR DESCRIPTION
### What this PR does

Account-type Lanzou storages fail to mount with:

```
failed init storage: login err: <html><script>var arg1='F921C7A4...'
```

The login endpoint (`up.woozooo.com/mlogin.php`) can be fronted by the same Aliyun WAF `acw_sc__v2` anti-bot challenge as other Lanzou pages. The challenge is already solved in the shared `request()` layer, but `Login()` bypasses that layer and posts with a bare resty client, so it receives the challenge HTML and treats it as a login failure.

### Fix

- Solve the challenge in `Login()` the same way as `request()`: extract `arg1`, compute `acw_sc__v2` via `CalcAcwScV2`, retry with the cookie (up to 3 attempts).
- Send the configured `User-Agent` on the login request.
- Extract the login URL into a package-level var so the flow is unit-testable.

### Testing

- New unit test `TestLoginSolvesAcwScV2Challenge` (httptest server serves the challenge first, then requires the computed cookie) — fails before the fix with the exact production error, passes after.
- Verified end to end against a real Lanzou account: previously failing mount now succeeds (storage status `work`), file listing and download links work.