### PR TITLE
fix(security): enforce user base path on all request paths

### DIFF
--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -89,12 +89,6 @@ func JoinBasePath(basePath, reqPath string) (string, error) {
 		return "", errs.RelativePath
 	}
 
-	reqPath = FixAndCleanPath(reqPath)
-
-	if strings.HasPrefix(reqPath, "/") {
-		return reqPath, nil
-	}
-
 	return stdpath.Join(FixAndCleanPath(basePath), FixAndCleanPath(reqPath)), nil
 }
 

--- a/pkg/utils/path_test.go
+++ b/pkg/utils/path_test.go
@@ -66,3 +66,36 @@ func TestJoinUnderBase(t *testing.T) {
 		t.Fatalf("expected nested path to be rejected")
 	}
 }
+
+func TestJoinBasePath(t *testing.T) {
+	// A user's base path confines every request path, not just "/".
+	datas := []struct {
+		basePath string
+		reqPath  string
+		want     string
+	}{
+		{"/public", "/", "/public"},
+		{"/public", "/sub", "/public/sub"},
+		{"/public", "sub", "/public/sub"},
+		{"/public", "/sub/file.txt", "/public/sub/file.txt"},
+		{"/public", "/other_storage", "/public/other_storage"},
+		{"/", "/sub", "/sub"},
+		{"", "/sub", "/sub"},
+	}
+	for _, d := range datas {
+		got, err := JoinBasePath(d.basePath, d.reqPath)
+		if err != nil {
+			t.Fatalf("JoinBasePath(%q, %q) error: %v", d.basePath, d.reqPath, err)
+		}
+		if got != d.want {
+			t.Errorf("JoinBasePath(%q, %q) = %q, want %q", d.basePath, d.reqPath, got, d.want)
+		}
+	}
+
+	// relative segments must still be rejected
+	for _, reqPath := range []string{"..", "../x", "/x/..", "/x/../y"} {
+		if _, err := JoinBasePath("/public", reqPath); err == nil {
+			t.Errorf("JoinBasePath(%q, %q) expected error, got nil", "/public", reqPath)
+		}
+	}
+}


### PR DESCRIPTION
### Problem

`utils.JoinBasePath` returned the request path unchanged whenever it started with `/`:

```go
reqPath = FixAndCleanPath(reqPath)
if strings.HasPrefix(reqPath, "/") {
    return reqPath, nil
}
return stdpath.Join(FixAndCleanPath(basePath), FixAndCleanPath(reqPath)), nil
```

`FixAndCleanPath` always prepends `/`, so the early return matched **every** request and the base path was never applied. Only the exact path `/` was rebased, by `User.JoinPath`.

### Impact

A user restricted by base path was not actually confined. The built-in guest and general roles carry a permission scope of `/`, and `CanReadPathByRole` grants access to any path under a scope — so a guest confined to `/public` could list and download unrelated storages simply by requesting their absolute paths.

Reproduced on a local instance (guest, `base_path=/lanzou`, role scope `/`, no write permission):

```
POST /api/fs/list {"path":"/wukong"}   → 200, full contents of an unrelated storage
```

After the fix the same request resolves to `/lanzou/wukong` and returns "object not found".

It also broke normal navigation for base-path users: entering a subfolder resolved to the real root instead of a path under the base, so the folder appeared inaccessible (403). This is visible in #9600.

### Fix

Drop the early return and restore the join. Regression introduced in 6b2d81ee (#9249).

### Testing

- New `TestJoinBasePath` covering root, nested, relative-input and empty-base cases plus the existing rejection of `..` segments — fails before the fix, passes after.
- Verified end to end: base-path user can no longer reach paths outside the base; admin (base `/`) unaffected; existing `pkg/utils` tests pass. (`TestSecureJoin` and the aria2 rpc tests fail identically on unmodified main in this environment — unrelated.)