### PR TITLE
harden: the ffmpeg-go library processes video and image... in util.go

### DIFF
--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -49,7 +51,16 @@ func sanitizeFilePath(path string) (string, error) {
 	if !filepath.IsAbs(cleaned) {
 		return "", fmt.Errorf("file path must be absolute: %s", path)
 	}
-	if strings.ContainsAny(cleaned, ";&|`$<>!\n\r\x00") {
+	// Reject any control character (including NUL, CR, LF and other
+	// non-printable bytes) instead of relying on a fixed blacklist, since a
+	// blacklist can be bypassed via alternative encodings or characters that
+	// were not anticipated.
+	for _, r := range cleaned {
+		if r == utf8.RuneError || unicode.IsControl(r) {
+			return "", fmt.Errorf("file path contains invalid characters: %s", path)
+		}
+	}
+	if strings.ContainsAny(cleaned, ";&|`$<>!") {
 		return "", fmt.Errorf("file path contains invalid characters: %s", path)
 	}
 	info, err := os.Stat(cleaned)


### PR DESCRIPTION
## Summary
Harden input handling in `drivers/local/util.go` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `drivers/local/util.go:43` |
| **Assessment** | Defensive hardening |
| **Chain Complexity** | 2-step |

**Description**: The ffmpeg-go library processes video and image files with a blacklist-based sanitization approach. While sanitizeFilePath checks for shell metacharacters, blacklist approaches may miss injection vectors through alternative encoding, null bytes, or unicode normalization. The file path is passed directly to ffmpeg.Input() which executes ffmpeg with the provided path.

## Threat Model Context

This is a Go service - vulnerabilities in HTTP handlers are remotely exploitable.

## Changes
- `drivers/local/util.go`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
