### PR TITLE
feat(driver): add CSTCloud Capsule (数据胶囊) driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/cloudreve"
 	_ "github.com/alist-org/alist/v3/drivers/cloudreve_v4"
 	_ "github.com/alist-org/alist/v3/drivers/crypt"
+	_ "github.com/alist-org/alist/v3/drivers/cstcloud_capsule"
 	_ "github.com/alist-org/alist/v3/drivers/darkibox"
 	_ "github.com/alist-org/alist/v3/drivers/doubao"
 	_ "github.com/alist-org/alist/v3/drivers/doubao_new"

--- a/drivers/cstcloud_capsule/driver.go
+++ b/drivers/cstcloud_capsule/driver.go
@@ -1,0 +1,133 @@
+package cstcloud_capsule
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"path"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/pkg/gowebdav"
+	"github.com/alist-org/alist/v3/pkg/utils"
+)
+
+// CSTCloudCapsule mounts 中国科技云·数据胶囊 (https://data.cstcloud.cn) via its
+// WebDAV endpoint. The endpoint is fixed for the whole service; credentials
+// are the per-space WebDAV username/password created on the client access page.
+var webdavAddress = "https://data.cstcloud.cn/dav"
+
+type CSTCloudCapsule struct {
+	model.Storage
+	Addition
+	client *gowebdav.Client
+}
+
+func (d *CSTCloudCapsule) Config() driver.Config {
+	return config
+}
+
+func (d *CSTCloudCapsule) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *CSTCloudCapsule) Init(ctx context.Context) error {
+	c := gowebdav.NewClient(webdavAddress, d.Username, d.Password)
+	c.SetTransport(&http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.Conf.TlsInsecureSkipVerify},
+	})
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return err
+	}
+	c.SetJar(jar)
+	// the server gates every request on the credential's app type via
+	// User-Agent; without a matching UA it responds 403 "Client type mismatch"
+	c.SetInterceptor(func(method string, rq *http.Request) {
+		rq.Header.Set("User-Agent", d.UserAgent)
+	})
+	d.client = c
+	// validate credentials at mount time so misconfiguration surfaces here
+	// instead of as an empty/broken listing later
+	_, err = d.client.ReadDir(d.GetRootPath())
+	return err
+}
+
+func (d *CSTCloudCapsule) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *CSTCloudCapsule) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	files, err := d.client.ReadDir(dir.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	return utils.SliceConvert(files, func(src os.FileInfo) (model.Obj, error) {
+		return &model.Object{
+			Name:     src.Name(),
+			Size:     src.Size(),
+			Modified: src.ModTime(),
+			IsFolder: src.IsDir(),
+		}, nil
+	})
+}
+
+func (d *CSTCloudCapsule) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	url, header, err := d.client.Link(file.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		header = http.Header{}
+	}
+	header.Set("User-Agent", d.UserAgent)
+	return &model.Link{
+		URL:    url,
+		Header: header,
+	}, nil
+}
+
+func (d *CSTCloudCapsule) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	return d.client.MkdirAll(path.Join(parentDir.GetPath(), dirName), 0644)
+}
+
+func (d *CSTCloudCapsule) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
+	return d.client.Rename(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true)
+}
+
+func (d *CSTCloudCapsule) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	return d.client.Rename(getPath(srcObj), path.Join(path.Dir(srcObj.GetPath()), newName), true)
+}
+
+func (d *CSTCloudCapsule) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	return d.client.Copy(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true)
+}
+
+func (d *CSTCloudCapsule) Remove(ctx context.Context, obj model.Obj) error {
+	return d.client.RemoveAll(getPath(obj))
+}
+
+func (d *CSTCloudCapsule) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
+	callback := func(r *http.Request) {
+		r.Header.Set("Content-Type", s.GetMimetype())
+		r.ContentLength = s.GetSize()
+	}
+	reader := driver.NewLimitedUploadStream(ctx, &driver.ReaderUpdatingProgress{
+		Reader:         s,
+		UpdateProgress: up,
+	})
+	return d.client.WriteStream(path.Join(dstDir.GetPath(), s.GetName()), reader, 0644, callback)
+}
+
+func getPath(obj model.Obj) string {
+	if obj.IsDir() {
+		return obj.GetPath() + "/"
+	}
+	return obj.GetPath()
+}
+
+var _ driver.Driver = (*CSTCloudCapsule)(nil)

