### PR TITLE
fix(webdav): retry stale digest authentication

### DIFF
--- a/pkg/gowebdav/digestAuth.go
+++ b/pkg/gowebdav/digestAuth.go
@@ -60,6 +60,26 @@ func digestParts(resp *http.Response) map[string]string {
 	return result
 }
 
+func isStaleDigestChallenge(resp *http.Response) bool {
+	for _, header := range resp.Header.Values("WWW-Authenticate") {
+		for _, directive := range strings.Split(header, ",") {
+			directive = strings.TrimSpace(directive)
+			if len(directive) >= len("Digest ") && strings.EqualFold(directive[:len("Digest ")], "Digest ") {
+				directive = strings.TrimSpace(directive[len("Digest "):])
+			}
+			name, value, ok := strings.Cut(directive, "=")
+			if !ok || !strings.EqualFold(strings.TrimSpace(name), "stale") {
+				continue
+			}
+			value = strings.Trim(strings.TrimSpace(value), `"`)
+			if strings.EqualFold(value, "true") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func getMD5(text string) string {
 	hasher := md5.New()
 	hasher.Write([]byte(text))

--- a/pkg/gowebdav/requests.go
+++ b/pkg/gowebdav/requests.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (c *Client) req(method, path string, body io.Reader, intercept func(*http.Request)) (req *http.Response, err error) {
+	return c.reqWithDigestRetry(method, path, body, intercept, true)
+}
+
+func (c *Client) reqWithDigestRetry(method, path string, body io.Reader, intercept func(*http.Request), allowStaleRetry bool) (req *http.Response, err error) {
 	var r *http.Request
 	var retryBuf io.Reader
 	canRetry := true
@@ -86,8 +90,19 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 		// retryBuf will be nil if body was nil initially so no check
 		// for body == nil is required here.
 		if canRetry {
-			return c.req(method, path, retryBuf, intercept)
+			_ = rs.Body.Close()
+			return c.reqWithDigestRetry(method, path, retryBuf, intercept, allowStaleRetry)
 		}
+	} else if rs.StatusCode == 401 && auth.Type() == "DigestAuth" && allowStaleRetry && isStaleDigestChallenge(rs) {
+		c.authMutex.Lock()
+		c.auth = &DigestAuth{auth.User(), auth.Pass(), digestParts(rs)}
+		c.authMutex.Unlock()
+
+		if canRetry {
+			_ = rs.Body.Close()
+			return c.reqWithDigestRetry(method, path, retryBuf, intercept, false)
+		}
+		return rs, newPathError("Authorize", c.root, rs.StatusCode)
 	} else if rs.StatusCode == 401 {
 		return rs, newPathError("Authorize", c.root, rs.StatusCode)
 	}

--- a/pkg/gowebdav/requests_test.go
+++ b/pkg/gowebdav/requests_test.go
@@ -1,0 +1,68 @@
+package gowebdav
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestClientRetriesStaleDigestChallenge(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("initial request unexpectedly had authorization: %q", got)
+			}
+			w.Header().Set("WWW-Authenticate", `Digest realm="webdav", nonce="nonce-one", algorithm=MD5, qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); !strings.Contains(got, `nonce="nonce-one"`) {
+				t.Errorf("first digest request used the wrong nonce: %q", got)
+			}
+			w.Header().Set("WWW-Authenticate", `Digest realm="webdav", nonce="nonce-two", algorithm=MD5, qop="auth", stale=true`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case 3:
+			if got := r.Header.Get("Authorization"); !strings.Contains(got, `nonce="nonce-two"`) {
+				t.Errorf("retried digest request used the wrong nonce: %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user", "password")
+	if err := client.Connect(); err != nil {
+		t.Fatalf("connect with a refreshed digest nonce: %v", err)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("request count = %d, want 3", got)
+	}
+}
+
+func TestClientLimitsStaleDigestRetries(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		nonce := "nonce-one"
+		if request > 1 {
+			nonce = "nonce-two"
+		}
+		w.Header().Set("WWW-Authenticate", `Digest realm="webdav", nonce="`+nonce+`", algorithm=MD5, qop="auth", stale=true`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user", "password")
+	if err := client.Connect(); err == nil {
+		t.Fatal("connect unexpectedly succeeded after repeated stale challenges")
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("request count = %d, want one initial request, one digest request, and one stale retry", got)
+	}
+}


### PR DESCRIPTION
## What this changes

Refreshes Digest authentication when a WebDAV server rejects an expired nonce with a new `WWW-Authenticate` challenge containing `stale=true`.

Previously, the first Digest challenge was handled, but any later 401 from an already active `DigestAuth` immediately returned an authorization error. Servers that periodically expire nonces therefore became unusable until the client was recreated.

The retry is deliberately bounded to one stale challenge so a misbehaving server cannot cause unbounded recursion. Responses are closed before retrying so the underlying connection can be reused safely.

## Tests

- Added an `httptest` WebDAV flow covering initial authentication, nonce expiry, refreshed authentication, and success
- Added a repeated-stale test proving the retry is bounded
- `go test ./pkg/gowebdav -count=1`
- All `pkg/...` tests pass except the existing `pkg/aria2/rpc` integration tests, which require an aria2 server on `localhost:6800`

Fixes #7556
