### PR TITLE
fix(lanzou): support new password download pages

### DIFF
--- a/drivers/lanzou/driver.go
+++ b/drivers/lanzou/driver.go
@@ -3,6 +3,7 @@ package lanzou
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -19,6 +20,9 @@ type LanZou struct {
 	vei string
 
 	flag int32
+
+	clientOnce sync.Once
+	client     *resty.Client
 }
 
 func (d *LanZou) Config() driver.Config {

--- a/drivers/lanzou/help.go
+++ b/drivers/lanzou/help.go
@@ -159,23 +159,24 @@ var findKVReg = regexp.MustCompile(`'(.+?)':('?([^' },]*)'?)`) // 拆分kv
 
 // 根据key查询js变量
 func findJSVarFunc(key, data string) string {
-	var values []string
-	if key != "sasign" {
-		values = regexp.MustCompile(`var ` + key + `\s*=\s*['"]?(.+?)['"]?;`).FindStringSubmatch(data)
-	} else {
-		matches := regexp.MustCompile(`var `+key+`\s*=\s*['"]?(.+?)['"]?;`).FindAllStringSubmatch(data, -1)
-		if len(matches) == 3 {
-			values = matches[1]
-		} else {
-			if len(matches) > 0 {
-				values = matches[0]
+	matches := regexp.MustCompile(`var\s+`+regexp.QuoteMeta(key)+`\s*=\s*(?:'([^']*)'|"([^"]*)"|([^;\s]+))\s*;`).FindAllStringSubmatch(data, -1)
+	value := func(match []string) string {
+		for _, candidate := range match[1:] {
+			if candidate != "" {
+				return candidate
 			}
 		}
-	}
-	if len(values) == 0 {
 		return ""
 	}
-	return values[1]
+	if key == "sasign" && len(matches) == 3 {
+		return value(matches[1])
+	}
+	for i := len(matches) - 1; i >= 0; i-- {
+		if v := value(matches[i]); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 var findFunction = regexp.MustCompile(`(?ims)^function[^{]+`)

--- a/drivers/lanzou/help_test.go
+++ b/drivers/lanzou/help_test.go
@@ -1,0 +1,36 @@
+package lanzou
+
+import "testing"
+
+func TestFindJSVarFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		data string
+		want string
+	}{
+		{name: "single quoted", key: "sign", data: `var sign = 'complete-sign';`, want: "complete-sign"},
+		{name: "double quoted", key: "sign", data: `var sign = "complete-sign";`, want: "complete-sign"},
+		{name: "unquoted", key: "kd", data: `var kd = 1;`, want: "1"},
+		{name: "last non-empty declaration", key: "isngis", data: `var isngis = ''; var isngis = 'real-sign';`, want: "real-sign"},
+		{name: "sasign middle declaration", key: "sasign", data: `var sasign='first'; var sasign='middle'; var sasign='last';`, want: "middle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findJSVarFunc(tt.key, tt.data); got != tt.want {
+				t.Fatalf("findJSVarFunc() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTMLJSONToMapUsesCompleteLastVariable(t *testing.T) {
+	data := `var isngis = ''; var isngis = 'complete-sign'; data: { 'action':'downprocess','sign':isngis,'kd':1,'p':pwd }`
+	params, err := htmlJsonToMap(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if params["sign"] != "complete-sign" {
+		t.Fatalf("sign = %q, want %q", params["sign"], "complete-sign")
+	}
+}

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -90,7 +91,7 @@ func (d *LanZou) _post(url string, callback base.ReqCallback, resp interface{}, 
 		if info == "" {
 			info = utils.Json.Get(data, "info").ToString()
 		}
-		return data, fmt.Errorf(info)
+		return data, errors.New(info)
 	}
 }
 
@@ -102,7 +103,11 @@ func (d *LanZou) request(url string, method string, callback base.ReqCallback, u
 		})
 		client = upClient
 	} else {
-		client = base.RestyClient
+		d.clientOnce.Do(func() {
+			jar, _ := cookiejar.New(nil)
+			d.client = base.RestyClient.Clone().SetCookieJar(jar)
+		})
+		client = d.client
 	}
 
 	// acw_sc__v2 反爬挑战可能出现在任意页面/接口(分享页、iframe 页、ajaxm.php 等)。
@@ -115,10 +120,10 @@ func (d *LanZou) request(url string, method string, callback base.ReqCallback, u
 			"Referer":    "https://pc.woozooo.com",
 			"User-Agent": d.UserAgent,
 		})
-		if d.Cookie != "" {
+		if d.Cookie != "" && strings.HasPrefix(url, strings.TrimRight(d.BaseUrl, "/")+"/") {
 			req.SetHeader("cookie", d.Cookie)
 		}
-		if acwScV2 != "" {
+		if acwScV2 != "" && client.GetClient().Jar == nil {
 			req.SetCookie(&http.Cookie{Name: "acw_sc__v2", Value: acwScV2})
 		}
 		if callback != nil {
@@ -139,6 +144,13 @@ func (d *LanZou) request(url string, method string, callback base.ReqCallback, u
 				return body, e
 			}
 			acwScV2 = vs
+			if jar := client.GetClient().Jar; jar != nil {
+				jar.SetCookies(res.Request.RawRequest.URL, []*http.Cookie{{
+					Name:  "acw_sc__v2",
+					Value: vs,
+					Path:  "/",
+				}})
+			}
 			continue
 		}
 		return body, nil
@@ -308,8 +320,30 @@ var findSubFolderReg = regexp.MustCompile(`(?i)(?:folderlink|mbxfolder).+href="/
 // 获取下载页面链接
 var findDownPageParamReg = regexp.MustCompile(`<iframe.*?src="(.+?)"`)
 
-// 获取文件ID
-var findFileIDReg = regexp.MustCompile(`'/ajaxm\.php\?file=(\d+)'`)
+// 获取下载接口及文件 ID。旧页面使用 ajaxm.php，新版密码文件页面使用
+// ajaxfile.php；地址也可能使用单/双引号或完整 URL。
+var findAjaxPathReg = regexp.MustCompile(`(?i)(/ajax(?:m|file)\.php\?file=(\d+)\b)`)
+var findFileIDVarReg = regexp.MustCompile(`(?i)\b(?:f_id|fid)\s*=\s*['"]?(\d+)['"]?\s*;`)
+
+func findFileID(data string) (string, bool) {
+	if matches := findAjaxPathReg.FindStringSubmatch(data); len(matches) == 3 {
+		return matches[2], true
+	}
+	if matches := findFileIDVarReg.FindStringSubmatch(data); len(matches) == 2 {
+		return matches[1], true
+	}
+	return "", false
+}
+
+func getAjaxmPath(data string) string {
+	if matches := findAjaxPathReg.FindStringSubmatch(data); len(matches) == 3 {
+		return matches[1]
+	}
+	if fileID, ok := findFileID(data); ok {
+		return "/ajaxm.php?file=" + fileID
+	}
+	return "/ajaxm.php"
+}
 
 // GET 页面并去除注释(acw_sc__v2 反爬挑战已在 request 层统一处理)
 func (d *LanZou) getHtml(url string, callback base.ReqCallback) (string, error) {
@@ -394,15 +428,17 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 		}
 		param["p"] = pwd
 
-		fileIDs := findFileIDReg.FindStringSubmatch(sharePageData)
-		var fileID string
-		if len(fileIDs) > 1 {
-			fileID = fileIDs[1]
-		} else {
-			return nil, fmt.Errorf("not find file id")
-		}
 		var resp FileShareInfoAndUrlResp[string]
-		_, err = d.post(d.ShareUrl+"/ajaxm.php?file="+fileID, func(req *resty.Request) { req.SetFormData(param) }, &resp)
+		_, err = d.post(d.ShareUrl+getAjaxmPath(sharePageData), func(req *resty.Request) {
+			req.SetHeader("Accept", "application/json, text/javascript, */*; q=0.01")
+			req.SetHeader("Referer", strings.TrimRight(d.ShareUrl, "/")+"/"+shareID)
+			req.SetHeader("Origin", strings.TrimRight(d.ShareUrl, "/"))
+			req.SetHeader("X-Requested-With", "XMLHttpRequest")
+			req.SetHeader("Sec-Fetch-Dest", "empty")
+			req.SetHeader("Sec-Fetch-Mode", "cors")
+			req.SetHeader("Sec-Fetch-Site", "same-origin")
+			req.SetFormData(param)
+		}, &resp)
 		if err != nil {
 			return nil, err
 		}
@@ -425,15 +461,8 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 			return nil, err
 		}
 
-		fileIDs := findFileIDReg.FindStringSubmatch(nextPageData)
-		var fileID string
-		if len(fileIDs) > 1 {
-			fileID = fileIDs[1]
-		} else {
-			return nil, fmt.Errorf("not find file id")
-		}
 		var resp FileShareInfoAndUrlResp[int]
-		_, err = d.post(d.ShareUrl+"/ajaxm.php?file="+fileID, func(req *resty.Request) { req.SetFormData(param) }, &resp)
+		_, err = d.post(d.ShareUrl+getAjaxmPath(nextPageData), func(req *resty.Request) { req.SetFormData(param) }, &resp)
 		if err != nil {
 			return nil, err
 		}

--- a/drivers/lanzou/util_test.go
+++ b/drivers/lanzou/util_test.go
@@ -1,0 +1,165 @@
+package lanzou
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/go-resty/resty/v2"
+)
+
+func TestFindFileID(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+		ok   bool
+	}{
+		{name: "legacy single quoted path", html: `url: '/ajaxm.php?file=12345'`, want: "12345", ok: true},
+		{name: "double quoted path", html: `url: "/ajaxm.php?file=23456"`, want: "23456", ok: true},
+		{name: "absolute URL", html: `url: "https://example.lanzouv.com/ajaxm.php?file=34567"`, want: "34567", ok: true},
+		{name: "unquoted expression", html: `fetch('/ajaxm.php?file=45678&p=1')`, want: "45678", ok: true},
+		{name: "password file endpoint", html: `url : '/ajaxfile.php?file=215138709'`, want: "215138709", ok: true},
+		{name: "f_id variable", html: `var f_id = '56789';`, want: "56789", ok: true},
+		{name: "fid variable without quotes", html: `let fid=67890;`, want: "67890", ok: true},
+		{name: "missing ID", html: `url: '/ajaxm.php?action=downprocess'`, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findFileID(tt.html)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("findFileID() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestGetAjaxmPath(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{name: "legacy page with file ID", html: `url: '/ajaxm.php?file=12345'`, want: "/ajaxm.php?file=12345"},
+		{name: "password file endpoint", html: `url : '/ajaxfile.php?file=215138709'`, want: "/ajaxfile.php?file=215138709"},
+		{name: "new page without file ID", html: `data: {'action':'downprocess','sign':sign,'ves':1}`, want: "/ajaxm.php"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAjaxmPath(tt.html); got != tt.want {
+				t.Fatalf("getAjaxmPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetFilesByShareURLWithoutFileID(t *testing.T) {
+	originalClient, originalNoRedirectClient := base.RestyClient, base.NoRedirectClient
+	base.RestyClient = resty.New()
+	base.NoRedirectClient = resty.New().SetRedirectPolicy(resty.RedirectPolicyFunc(
+		func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	))
+	t.Cleanup(func() {
+		base.RestyClient = originalClient
+		base.NoRedirectClient = originalNoRedirectClient
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/fn":
+			fmt.Fprint(w, `<script>var sign = 'test-sign'; data: {'action':'downprocess','sign':sign,'ves':1}</script>`)
+		case "/ajaxm.php":
+			if r.URL.RawQuery != "" {
+				t.Errorf("unexpected ajaxm query: %q", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"zt":1,"dom":%q,"url":"download","inf":0}`, server.URL)
+		case "/file/download":
+			w.Header().Set("Location", server.URL+"/direct")
+			w.WriteHeader(http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	d := &LanZou{Addition: Addition{ShareUrl: server.URL, UserAgent: "test"}}
+	sharePage := `<title>test.txt - 蓝奏云</title><iframe src="/fn"></iframe><span>大小 1 M</span>`
+	file, err := d.getFilesByShareUrl("share-id", "", sharePage)
+	if err != nil {
+		t.Fatalf("getFilesByShareUrl() error = %v", err)
+	}
+	if file.Url != server.URL+"/direct" {
+		t.Fatalf("file URL = %q, want %q", file.Url, server.URL+"/direct")
+	}
+}
+
+func TestGetPasswordFileThroughAjaxfileEndpoint(t *testing.T) {
+	originalClient, originalNoRedirectClient := base.RestyClient, base.NoRedirectClient
+	base.RestyClient = resty.New()
+	base.NoRedirectClient = resty.New().SetRedirectPolicy(resty.RedirectPolicyFunc(
+		func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	))
+	t.Cleanup(func() {
+		base.RestyClient = originalClient
+		base.NoRedirectClient = originalNoRedirectClient
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/share-id":
+			http.SetCookie(w, &http.Cookie{Name: "share_session", Value: "ok", Path: "/"})
+			fmt.Fprint(w, `<title>protected.apk - 蓝奏云</title><div id="passwddiv"></div><script>
+function down_p(){
+var sign = 'test-sign';
+$.ajax({url:'/ajaxfile.php?file=215138709',data:{'action':'downprocess','sign':sign,'kd':1,'p':pwd}});
+}</script><span>大小 1 M</span>`)
+		case "/ajaxfile.php":
+			if r.URL.Query().Get("file") != "215138709" {
+				t.Errorf("unexpected file query: %q", r.URL.RawQuery)
+			}
+			cookie, err := r.Cookie("share_session")
+			if err != nil || cookie.Value != "ok" {
+				t.Errorf("share cookie missing: %v", err)
+			}
+			if got := r.Header.Get("Referer"); got != server.URL+"/share-id" {
+				t.Errorf("Referer = %q", got)
+			}
+			if got := r.Header.Get("Origin"); got != server.URL {
+				t.Errorf("Origin = %q", got)
+			}
+			if got := r.Header.Get("X-Requested-With"); got != "XMLHttpRequest" {
+				t.Errorf("X-Requested-With = %q", got)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.Form.Get("p"); got != "1234" {
+				t.Errorf("password = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"zt":1,"dom":%q,"url":"download","inf":"protected.apk"}`, server.URL)
+		case "/file/download":
+			w.Header().Set("Location", server.URL+"/direct")
+			w.WriteHeader(http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	d := &LanZou{Addition: Addition{ShareUrl: server.URL, UserAgent: "test"}}
+	file, err := d.GetFilesByShareUrl("share-id", "1234")
+	if err != nil {
+		t.Fatalf("GetFilesByShareUrl() error = %v", err)
+	}
+	if file.Url != server.URL+"/direct" {
+		t.Fatalf("file URL = %q, want %q", file.Url, server.URL+"/direct")
+	}
+}


### PR DESCRIPTION
## Summary

- recognize both ajaxm.php and ajaxfile.php download endpoints, with a no-ID fallback
- parse complete JavaScript variable values and prefer the latest non-empty declaration
- persist share-page and anti-bot cookies per driver and send browser-equivalent AJAX headers
- keep account cookies scoped to the management base URL

## Testing

- go test ./drivers/lanzou
- verified link generation with password-protected APK, PDF, and RAR files
- verified archive link generation for a real RAR file