### PR TITLE
fix(webdav): avoid duplicate BasePath resolution

### DIFF
--- a/server/webdav/path.go
+++ b/server/webdav/path.go
@@ -1,7 +1,6 @@
 package webdav
 
 import (
-	"path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/model"
@@ -14,8 +13,14 @@ func ResolvePath(user *model.User, raw string) (string, error) {
 	cleaned := utils.FixAndCleanPath(raw)
 	basePath := utils.FixAndCleanPath(user.BasePath)
 
-	if cleaned != "/" && basePath != "/" && !utils.IsSubPath(basePath, cleaned) {
-		cleaned = path.Join(basePath, strings.TrimPrefix(cleaned, "/"))
+	// WebDAV paths are normally relative to the user's base path, but some
+	// clients include that base path in the request URL. Normalize both forms
+	// to a path relative to BasePath before JoinPath applies it.
+	if basePath != "/" && utils.IsSubPath(basePath, cleaned) {
+		cleaned = strings.TrimPrefix(cleaned, basePath)
+		if cleaned == "" {
+			cleaned = "/"
+		}
 	}
 
 	return user.JoinPath(cleaned)

--- a/server/webdav/path_test.go
+++ b/server/webdav/path_test.go
@@ -1,0 +1,59 @@
+package webdav
+
+import (
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/model"
+)
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		raw      string
+		want     string
+	}{
+		{
+			name:     "non-root base root request",
+			basePath: "/webdav",
+			raw:      "/",
+			want:     "/webdav",
+		},
+		{
+			name:     "non-root base relative child",
+			basePath: "/webdav",
+			raw:      "/cc-switch-sync",
+			want:     "/webdav/cc-switch-sync",
+		},
+		{
+			name:     "non-root base already-qualified child",
+			basePath: "/webdav",
+			raw:      "/webdav/cc-switch-sync",
+			want:     "/webdav/cc-switch-sync",
+		},
+		{
+			name:     "non-root base itself",
+			basePath: "/webdav",
+			raw:      "/webdav",
+			want:     "/webdav",
+		},
+		{
+			name:     "root base",
+			basePath: "/",
+			raw:      "/cc-switch-sync",
+			want:     "/cc-switch-sync",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolvePath(&model.User{BasePath: tt.basePath}, tt.raw)
+			if err != nil {
+				t.Fatalf("ResolvePath(%q, %q) error: %v", tt.basePath, tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolvePath(%q, %q) = %q, want %q", tt.basePath, tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix WebDAV path resolution for users configured with a non-root BasePath.

When a WebDAV user has a BasePath such as `/webdav`, a request like `MKCOL /dav/cc-switch-sync/` was incorrectly resolved to `/webdav/webdav/cc-switch-sync`.

This caused the underlying storage lookup to fail with `409 Conflict` because the expected parent directory did not exist.

This change normalizes requests that already include the user's BasePath before calling `User.JoinPath`, preventing duplicate BasePath concatenation.

## Related Issue

Closes #9613

## Tests

Added `TestResolvePath` covering:

- Root requests with a non-root BasePath
- Relative child paths with a non-root BasePath
- Requests that already include the BasePath
- Requests targeting the BasePath itself
- Root BasePath behavior

Tests passed:

`go test ./server/webdav ./pkg/utils ./internal/model -count=1`

Result:

- `ok github.com/alist-org/alist/v3/server/webdav`
- `ok github.com/alist-org/alist/v3/pkg/utils`
- `internal/model` has no test files