### PR TITLE
fix(fs): accept uploads without Content-Length

### DIFF
--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -51,6 +51,13 @@ func FsStream(c *gin.Context) {
 	}
 	dir, name := stdpath.Split(path)
 	size := c.Request.ContentLength
+	if sizeStr := c.GetHeader("Content-Length"); sizeStr != "" {
+		size, err = strconv.ParseInt(sizeStr, 10, 64)
+		if err != nil {
+			common.ErrorResp(c, err, 400)
+			return
+		}
+	}
 	if size < 0 {
 		size = 0
 	}

--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -50,11 +50,9 @@ func FsStream(c *gin.Context) {
 		}
 	}
 	dir, name := stdpath.Split(path)
-	sizeStr := c.GetHeader("Content-Length")
-	size, err := strconv.ParseInt(sizeStr, 10, 64)
-	if err != nil {
-		common.ErrorResp(c, err, 400)
-		return
+	size := c.Request.ContentLength
+	if size < 0 {
+		size = 0
 	}
 	h := make(map[*utils.HashType]string)
 	if md5 := c.GetHeader("X-File-Md5"); md5 != "" {

--- a/server/handles/fsup_test.go
+++ b/server/handles/fsup_test.go
@@ -25,3 +25,20 @@ func TestFsStreamAcceptsMissingContentLength(t *testing.T) {
 		t.Fatalf("missing Content-Length was rejected before upload handling: code=%d body=%s", recorder.Code, recorder.Body.String())
 	}
 }
+
+func TestFsStreamRejectsInvalidContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/api/fs/put", http.NoBody)
+	request.Header.Set("File-Path", "/test.txt")
+	request.Header.Set("Content-Length", "invalid")
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = request
+	context.Set("user", &model.User{BasePath: "/"})
+
+	FsStream(context)
+
+	if !strings.Contains(recorder.Body.String(), `"code":400`) || !strings.Contains(recorder.Body.String(), "strconv.ParseInt") {
+		t.Fatalf("invalid Content-Length was not rejected: code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/server/handles/fsup_test.go
+++ b/server/handles/fsup_test.go
@@ -1,0 +1,27 @@
+package handles
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/gin-gonic/gin"
+)
+
+func TestFsStreamAcceptsMissingContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/api/fs/put", http.NoBody)
+	request.Header.Set("File-Path", "/test.txt")
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = request
+	context.Set("user", &model.User{BasePath: "/"})
+
+	FsStream(context)
+
+	if recorder.Code == http.StatusBadRequest || strings.Contains(recorder.Body.String(), "strconv.ParseInt") {
+		t.Fatalf("missing Content-Length was rejected before upload handling: code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes: PUT /api/fs/put returns a code 400 strconv.ParseInt error for an empty request whose Content-Length header is absent.
- Root cause: FsStream reparses the literal Gin header instead of using net/http's normalized Request.ContentLength, so an absent header becomes an empty string and fails before upload handling.
- A present malformed literal Content-Length is still rejected with code 400 before upload handling.

Closes #9606.

## Regression evidence

- Before: `go test ./server/handles -run '^TestFsStreamAcceptsMissingContentLength$' -count=1 -v` exited `1`

- After: `go test ./server/handles -run '^TestFsStreamAcceptsMissingContentLength$' -count=1 -v` exited `0`

- Review regression: `go test ./server/handles -run '^TestFsStreamRejectsInvalidContentLength$' -count=1 -v` failed on the previous PR head and passes after the follow-up.

## Verification

- `go test -vet=off ./server/... -count=1`
- `go test -race ./server/handles -count=1`
- `go vet ./server/handles`
- `git diff --check`

## Validation notes

- `go test ./server/... -count=1` reaches an unchanged Go 1.25 vet error in `server/s3/backend.go`; the same error reproduces on base `3e49fa4`. Running the server suite with `-vet=off` passes, and `go vet ./server/handles` passes.
- `go test -vet=off ./... -count=1` additionally requires local FUSE headers and a running aria2 service, and has an unrelated Windows-path assertion that fails on macOS. The affected server suite passes in full.

## Scope

- 2 files changed, +54 / -5 lines