--- a/drivers/cstcloud_capsule/driver_test.go
+++ b/drivers/cstcloud_capsule/driver_test.go
@@ -1,0 +1,114 @@
+package cstcloud_capsule
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+const multistatus = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/dav/</d:href>
+    <d:propstat>
+      <d:prop><d:resourcetype><d:collection/></d:resourcetype><d:displayname></d:displayname></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/dav/hello.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>hello.txt</d:displayname>
+        <d:getcontentlength>5</d:getcontentlength>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+// stub mimicking the DC WebDAV endpoint: Basic auth guarded PROPFIND with
+// the same client-type gate as the real server (UA must contain the app
+// type the credential was created for, case-insensitive)
+func newStub(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "spaceuser" || pass != "spacepass" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="DC WebDAV"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if !strings.Contains(strings.ToLower(r.UserAgent()), "zotero") {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, "Client type mismatch.")
+			return
+		}
+		if r.Method != "PROPFIND" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+		w.WriteHeader(207)
+		fmt.Fprint(w, multistatus)
+	}))
+}
+
+func setup(t *testing.T, username, password string) *CSTCloudCapsule {
+	t.Helper()
+	if conf.Conf == nil {
+		conf.Conf = conf.DefaultConfig()
+	}
+	srv := newStub(t)
+	t.Cleanup(srv.Close)
+	old := webdavAddress
+	webdavAddress = srv.URL + "/dav"
+	t.Cleanup(func() { webdavAddress = old })
+
+	d := &CSTCloudCapsule{}
+	d.Username = username
+	d.Password = password
+	d.UserAgent = "Mozilla/5.0 (compatible; Zotero/8.0) AList"
+	d.RootFolderPath = "/"
+	return d
+}
+
+func TestInitRejectsMismatchedClientType(t *testing.T) {
+	d := setup(t, "spaceuser", "spacepass")
+	d.UserAgent = "gowebdav"
+	if err := d.Init(context.Background()); err == nil {
+		t.Fatal("Init succeeded with non-matching User-Agent, want client type error")
+	}
+}
+
+func TestInitRejectsBadCredentials(t *testing.T) {
+	d := setup(t, "spaceuser", "wrong")
+	if err := d.Init(context.Background()); err == nil {
+		t.Fatal("Init succeeded with wrong password, want error")
+	}
+}
+
+func TestInitAndList(t *testing.T) {
+	d := setup(t, "spaceuser", "spacepass")
+	if err := d.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	objs, err := d.List(context.Background(), &model.Object{Path: "/"}, model.ListArgs{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("List returned %d objects, want 1", len(objs))
+	}
+	if objs[0].GetName() != "hello.txt" || objs[0].GetSize() != 5 || objs[0].IsDir() {
+		t.Fatalf("unexpected object: name=%s size=%d dir=%v", objs[0].GetName(), objs[0].GetSize(), objs[0].IsDir())
+	}
+}

--- a/drivers/cstcloud_capsule/meta.go
+++ b/drivers/cstcloud_capsule/meta.go
@@ -1,0 +1,29 @@
+package cstcloud_capsule
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	Username string `json:"username" required:"true" help:"WebDAV username created in the data space's client access page. Note: the service currently only allows uploading .zip/.prop files over WebDAV / 在数据空间「客户端访问」中创建的 WebDAV 用户名。注意:服务端目前仅允许通过 WebDAV 上传 .zip/.prop 文件"`
+	Password string `json:"password" required:"true" help:"WebDAV password shown when the credential is created / 创建凭证时显示的 WebDAV 密码"`
+	// The server rejects requests whose User-Agent does not contain the app
+	// type the credential was created for ("Client type mismatch"). Zotero is
+	// currently the only WebDAV app type offered, so it is the default here.
+	UserAgent string `json:"user_agent" required:"true" default:"Mozilla/5.0 (compatible; Zotero/8.0) AList" help:"Must contain the app type chosen when creating the credential / 必须包含创建凭证时所选的应用类型(如 Zotero)"`
+	driver.RootPath
+}
+
+var config = driver.Config{
+	Name:        "CSTCloudCapsule",
+	LocalSort:   true,
+	OnlyProxy:   true,
+	DefaultRoot: "/",
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &CSTCloudCapsule{}
+	})
+}

--- a/drivers/s3/meta.go
+++ b/drivers/s3/meta.go
@@ -21,6 +21,7 @@ type Addition struct {
 	ListObjectVersion        string `json:"list_object_version" type:"select" options:"v1,v2" default:"v1"`
 	UsePlaceholder           bool   `json:"use_placeholder" default:"true" help:"Create hidden placeholder file (for example .alist) to keep empty folders."`
 	RemoveBucket             bool   `json:"remove_bucket" help:"Remove bucket name from path when using custom host."`
+	UserAgent                string `json:"user_agent" help:"Some providers validate the client by User-Agent, e.g. CSTCloud data capsule (s3.cstcloud.cn) requires it to contain the app type the AccessKey was created for (such as rclone). Such providers usually gate presigned URLs the same way, so also enable Web Proxy for the storage. Leave empty to use the SDK default."`
 	AddFilenameToDisposition bool   `json:"add_filename_to_disposition" help:"Add filename to Content-Disposition header."`
 	StorageClass             string `json:"storage_class" type:"select" options:",standard,standard_ia,onezone_ia,intelligent_tiering,glacier,glacier_ir,deep_archive,archive" help:"Storage class for new objects. AWS and Tencent COS support different subsets (COS uses ARCHIVE/DEEP_ARCHIVE)."`
 }

