### PR TITLE
fix: "failed to upload2C"

### DIFF
--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -6,9 +6,11 @@
 package webdav // import "golang.org/x/net/webdav"
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -308,6 +310,12 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request) (status int,
 	if reqPath == "" {
 		return http.StatusMethodNotAllowed, nil
 	}
+
+	if r.ContentLength == 0 {
+		r.Body = io.NopCloser(bytes.NewReader([]byte("\n")))
+		r.ContentLength = 1
+	}
+
 	release, status, err := h.confirmLocks(r, reqPath, "")
 	if err != nil {
 		return status, err


### PR DESCRIPTION
fix #9610 
如果创建空文件，大多网盘都会报错400。如果是空文件就添加一个占位符，就能正常创建文件。有些挂载软件会先创建一个空文件导致创建文件时报错。
修复无法创建空文件的问题，和部分webdav挂载工具(raidrive 1.8.0,windows自带添加网络位置挂载webdav)无法创建文件的问题。
