### PR TITLE
fix(139): declare the PC client type to lift the 50 GB upload cap

### DIFF
--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -597,7 +597,9 @@ func (d *Yun139) personalRequest(pathname string, method string, callback base.R
 		"X-Yun-Api-Version":    "v1",
 		"X-Yun-App-Channel":    "10000034",
 		"X-Yun-Channel-Source": "10000034",
-		"X-Yun-Client-Info":    "||9|7.14.0|chrome|120.0.0.0|||windows 10||zh-CN|||dW5kZWZpbmVk||",
+		// 第三个字段是客户端类型，服务端按它决定单文件上传上限：
+		// 9（网页）和 2（App）为 50 GB，13（PC 客户端）为 500 GB。
+		"X-Yun-Client-Info":    "||13|7.14.0|chrome|120.0.0.0|||windows 10||zh-CN|||dW5kZWZpbmVk||",
 		"X-Yun-Module-Type":    "100",
 		"X-Yun-Svc-Type":       "1",
 	})


### PR DESCRIPTION
`personal_new` uploads fail with `权益不足` (code `04010319`) above 50 GB, even on accounts whose membership includes the larger limit. The cause is one field in a request header.

## The field

`X-Yun-Client-Info` is pipe separated, and its third field is the client type. The server reads it to decide which single-file upload limit of the account's membership applies. The membership benefit itself spells the split out: `RHR005 大文件上传 (APP50G, PC500G)`.

The driver sends `9`:

```
||9|7.14.0|chrome|120.0.0.0|||windows 10||zh-CN|||dW5kZWZpbmVk||
   ^ client type
```

## Measurements

Taken against the live API on an account that carries the larger limit. `/file/create` only declares a size, so nothing is uploaded; every task created during the run was trashed afterwards.

Boundaries, resolved to 1 GB:

| client type | 50 GB | 51 GB | 500 GB | 501 GB |
|---|---|---|---|---|
| `9` (web) | pass | reject | reject | reject |
| `2` (app) | pass | reject | reject | reject |
| `13` (desktop client) | pass | pass | pass | reject |

Only this field moves the boundary. Each of these was changed on its own at 100 GB, a size that `13` accepts:

| change | result |
|---|---|
| field 3, `13` to `9`, platform left at `PC` | reject |
| field 5, platform `PC` to `chrome`, type left at `13` | pass |
| field 4, version to `7.14.0` | pass |
| field 7, device fingerprint cleared | pass |
| `X-Yun-App-Channel` to `10000034` | pass |
| `X-Yun-Svc-Type` to `2` | pass |

`X-Yun-Module-Type` is validated for its value and rejects the request outright when changed, but does not affect the boundary.

The final check ran through the driver itself rather than a synthetic request, so the full header set that `personalRequest` builds was in play, including `Mcloud-Sign` and the `x-DeviceInfo` header that the driver also sends. Before the change 100 GB was rejected and 50 GB accepted; after it 500 GB is accepted and 501 GB rejected. `x-DeviceInfo` still carries `9` and was deliberately left alone, since the measurements show it has no effect here and leaving it narrows the change to a single value.