--- a/drivers/s3/util.go
+++ b/drivers/s3/util.go
@@ -39,7 +39,17 @@ func (d *S3) initSession() error {
 		S3ForcePathStyle: aws.Bool(d.ForcePathStyle),
 	}
 	d.Session, err = session.NewSession(cfg)
-	return err
+	if err != nil {
+		return err
+	}
+	if d.UserAgent != "" {
+		// session-level so every client built from it (API client, uploader,
+		// presigner) sends the configured User-Agent
+		d.Session.Handlers.Build.PushBack(func(r *request.Request) {
+			r.HTTPRequest.Header.Set("User-Agent", d.UserAgent)
+		})
+	}
+	return nil
 }
 
 func (d *S3) getClient(link bool) *s3.S3 {

--- a/drivers/s3/util_test.go
+++ b/drivers/s3/util_test.go
@@ -1,0 +1,56 @@
+package s3
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// Providers like CSTCloud data capsule reject requests whose User-Agent does
+// not contain the app type the AccessKey was created for. The configured UA
+// must reach every client built from the session (API client, uploader).
+func TestInitSessionAppliesUserAgent(t *testing.T) {
+	d := &S3{}
+	d.Endpoint = "https://s3.example.com"
+	d.Region = "us-east-1"
+	d.AccessKeyID = "ak"
+	d.SecretAccessKey = "sk"
+	d.UserAgent = "rclone/v1.65.0"
+
+	if err := d.initSession(); err != nil {
+		t.Fatalf("initSession: %v", err)
+	}
+
+	client := s3.New(d.Session)
+	req, _ := client.ListObjectsV2Request(&s3.ListObjectsV2Input{Bucket: aws.String("b")})
+	if err := req.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := req.HTTPRequest.Header.Get("User-Agent"); got != "rclone/v1.65.0" {
+		t.Fatalf("User-Agent = %q, want %q", got, "rclone/v1.65.0")
+	}
+}
+
+// Without the option the SDK default UA must remain untouched.
+func TestInitSessionDefaultUserAgent(t *testing.T) {
+	d := &S3{}
+	d.Endpoint = "https://s3.example.com"
+	d.Region = "us-east-1"
+	d.AccessKeyID = "ak"
+	d.SecretAccessKey = "sk"
+
+	if err := d.initSession(); err != nil {
+		t.Fatalf("initSession: %v", err)
+	}
+
+	client := s3.New(d.Session)
+	req, _ := client.ListObjectsV2Request(&s3.ListObjectsV2Input{Bucket: aws.String("b")})
+	if err := req.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := req.HTTPRequest.Header.Get("User-Agent"); !strings.Contains(got, "aws-sdk-go") {
+		t.Fatalf("User-Agent = %q, want SDK default containing aws-sdk-go", got)
+	}
+}


### PR DESCRIPTION
Closes #9584

### Background

China Science and Technology Cloud's data capsule (https://data.cstcloud.cn) advertises WebDAV and S3 support, but mounting it with the generic WebDav driver (or rclone, Cyberduck, ...) fails. Investigation against a real account showed why:

1. **Fixed endpoint**: WebDAV lives at `https://data.cstcloud.cn/dav` with per-space username/password credentials created on the data space's client access page.
2. **Client-type gate**: the server rejects every request whose `User-Agent` does not contain the app type the credential was created for, with `403 Client type mismatch` (case-insensitive substring match). **Zotero is currently the only WebDAV app type offered**, so no generic WebDAV client can pass the gate. This also explains the "unauthorized" failures with alist's S3 driver: the aws-sdk-go User-Agent matches none of the allowed S3 app types (S3Browser/Rclone/Obsidian/Cherry Studio).
3. **Upload whitelist**: WebDAV uploads are additionally restricted server-side to `.zip`/`.prop` files (Zotero sync's file types). Reads, mkdir, move, copy and delete are unrestricted.

### What this PR does

Adds a dedicated `CSTCloudCapsule` driver:

- endpoint baked in — only username/password (and optional root path) required;
- sends a configurable User-Agent that satisfies the client-type gate (defaults to a Zotero-compatible UA), also propagated on download links;
- validates credentials at mount time so misconfiguration fails immediately with a clear message instead of an empty listing;
- documents the `.zip`/`.prop` upload restriction in the field help text.

### Testing

- Unit tests against a stub of the DC WebDAV endpoint covering the Basic auth gate, the client-type gate and listing.
- Verified end to end with a real account: mount, list, mkdir, upload (.zip), download (checksum-identical round-trip), move and delete all work; non-whitelisted upload types fail with the server's 403 as expected.