### PR TITLE
fix(settings): drop the polyfill.io script left in customize_head

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -17,6 +17,36 @@ import (
 
 var initialSettingItems []model.SettingItem
 
+// legacyDefaults lists values a setting shipped as its default in versions
+// older than the one PreDefault records. Keeping the whole chain matters
+// because an install only ever carries the default of the version it was set
+// up with: matching just the newest one leaves older installs pinned to a
+// default they never chose.
+var legacyDefaults = map[string][]string{
+	// The original polyfill.io domain changed hands in 2024 and served
+	// malware to visitors. It is no longer needed either: the frontend's
+	// legacy bundle carries the String.prototype.replaceAll polyfill itself.
+	conf.CustomizeHead: {
+		`<script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.replaceAll"></script>`,
+	},
+}
+
+// isShippedDefault reports whether value is one of the defaults this setting
+// was seeded with, in this or an earlier version. Such a value was never
+// chosen by the user, so an upgrade is free to replace it with the current
+// default; anything else is treated as a customisation and preserved.
+func isShippedDefault(item *model.SettingItem, value string) bool {
+	if value == item.PreDefault {
+		return true
+	}
+	for _, legacy := range legacyDefaults[item.Key] {
+		if value == legacy {
+			return true
+		}
+	}
+	return false
+}
+
 func initSettings() {
 	InitialSettings()
 	// check deprecated
@@ -52,7 +82,7 @@ func initSettings() {
 				continue
 			}
 		}
-		if stored != nil && item.Key != conf.VERSION && stored.Value != item.PreDefault {
+		if stored != nil && item.Key != conf.VERSION && !isShippedDefault(item, stored.Value) {
 			item.Value = stored.Value
 		}
 		_, err = op.HandleSettingItemHook(item)

--- a/internal/bootstrap/data/setting_test.go
+++ b/internal/bootstrap/data/setting_test.go
@@ -1,0 +1,83 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/conf"
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+func TestIsShippedDefault(t *testing.T) {
+	const (
+		current = "current-default"
+		older   = "older-default"
+		oldest  = "oldest-default"
+	)
+	item := &model.SettingItem{Key: "k", Value: current, PreDefault: current}
+	legacyDefaults[item.Key] = []string{older, oldest}
+	t.Cleanup(func() { delete(legacyDefaults, item.Key) })
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"the default shipped today", current, true},
+		{"a default shipped by an earlier version", older, true},
+		{"the oldest default we ever shipped", oldest, true},
+		{"a value the user chose", "something the user typed", false},
+		{"an empty value the user saved", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShippedDefault(item, tt.value); got != tt.want {
+				t.Errorf("isShippedDefault(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// A setting that never changed its default has no history to carry, so only
+// the current default counts as "not customised".
+func TestIsShippedDefaultWithoutHistory(t *testing.T) {
+	item := &model.SettingItem{Key: "no-history", Value: "only-default", PreDefault: "only-default"}
+	if !isShippedDefault(item, "only-default") {
+		t.Error("the current default should count as shipped")
+	}
+	if isShippedDefault(item, "user value") {
+		t.Error("a user value must not count as shipped")
+	}
+}
+
+// The polyfill script AList used to seed into customize_head must be
+// recognised in both of the forms it shipped in, so an upgrade drops it
+// instead of preserving a third-party script the user never asked for.
+// The original polyfill.io domain was sold and served malware in 2024.
+func TestCustomizeHeadDropsEveryShippedPolyfill(t *testing.T) {
+	if conf.Conf == nil {
+		conf.Conf = conf.DefaultConfig()
+	}
+	var head *model.SettingItem
+	for _, item := range InitialSettings() {
+		if item.Key == conf.CustomizeHead {
+			head = &item
+			break
+		}
+	}
+	if head == nil {
+		t.Fatal("customize_head is not among the initial settings")
+	}
+
+	shipped := []string{
+		`<script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.replaceAll"></script>`,
+		`<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=String.prototype.replaceAll"></script>`,
+	}
+	for _, value := range shipped {
+		if !isShippedDefault(head, value) {
+			t.Errorf("customize_head keeps a previously shipped default: %s", value)
+		}
+	}
+	if isShippedDefault(head, `<script src="https://example.com/mine.js"></script>`) {
+		t.Error("a script the user added must be preserved")
+	}
+}


### PR DESCRIPTION
### Problem

AList used to seed a polyfill script into `customize_head`. #6740 moved that default from `polyfill.io` to Cloudflare's mirror after the original domain changed hands and [served malware to visitors](https://github.com/polyfillpolyfill/polyfill-service/issues/2873), and the current default is empty, so the script is dropped on upgrade.

That only works for installs whose stored value matches the **newest** previous default:

```go
if stored != nil && item.Key != conf.VERSION && stored.Value != item.PreDefault {
    item.Value = stored.Value // treated as a user customisation, kept
}
```

An install carries the default of the version it was set up with. Anything set up before #6740 still holds the `polyfill.io` value, which does not match `PreDefault`, so it is preserved as if the user had chosen it — those installs keep loading the hijacked domain, and no upgrade clears it.

Reproduced on 3.63.0: setting `customize_head` to the old value and restarting keeps it, and the script is served in the page's `<head>`.

### Fix

Match the whole chain of defaults a setting has shipped with, not just the newest one, and list the `polyfill.io` form for `customize_head`. The history lives in a bootstrap-local map rather than on `model.SettingItem`, which keeps that struct comparable — `initSettings` compares items by value.

Values outside the chain are still treated as customisations and preserved.

The script is not needed either way: the frontend's legacy bundle carries the `String.prototype.replaceAll` polyfill it provided (verified in `polyfills-legacy.*.js`), the sources call the method nowhere, and every browser has supported it natively since 2020.

### Testing

- Unit tests for the match: current default, older defaults, user values, and a setting without history; plus one asserting the real `customize_head` entry recognises both shipped polyfill forms.
- Verified live on an upgraded instance: a stored `polyfill.io` value is cleared on restart and no longer served in the page, while an unrelated user script in the same setting survives untouched.